### PR TITLE
chore: improve MariaDB macOS builds by dynamically detecting latest X…

### DIFF
--- a/.github/workflows/release-mariadb.yml
+++ b/.github/workflows/release-mariadb.yml
@@ -252,8 +252,10 @@ jobs:
           cd "$BUILD_DIR"
 
           # Fix for Xcode 16+ SDK/toolchain mismatch issues
-          # Force Xcode as the active developer directory and use its SDK
-          sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+          # Force latest Xcode as the active developer directory
+          XCODE_PATH=$(ls -d /Applications/Xcode*.app 2>/dev/null | sort -V | tail -1)
+          echo "Using Xcode: $XCODE_PATH"
+          sudo xcode-select -s "$XCODE_PATH/Contents/Developer"
 
           # Get SDK and toolchain paths
           export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)


### PR DESCRIPTION
…code installation

- Replace hardcoded Xcode_16.4.app path with dynamic detection using ls and sort
- Add XCODE_PATH variable to find latest Xcode installation in /Applications
- Add echo statement to display detected Xcode path for debugging
- Update comment to reflect dynamic Xcode detection instead of hardcoded version
- Use sort -V for proper version sorting of Xcode installations