### PR TITLE
feat: add Valkey database support

### DIFF
--- a/.github/workflows/release-valkey.yml
+++ b/.github/workflows/release-valkey.yml
@@ -308,7 +308,7 @@ jobs:
           # This exposes Dl_info and dladdr in dlfcn.h
           sed -i 's/\_\_GNU\_VISIBLE/1/' /usr/include/dlfcn.h
 
-          cd /cygdrive/d/a/hostdb/hostdb
+          cd "$(cygpath "$GITHUB_WORKSPACE")"
 
           # Download source from GitHub
           curl -fsSL "https://github.com/valkey-io/valkey/archive/refs/tags/${VERSION}.tar.gz" \
@@ -373,7 +373,7 @@ jobs:
         if: matrix.build_type == 'native-windows'
         shell: C:\cygwin\bin\bash.exe --login -eo pipefail -o igncr '{0}'
         run: |
-          cd /cygdrive/d/a/hostdb/hostdb/dist
+          cd "$(cygpath "$GITHUB_WORKSPACE")/dist"
           for f in *.tar.gz *.zip; do
             if [ -f "$f" ]; then
               sha256sum "$f" >> checksums.txt


### PR DESCRIPTION
## Summary
- Add Valkey database support (Redis fork with BSD-3-Clause license)
- Versions: 9.0.1 (latest), 8.0.6 (LTS)
- Platforms: linux-x64, linux-arm64, darwin-x64, darwin-arm64, win32-x64
- Windows builds use Cygwin with redis-windows patches for POSIX compatibility

## Files Added
- `builds/valkey/` - Download script, Dockerfile, build scripts, sources.json
- `.github/workflows/release-valkey.yml` - Release workflow

## Files Modified
- `databases.json` - Added Valkey config, updated Redis status to completed
- `package.json` - Added `download:valkey` script

## Notes
- Windows build requires Cygwin and applies patches from redis-windows project
- Valkey doesn't officially support Windows; Cygwin provides POSIX compatibility layer