### PR TITLE
chore: fix Valkey Windows builds by patching dlfcn.h and adjusting build flags

### DIFF
--- a/.github/workflows/release-valkey.yml
+++ b/.github/workflows/release-valkey.yml
@@ -304,6 +304,10 @@ jobs:
 
           echo "Building Valkey $VERSION for $PLATFORM (Cygwin build)"
 
+          # Apply redis-windows patches to enable GNU extensions
+          # This exposes Dl_info and dladdr in dlfcn.h
+          sed -i 's/\_\_GNU\_VISIBLE/1/' /usr/include/dlfcn.h
+
           cd /cygdrive/d/a/hostdb/hostdb
 
           # Download source from GitHub
@@ -313,8 +317,12 @@ jobs:
 
           cd "valkey-${VERSION}"
 
-          # Build with TLS support
-          make -j$(nproc) BUILD_TLS=yes
+          # Remove module_tests from build targets (not supported on Windows)
+          sed -i 's/all: \(.*\) module_tests$/all: \1/' src/Makefile
+
+          # Build with TLS support and Windows-compatible flags
+          # -Wno-char-subscripts suppresses warnings, -O0 helps compatibility
+          make -j$(nproc) BUILD_TLS=yes CFLAGS="-Wno-char-subscripts -O0"
 
           # Install
           make PREFIX="$(pwd)/../install/valkey" install


### PR DESCRIPTION
- Patch /usr/include/dlfcn.h to enable GNU extensions (exposes Dl_info and dladdr)
- Remove module_tests from build targets in src/Makefile (not supported on Windows)
- Add CFLAGS="-Wno-char-subscripts -O0" to make command for better Windows compatibility
- Add comments explaining each patch and flag purpose