### PR TITLE
chore: disable version check workflow and improve stream cleanup 

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,11 +1,17 @@
 name: Version Check
 
+# TODO: Re-enable this workflow once `hostdb` is published to npm.
+# Currently disabled because the package doesn't exist on npm yet,
+# so the version check always falls back to 0.0.0.
+# When enabling, verify the package name in the "Get npm version" step.
+
 on:
   pull_request:
     branches: [main]
 
 jobs:
   check-version:
+    if: false # Disabled until package is published to npm
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
- Disable version-check workflow until hostdb package is published to npm
- Add TODO comment explaining workflow is disabled because package doesn't exist yet
- Add if: false condition to prevent workflow execution
- Improve stream cleanup in computeSha256() by canceling reader in finally block
- Move reader declaration outside try block for proper cleanup access
- Add try-catch around reader.cancel() to ignore cleanup errors