### PR TITLE
chore: restrict MariaDB macOS builds to search only within Xcode SDK

### DIFF
--- a/.github/workflows/release-mariadb.yml
+++ b/.github/workflows/release-mariadb.yml
@@ -277,10 +277,15 @@ jobs:
 
           # Configure (disable Columnstore as it has macOS compatibility issues)
           # Use xcrun to ensure cmake inherits correct SDK environment
+          # Force CMake to only search within the Xcode SDK (not Command Line Tools)
           xcrun cmake "$SOURCE_DIR" \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_INSTALL_PREFIX="$GITHUB_WORKSPACE/install/mariadb" \
             -DCMAKE_OSX_SYSROOT="$SDKROOT" \
+            -DCMAKE_FIND_ROOT_PATH="$SDKROOT" \
+            -DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=ONLY \
+            -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=ONLY \
+            -DZLIB_ROOT="$SDKROOT/usr" \
             -DBISON_EXECUTABLE="$BISON_PATH" \
             -DWITH_SSL="$OPENSSL_PREFIX" \
             -DWITH_PCRE=system \


### PR DESCRIPTION
- Add CMAKE_FIND_ROOT_PATH flag pointing to SDKROOT to restrict search paths
- Add CMAKE_FIND_ROOT_PATH_MODE_LIBRARY=ONLY to prevent searching outside SDK for libraries
- Add CMAKE_FIND_ROOT_PATH_MODE_INCLUDE=ONLY to prevent searching outside SDK for headers
- Add ZLIB_ROOT flag pointing to SDK's /usr directory for explicit zlib location
- Add comment explaining flags force CMake to only search within Xcode SDK (not Command Line Tools)