### PR TITLE
chore: fix MariaDB builds for CMake 4.0+ by setting minimum policy ve…

### DIFF
--- a/.github/workflows/release-mariadb.yml
+++ b/.github/workflows/release-mariadb.yml
@@ -280,7 +280,10 @@ jobs:
           # Configure (disable Columnstore as it has macOS compatibility issues)
           # Use xcrun to ensure cmake inherits correct SDK environment
           # Include both Xcode SDK and Homebrew in search paths (exclude Command Line Tools)
+          # CMAKE_POLICY_VERSION_MINIMUM fixes compatibility with older wsrep-lib CMakeLists.txt
+          # that specify cmake_minimum_required < 3.5 (CMake 4.0+ removed support for < 3.5)
           xcrun cmake "$SOURCE_DIR" \
+            -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_INSTALL_PREFIX="$GITHUB_WORKSPACE/install/mariadb" \
             -DCMAKE_OSX_SYSROOT="$SDKROOT" \

--- a/builds/mariadb/Dockerfile
+++ b/builds/mariadb/Dockerfile
@@ -68,7 +68,10 @@ WORKDIR /build/mariadb-src
 # - STANDALONE layout for relocatable installation
 # - Bundle most dependencies for portability
 # - Disable features not needed for embedded/dev use
+# - CMAKE_POLICY_VERSION_MINIMUM fixes compatibility with older wsrep-lib CMakeLists.txt
+#   that specify cmake_minimum_required < 3.5 (CMake 4.0+ removed support for < 3.5)
 RUN cmake . \
+    -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX=/opt/mariadb \
     -DINSTALL_LAYOUT=STANDALONE \


### PR DESCRIPTION
…rsion to 3.5

- Add CMAKE_POLICY_VERSION_MINIMUM=3.5 flag to both macOS and Docker builds
- Add comments explaining fix is needed for wsrep-lib CMakeLists.txt compatibility
- Explain wsrep-lib specifies cmake_minimum_required < 3.5 which CMake 4.0+ no longer supports