### PR TITLE
chore: fix Redis macOS builds by passing TLS flags to make install to…

### DIFF
--- a/.github/workflows/release-redis.yml
+++ b/.github/workflows/release-redis.yml
@@ -268,8 +268,11 @@ jobs:
             BUILD_TLS=yes \
             OPENSSL_PREFIX="$OPENSSL_PREFIX"
 
-          # Install
-          make PREFIX="$GITHUB_WORKSPACE/install/redis" install
+          # Install (must pass same flags to prevent rebuild without TLS)
+          make PREFIX="$GITHUB_WORKSPACE/install/redis" \
+            BUILD_TLS=yes \
+            OPENSSL_PREFIX="$OPENSSL_PREFIX" \
+            install
 
           # Copy config files
           cp redis.conf "$GITHUB_WORKSPACE/install/redis/"


### PR DESCRIPTION
… prevent rebuild without TLS

- Add BUILD_TLS=yes and OPENSSL_PREFIX to make install command in macOS workflow
- Add comment explaining flags must be passed to prevent rebuild without TLS support
- Split make install command across multiple lines for readability