### PR TITLE
chore: simplify MariaDB macOS builds by using environment variables i…

### DIFF
--- a/.github/workflows/release-mariadb.yml
+++ b/.github/workflows/release-mariadb.yml
@@ -255,27 +255,32 @@ jobs:
           # Force Xcode as the active developer directory and use its SDK
           sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
 
-          # Export SDKROOT to force all tools to use the same SDK
+          # Get SDK and toolchain paths
           export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
           XCODE_TOOLCHAIN=$(xcode-select -p)/Toolchains/XcodeDefault.xctoolchain
 
           echo "Using Xcode SDK (SDKROOT): $SDKROOT"
           echo "Using Xcode Toolchain: $XCODE_TOOLCHAIN"
 
+          # Set compiler environment variables to force correct SDK
+          # These take precedence over any CMake-added flags
+          export CC="$XCODE_TOOLCHAIN/usr/bin/clang"
+          export CXX="$XCODE_TOOLCHAIN/usr/bin/clang++"
+          export CFLAGS="--sysroot=$SDKROOT"
+          export CXXFLAGS="--sysroot=$SDKROOT -stdlib=libc++"
+          export LDFLAGS="--sysroot=$SDKROOT"
+
           # Verify clang uses correct SDK
           echo "Clang SDK check:"
-          "$XCODE_TOOLCHAIN/usr/bin/clang" --version
-          "$XCODE_TOOLCHAIN/usr/bin/clang" -print-search-dirs | head -3
+          $CC --version
+          $CC -v -E -x c /dev/null 2>&1 | grep "selected sysroot" || true
 
           # Configure (disable Columnstore as it has macOS compatibility issues)
-          cmake "$SOURCE_DIR" \
+          # Use xcrun to ensure cmake inherits correct SDK environment
+          xcrun cmake "$SOURCE_DIR" \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_INSTALL_PREFIX="$GITHUB_WORKSPACE/install/mariadb" \
             -DCMAKE_OSX_SYSROOT="$SDKROOT" \
-            -DCMAKE_C_COMPILER="$XCODE_TOOLCHAIN/usr/bin/clang" \
-            -DCMAKE_CXX_COMPILER="$XCODE_TOOLCHAIN/usr/bin/clang++" \
-            -DCMAKE_C_FLAGS="-isysroot $SDKROOT" \
-            -DCMAKE_CXX_FLAGS="-isysroot $SDKROOT -stdlib=libc++" \
             -DBISON_EXECUTABLE="$BISON_PATH" \
             -DWITH_SSL="$OPENSSL_PREFIX" \
             -DWITH_PCRE=system \


### PR DESCRIPTION
…nstead of CMake flags

- Replace CMAKE_C_COMPILER and CMAKE_CXX_COMPILER flags with CC and CXX environment variables
- Replace CMAKE_C_FLAGS and CMAKE_CXX_FLAGS with CFLAGS and CXXFLAGS environment variables
- Add LDFLAGS environment variable with --sysroot flag
- Add comments explaining environment variables take precedence over CMake-added flags
- Wrap cmake invocation with xcrun to ensure it inherits correct SDK environment -