### PR TITLE
chore: add MongoDB release workflow with multi-platform download support

### DIFF
--- a/.github/workflows/release-mongodb.yml
+++ b/.github/workflows/release-mongodb.yml
@@ -1,0 +1,263 @@
+name: Release MongoDB
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'MongoDB version'
+        required: true
+        type: choice
+        options:
+          - 8.2.3
+          - 8.0.17
+          - 7.0.28
+        default: 8.0.17
+      platforms:
+        description: 'Platforms'
+        required: true
+        default: 'all'
+        type: choice
+        options:
+          - 'all'
+          - 'linux-x64'
+          - 'linux-arm64'
+          - 'darwin-x64'
+          - 'darwin-arm64'
+          - 'win32-x64'
+
+# Prevent concurrent runs that could conflict when updating releases.json
+concurrency:
+  group: release-mongodb
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ github.event.inputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate version against databases.json
+        run: |
+          DB="mongodb"
+
+          echo "Validating MongoDB version: $VERSION"
+
+          # Check if version exists and is enabled in databases.json
+          ENABLED=$(jq -r ".databases.$DB.versions[\"$VERSION\"] // false" databases.json)
+          if [ "$ENABLED" != "true" ]; then
+            echo "::error::Version '$VERSION' is not enabled in databases.json"
+            echo ""
+            echo "Available versions:"
+            jq -r ".databases.$DB.versions | to_entries | map(select(.value == true)) | .[].key" databases.json
+            exit 1
+          fi
+
+          echo "✓ Version $VERSION is enabled in databases.json"
+
+      - name: Validate sources.json exists
+        run: |
+          DB="mongodb"
+          if [ ! -f "builds/$DB/sources.json" ]; then
+            echo "::error::Missing builds/$DB/sources.json"
+            exit 1
+          fi
+          echo "✓ builds/$DB/sources.json exists"
+
+      - name: Validate version in sources.json
+        run: |
+          DB="mongodb"
+
+          HAS_VERSION=$(jq -r ".versions[\"$VERSION\"] // empty" "builds/$DB/sources.json")
+          if [ -z "$HAS_VERSION" ]; then
+            echo "::error::Version '$VERSION' not found in builds/$DB/sources.json"
+            echo ""
+            echo "Available versions in sources.json:"
+            jq -r ".versions | keys[]" "builds/$DB/sources.json"
+            exit 1
+          fi
+
+          echo "✓ Version $VERSION found in sources.json"
+
+  build:
+    needs: validate
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ github.event.inputs.version }}
+      PLATFORMS: ${{ github.event.inputs.platforms }}
+    outputs:
+      artifact_names: ${{ steps.build.outputs.artifact_names }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download and repackage MongoDB
+        id: build
+        run: |
+          if [ "$PLATFORMS" = "all" ]; then
+            pnpm download:mongodb -- --version "$VERSION" --all-platforms --output ./dist
+          else
+            # Convert comma-separated to multiple --platform flags
+            for platform in $(echo "$PLATFORMS" | tr ',' ' '); do
+              pnpm download:mongodb -- --version "$VERSION" --platform "$platform" --output ./dist
+            done
+          fi
+
+          # List created artifacts
+          ls -la ./dist/
+
+          # Create artifact names output (handle case where no files exist)
+          shopt -s nullglob
+          FILES=(./dist/*.tar.gz ./dist/*.zip)
+          if [ ${#FILES[@]} -eq 0 ]; then
+            echo "ERROR: No artifacts were created"
+            exit 1
+          fi
+          ARTIFACTS=$(printf '%s\n' "${FILES[@]}" | xargs -n1 basename | tr '\n' ',' | sed 's/,$//')
+          echo "artifact_names=$ARTIFACTS" >> $GITHUB_OUTPUT
+
+      - name: Generate checksums
+        run: |
+          cd dist
+          sha256sum *.tar.gz *.zip 2>/dev/null > checksums.txt || sha256sum *.tar.gz > checksums.txt
+          cat checksums.txt
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: mongodb-${{ github.event.inputs.version }}
+          path: |
+            dist/*.tar.gz
+            dist/*.zip
+            dist/checksums.txt
+          retention-days: 1
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: mongodb-${{ github.event.inputs.version }}
+          path: ./release-assets
+
+      - name: List release assets
+        run: ls -la ./release-assets/
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: mongodb-${{ github.event.inputs.version }}
+          name: MongoDB ${{ github.event.inputs.version }}
+          body: |
+            ## MongoDB ${{ github.event.inputs.version }}
+
+            Official MongoDB Community Server binaries repackaged for hostdb.
+
+            ### License Warning
+
+            MongoDB is licensed under **SSPL-1.0** which restricts commercial and closed-source use.
+            For commercial projects, use [FerretDB](https://www.ferretdb.com/) (Apache 2.0) as a drop-in replacement.
+
+            ### Platforms
+            - `linux-x64` - Linux x86_64 (Ubuntu 22.04+)
+            - `linux-arm64` - Linux ARM64 (Ubuntu 22.04+)
+            - `darwin-x64` - macOS x86_64
+            - `darwin-arm64` - macOS Apple Silicon
+            - `win32-x64` - Windows x64
+
+            ### Usage
+            ```bash
+            # Download URL pattern
+            https://github.com/${{ github.repository }}/releases/download/mongodb-${{ github.event.inputs.version }}/mongodb-${{ github.event.inputs.version }}-<platform>.tar.gz
+            ```
+
+            ### Checksums
+            See `checksums.txt` for SHA256 checksums.
+
+            ### Source
+            Official binaries from [MongoDB Community Downloads](https://www.mongodb.com/try/download/community)
+          files: |
+            release-assets/*.tar.gz
+            release-assets/*.zip
+            release-assets/checksums.txt
+          fail_on_unmatched_files: false
+
+  update-manifest:
+    needs: release
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ github.event.inputs.version }}
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Update releases.json
+        run: |
+          pnpm tsx scripts/update-releases.ts \
+            --database mongodb \
+            --version "$VERSION" \
+            --tag "mongodb-$VERSION"
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add releases.json
+          git diff --staged --quiet && echo "No changes to commit" && exit 0
+
+          git commit -m "chore: update releases.json for mongodb-$VERSION"
+
+          # Retry push with rebase if remote has changed
+          for i in 1 2 3; do
+            if git push; then
+              echo "Push succeeded"
+              exit 0
+            fi
+            echo "Push failed, attempting rebase (attempt $i/3)..."
+            git fetch origin main
+            if ! git rebase origin/main; then
+              echo "ERROR: Rebase failed due to conflicts. Manual intervention required."
+              git rebase --abort
+              exit 1
+            fi
+            sleep $((2**i))
+          done
+          echo "ERROR: Push failed after 3 attempts"
+          exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,22 +2,69 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.2.0] - 2025-01-06
+## [0.7.0] - 2026-01-08
+
+### Added
+
+- **MongoDB support** with full 5-platform coverage
+  - Official binaries from `fastdl.mongodb.org` CDN
+  - Versions: 8.0.17 (LTS), 8.2.3 (Rapid Release), 7.0.28 (Previous LTS)
+  - License warning in README about SSPL restrictions
+  - FerretDB recommended as open-source alternative for commercial use
+
+## [0.6.0] - 2026-01-07
+
+### Added
+
+- **Valkey support** with full 5-platform coverage
+  - Linux Foundation-backed Redis fork with BSD-3-Clause license
+  - Drop-in Redis replacement for commercial/closed-source projects
+  - Versions: 9.0.1, 8.0.6
+  - Source builds for all platforms
+
+## [0.5.0] - 2026-01-07
+
+### Added
+
+- **Redis support** with full 5-platform coverage
+  - Versions: 8.4.0, 7.4.7
+  - Source builds for all platforms
+  - License warning about RSALv2/SSPLv1 restrictions
+  - Valkey recommended as open-source alternative for commercial use
+
+## [0.4.0] - 2026-01-06
 
 ### Added
 
 - **MariaDB support** with full 5-platform coverage
   - `builds/mariadb/download.ts` - Downloads official binaries or MariaDB4j JARs
-  - `builds/mariadb/sources.json` - URL mappings for 3 LTS versions (11.8.5, 11.4.5, 10.6.24)
+  - `builds/mariadb/sources.json` - URL mappings for 3 LTS versions (11.8.5, 11.4.5, 10.11.15)
   - `builds/mariadb/Dockerfile` - Source builds for Linux platforms
   - `builds/mariadb/build-local.sh` - Local Docker build script
   - `.github/workflows/release-mariadb.yml` - Parallel builds across all 5 platforms
   - Native macOS builds on GitHub Actions (macos-13 for Intel, macos-14 for Apple Silicon)
 
+## [0.3.0] - 2026-01-05
+
+### Added
+
+- **MySQL support** with full 5-platform coverage
+  - Official binaries from Oracle CDN
+  - Versions: 8.4.7, 8.0.40
+  - `builds/mysql/download.ts` - Downloads and repackages official binaries
+  - `builds/mysql/sources.json` - URL mappings for all versions/platforms
+
+## [0.2.0] - 2026-01-04
+
+### Added
+
+- **PostgreSQL support** with full 5-platform coverage
+  - Via [zonky.io embedded-postgres-binaries](https://github.com/zonkyio/embedded-postgres-binaries)
+  - Versions: 18.1.0, 17.7.0, 16.11.0, 15.15.0
+
 - **databases.json as single source of truth**
   - Workflows now validate version input against `databases.json`
-  - Version input changed from dropdown to text field
-  - Invalid versions fail fast with helpful error messages showing available options
+  - Invalid versions fail fast with helpful error messages
   - Adding new versions no longer requires workflow file changes
 
 - **Documentation overhaul**
@@ -30,32 +77,14 @@ All notable changes to this project will be documented in this file.
   - Creates `builds/<id>/` directory with template files
   - Creates `.github/workflows/release-<id>.yml`
   - Adds `download:<id>` script to package.json
-  - Prints next steps for Claude Code to implement
+
+## [0.1.0] - 2026-01-03
 
 ### Changed
 
-- All release workflows now have a `validate` job that checks:
-  - Version is enabled in `databases.json`
-  - Version exists in `builds/<db>/sources.json`
-- Workflow version input changed from `type: choice` to `type: string`
-- Platform matrix for MariaDB uses different runners per platform:
-  - `ubuntu-latest` for Linux (Docker builds)
-  - `macos-13` for darwin-x64 (native Intel build)
-  - `macos-14` for darwin-arm64 (native Apple Silicon build)
+**Major pivot in project direction.** Originally hostdb was an npm monorepo using turborepo to publish platform-specific database packages. This approach was abandoned in favor of hosting binaries on GitHub Releases.
 
-## [0.1.0] - 2025-01-04
-
-### Changed
-
-**Major pivot in project direction.** Originally hostdb was an npm monorepo using turborepo to publish platform-specific database packages (`@host-db/mysql-darwin-arm64`, etc.). This approach was abandoned in favor of hosting binaries on GitHub Releases.
-
-#### Old Approach (0.0.x)
-- Turborepo monorepo with platform-specific npm packages
-- Binaries downloaded during `npm postinstall`
-- Complex package generation scripts
-- Manifests for each database version
-
-#### New Approach (0.1.0+)
+#### New Approach
 - Download official binaries from vendor CDNs (fast, seconds not hours)
 - Repackage with metadata and host on GitHub Releases
 - Queryable `releases.json` manifest for consumers (like SpinDB)
@@ -63,29 +92,18 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- `builds/mysql/download.ts` - Downloads official MySQL binaries
-- `builds/mysql/sources.json` - Maps versions/platforms to official URLs
 - `releases.json` - Manifest of all GitHub Releases (queryable by SpinDB)
 - `schemas/sources.schema.json` - Validates sources.json files
 - `schemas/releases.schema.json` - Validates releases.json
 - `scripts/update-releases.ts` - Updates releases.json after GitHub Release
-- `.github/workflows/release-mysql.yml` - GitHub Actions workflow for MySQL releases
-- `status` field in `databases.json` (`in-progress`, `pending`, `unsupported`)
+- `status` field in `databases.json` (`completed`, `in-progress`, `pending`, `unsupported`)
+- `pnpm dbs` command for listing databases
+- `pnpm prep` command for pre-commit checks
+- `pnpm sync:versions` command for syncing workflow dropdowns
 
 ### Removed
 
-- Turborepo configuration (`turbo.json`, `tsconfig.base.json`)
-- Platform-specific npm packages (`packages/`)
-- Database manifests (`manifests/`)
+- Turborepo configuration
+- Platform-specific npm packages
 - Old package generation scripts
-- pnpm workspace configuration (monorepo no longer needed)
-
-## [0.0.1] - 2025-01-03
-
-### Added
-
-- Initial project setup as npm monorepo
-- `databases.json` with metadata for 24 databases
-- `downloads.json` with CLI tools and prerequisites
-- JSON schemas for configuration validation
-- `pnpm dbs` command for listing databases
+- pnpm workspace configuration

--- a/README.md
+++ b/README.md
@@ -133,8 +133,22 @@ Auto-generated manifest updated after each GitHub Release. Structure:
 | MariaDB | Completed | 11.8.5, 11.4.5, 10.11.15 | Official + source builds |
 | Redis | In Progress | 8.4.0, 7.4.7 | Source builds |
 | SQLite | In Progress | 3.51.1 | Official amalgamation |
+| Valkey | In Progress | 8.1.1 | Redis-compatible, permissive license |
 
 See `pnpm dbs` for the full list.
+
+### Licensing Notes
+
+Some databases have restrictive licenses that limit commercial and closed-source use:
+
+| Database | License | Commercial Use | Open-Source Alternative |
+|----------|---------|----------------|------------------------|
+| MongoDB | SSPL | ❌ Restricted | [FerretDB](https://www.ferretdb.com/) (Apache 2.0) |
+| Redis | RSALv2 + SSPLv1 | ❌ Restricted | [Valkey](https://valkey.io/) (BSD-3-Clause) |
+
+**FerretDB** is a MongoDB-compatible database built on PostgreSQL. **Valkey** is a Redis fork maintained by the Linux Foundation after Redis changed to a non-open-source license.
+
+If you need MongoDB or Redis compatibility for commercial/closed-source projects, use FerretDB or Valkey instead.
 
 ## GitHub Actions
 

--- a/builds/mongodb/README.md
+++ b/builds/mongodb/README.md
@@ -1,0 +1,56 @@
+# MongoDB Binaries
+
+Official MongoDB Community Server binaries repackaged for hostdb.
+
+## License Warning
+
+MongoDB is licensed under **SSPL-1.0** (Server Side Public License), which **restricts commercial and closed-source use**. If you need MongoDB compatibility for commercial projects, use [FerretDB](https://www.ferretdb.com/) instead (Apache 2.0 license).
+
+## Versions
+
+| Version | Type | EOL | Notes |
+|---------|------|-----|-------|
+| 8.2.3 | Rapid Release | March 2026 | Latest features, shorter support |
+| 8.0.17 | LTS | Sept 2029 | **Recommended** - 5-year support |
+| 7.0.28 | LTS | Aug 2026 | Previous LTS |
+
+## Source
+
+All binaries are official MongoDB Community Server releases from:
+- **CDN**: `https://fastdl.mongodb.org/`
+
+## Platforms
+
+| Platform | Source |
+|----------|--------|
+| linux-x64 | Ubuntu 22.04 x86_64 |
+| linux-arm64 | Ubuntu 22.04 ARM64 |
+| darwin-x64 | macOS x86_64 |
+| darwin-arm64 | macOS ARM64 |
+| win32-x64 | Windows x64 |
+
+## Usage
+
+```bash
+# Download for current platform (default: 8.0.17)
+pnpm download:mongodb
+
+# Download specific version
+pnpm download:mongodb -- --version 7.0.28
+
+# Download for all platforms
+pnpm download:mongodb -- --version 8.0.17 --all-platforms
+```
+
+## What's Included
+
+The repackaged archive contains:
+- `mongod` - Database server
+- `mongos` - Sharding router
+- MongoDB shell and tools
+
+## Notes
+
+- Linux binaries target Ubuntu 22.04 (glibc 2.35+)
+- macOS binaries work on recent macOS versions
+- Windows binaries are standard x64 releases

--- a/builds/mongodb/download.ts
+++ b/builds/mongodb/download.ts
@@ -1,0 +1,426 @@
+#!/usr/bin/env tsx
+/**
+ * Download official MongoDB binaries for re-hosting
+ *
+ * Usage:
+ *   ./builds/mongodb/download.ts [options]
+ *   pnpm tsx builds/mongodb/download.ts [options]
+ *
+ * Options:
+ *   --version VERSION    MongoDB version (default: 8.0.17)
+ *   --platform PLATFORM  Target platform (default: current platform)
+ *   --output DIR         Output directory (default: ./dist)
+ *   --all-platforms      Download for all platforms
+ *   --help               Show help
+ */
+
+import {
+  createWriteStream,
+  createReadStream,
+  mkdirSync,
+  existsSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs'
+import { createHash } from 'node:crypto'
+import { resolve, dirname, basename } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { execSync } from 'node:child_process'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+type Platform =
+  | 'linux-x64'
+  | 'linux-arm64'
+  | 'darwin-x64'
+  | 'darwin-arm64'
+  | 'win32-x64'
+
+const VALID_PLATFORMS: Platform[] = [
+  'linux-x64',
+  'linux-arm64',
+  'darwin-x64',
+  'darwin-arm64',
+  'win32-x64',
+]
+
+function isValidPlatform(value: string): value is Platform {
+  return VALID_PLATFORMS.includes(value as Platform)
+}
+
+// Validate version format to prevent command injection (e.g., "8.0.17")
+const VERSION_REGEX = /^\d+\.\d+\.\d+$/
+
+function isValidVersion(value: string): boolean {
+  return VERSION_REGEX.test(value)
+}
+
+type SourceEntry = {
+  url: string
+  format: 'tar.xz' | 'tar.gz' | 'zip'
+  sha256: string | null
+}
+
+type Sources = {
+  database: string
+  baseUrl: string
+  versions: Record<string, Record<Platform, SourceEntry>>
+  notes: Record<string, string>
+}
+
+const colors = {
+  reset: '\x1b[0m',
+  red: '\x1b[31m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  blue: '\x1b[34m',
+  cyan: '\x1b[36m',
+}
+
+function log(color: keyof typeof colors, prefix: string, msg: string) {
+  console.log(`${colors[color]}[${prefix}]${colors.reset} ${msg}`)
+}
+
+function logInfo(msg: string) {
+  log('blue', 'INFO', msg)
+}
+function logSuccess(msg: string) {
+  log('green', 'OK', msg)
+}
+function logWarn(msg: string) {
+  log('yellow', 'WARN', msg)
+}
+function logError(msg: string) {
+  log('red', 'ERROR', msg)
+}
+
+function detectPlatform(): Platform {
+  const platform = process.platform
+  const arch = process.arch
+
+  if (platform === 'linux' && arch === 'x64') return 'linux-x64'
+  if (platform === 'linux' && arch === 'arm64') return 'linux-arm64'
+  if (platform === 'darwin' && arch === 'x64') return 'darwin-x64'
+  if (platform === 'darwin' && arch === 'arm64') return 'darwin-arm64'
+  if (platform === 'win32' && arch === 'x64') return 'win32-x64'
+
+  throw new Error(`Unsupported platform: ${platform}-${arch}`)
+}
+
+function loadSources(): Sources {
+  const sourcesPath = resolve(__dirname, 'sources.json')
+  const content = readFileSync(sourcesPath, 'utf-8')
+  try {
+    return JSON.parse(content) as Sources
+  } catch (error) {
+    throw new Error(`Failed to parse sources.json: invalid JSON`, {
+      cause: error,
+    })
+  }
+}
+
+async function downloadFile(url: string, destPath: string): Promise<void> {
+  logInfo(`Downloading: ${url}`)
+
+  const response = await fetch(url, { redirect: 'follow' })
+
+  if (!response.ok) {
+    throw new Error(
+      `Download failed: ${response.status} ${response.statusText}`,
+    )
+  }
+
+  const contentLength = response.headers.get('content-length')
+  const totalBytes = contentLength ? parseInt(contentLength, 10) : 0
+
+  mkdirSync(dirname(destPath), { recursive: true })
+
+  const fileStream = createWriteStream(destPath)
+  const reader = response.body?.getReader()
+
+  if (!reader) {
+    throw new Error('No response body')
+  }
+
+  let downloadedBytes = 0
+  const startTime = Date.now()
+
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+
+    fileStream.write(value)
+    downloadedBytes += value.length
+
+    // Progress update
+    if (totalBytes > 0) {
+      const percent = ((downloadedBytes / totalBytes) * 100).toFixed(1)
+      const mbDownloaded = (downloadedBytes / 1024 / 1024).toFixed(1)
+      const mbTotal = (totalBytes / 1024 / 1024).toFixed(1)
+      process.stdout.write(
+        `\r  ${mbDownloaded}MB / ${mbTotal}MB (${percent}%)    `,
+      )
+    } else {
+      const mbDownloaded = (downloadedBytes / 1024 / 1024).toFixed(1)
+      process.stdout.write(`\r  ${mbDownloaded}MB downloaded...    `)
+    }
+  }
+
+  // Wait for the file stream to fully close before proceeding
+  await new Promise<void>((resolve, reject) => {
+    fileStream.end()
+    fileStream.on('finish', resolve)
+    fileStream.on('error', reject)
+  })
+
+  console.log() // New line after progress
+
+  const duration = ((Date.now() - startTime) / 1000).toFixed(1)
+  logSuccess(
+    `Downloaded ${(downloadedBytes / 1024 / 1024).toFixed(1)}MB in ${duration}s`,
+  )
+}
+
+// Calculate SHA256 checksum using streaming to avoid loading large files into memory
+async function calculateSha256(filePath: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const hash = createHash('sha256')
+    const stream = createReadStream(filePath)
+
+    stream.on('data', (chunk) => hash.update(chunk))
+    stream.on('end', () => resolve(hash.digest('hex')))
+    stream.on('error', reject)
+  })
+}
+
+function repackage(
+  sourcePath: string,
+  format: string,
+  outputPath: string,
+  version: string,
+  platform: Platform,
+): void {
+  const tempDir = resolve(dirname(sourcePath), 'temp-extract')
+  mkdirSync(tempDir, { recursive: true })
+
+  logInfo('Extracting archive...')
+
+  // Extract based on format
+  if (format === 'tar.xz') {
+    execSync(`tar -xJf "${sourcePath}" -C "${tempDir}"`, { stdio: 'inherit' })
+  } else if (format === 'tar.gz') {
+    execSync(`tar -xzf "${sourcePath}" -C "${tempDir}"`, { stdio: 'inherit' })
+  } else if (format === 'zip') {
+    execSync(`unzip -q "${sourcePath}" -d "${tempDir}"`, { stdio: 'inherit' })
+  }
+
+  // Find extracted directory (MongoDB extracts to mongodb-PLATFORM-VERSION/)
+  const extractedDirs = execSync(`ls "${tempDir}"`, { encoding: 'utf-8' })
+    .trim()
+    .split('\n')
+  const mongoDir = extractedDirs.find((d) => d.startsWith('mongodb-'))
+
+  if (!mongoDir) {
+    throw new Error('Could not find extracted MongoDB directory')
+  }
+
+  const extractedPath = resolve(tempDir, mongoDir)
+
+  // Add metadata file
+  const metadata = {
+    name: 'mongodb',
+    version,
+    platform,
+    source: 'official',
+    rehosted_by: 'hostdb',
+    rehosted_at: new Date().toISOString(),
+  }
+  writeFileSync(
+    resolve(extractedPath, '.hostdb-metadata.json'),
+    JSON.stringify(metadata, null, 2),
+  )
+
+  // Create output tarball
+  mkdirSync(dirname(outputPath), { recursive: true })
+
+  logInfo(`Creating: ${basename(outputPath)}`)
+
+  // Rename directory to just 'mongodb' for consistency
+  const finalDir = resolve(tempDir, 'mongodb')
+  execSync(`mv "${extractedPath}" "${finalDir}"`)
+
+  // Create tarball
+  if (platform.startsWith('win32')) {
+    execSync(`cd "${tempDir}" && zip -rq "${outputPath}" mongodb`, {
+      stdio: 'inherit',
+    })
+  } else {
+    execSync(`tar -czf "${outputPath}" -C "${tempDir}" mongodb`, {
+      stdio: 'inherit',
+    })
+  }
+
+  // Cleanup temp
+  execSync(`rm -rf "${tempDir}"`)
+
+  logSuccess(`Created: ${outputPath}`)
+}
+
+function parseArgs(): {
+  version: string
+  platforms: Platform[]
+  outputDir: string
+} {
+  const args = process.argv.slice(2)
+  let version = '8.0.17'
+  let platforms: Platform[] = []
+  let outputDir = './dist'
+  let allPlatforms = false
+
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case '--version': {
+        if (i + 1 >= args.length || args[i + 1].startsWith('-')) {
+          logError('--version requires a value')
+          process.exit(1)
+        }
+        const versionValue = args[++i]
+        if (!isValidVersion(versionValue)) {
+          logError(`Invalid version format: ${versionValue}`)
+          logError('Version must be in format: X.Y.Z (e.g., 8.0.17)')
+          process.exit(1)
+        }
+        version = versionValue
+        break
+      }
+      case '--platform': {
+        if (i + 1 >= args.length || args[i + 1].startsWith('-')) {
+          logError('--platform requires a value')
+          process.exit(1)
+        }
+        const platformValue = args[++i]
+        if (!isValidPlatform(platformValue)) {
+          logError(`Invalid platform: ${platformValue}`)
+          logError(`Valid platforms: ${VALID_PLATFORMS.join(', ')}`)
+          process.exit(1)
+        }
+        platforms.push(platformValue)
+        break
+      }
+      case '--output':
+        if (i + 1 >= args.length || args[i + 1].startsWith('-')) {
+          logError('--output requires a value')
+          process.exit(1)
+        }
+        outputDir = args[++i]
+        break
+      case '--all-platforms':
+        allPlatforms = true
+        break
+      case '--help':
+      case '-h':
+        console.log(`
+Usage: ./builds/mongodb/download.ts [options]
+
+Options:
+  --version VERSION    MongoDB version (default: 8.0.17)
+  --platform PLATFORM  Target platform (default: current)
+  --output DIR         Output directory (default: ./dist)
+  --all-platforms      Download for all platforms
+  --help               Show this help
+
+Platforms: linux-x64, linux-arm64, darwin-x64, darwin-arm64, win32-x64
+
+Examples:
+  ./builds/mongodb/download.ts
+  ./builds/mongodb/download.ts --version 7.0.28 --platform linux-x64
+  ./builds/mongodb/download.ts --all-platforms
+`)
+        process.exit(0)
+    }
+  }
+
+  if (allPlatforms) {
+    platforms = [...VALID_PLATFORMS]
+  } else if (platforms.length === 0) {
+    platforms = [detectPlatform()]
+  }
+
+  return { version, platforms, outputDir }
+}
+
+async function main() {
+  const { version, platforms, outputDir } = parseArgs()
+  const sources = loadSources()
+
+  console.log()
+  logInfo(`MongoDB Download Script`)
+  logInfo(`Version: ${version}`)
+  logInfo(`Platforms: ${platforms.join(', ')}`)
+  logInfo(`Output: ${outputDir}`)
+  console.log()
+
+  const versionSources = sources.versions[version]
+  if (!versionSources) {
+    logError(`Version ${version} not found in sources.json`)
+    logInfo(`Available versions: ${Object.keys(sources.versions).join(', ')}`)
+    process.exit(1)
+  }
+
+  for (const platform of platforms) {
+    console.log()
+    logInfo(`=== ${platform} ===`)
+
+    const source = versionSources[platform]
+    if (!source) {
+      logWarn(`No source for ${platform}, skipping`)
+      continue
+    }
+
+    const ext = platform.startsWith('win32') ? 'zip' : 'tar.gz'
+    const downloadPath = resolve(
+      outputDir,
+      'downloads',
+      `mongodb-${version}-${platform}-original.${source.format}`,
+    )
+    const outputPath = resolve(outputDir, `mongodb-${version}-${platform}.${ext}`)
+
+    // Download
+    if (existsSync(downloadPath)) {
+      logInfo(`Using cached download: ${downloadPath}`)
+    } else {
+      await downloadFile(source.url, downloadPath)
+    }
+
+    // Verify checksum
+    const actualSha256 = await calculateSha256(downloadPath)
+    logInfo(`SHA256: ${actualSha256}`)
+
+    if (source.sha256) {
+      if (actualSha256 === source.sha256) {
+        logSuccess('Checksum verified')
+      } else {
+        logError(`Checksum mismatch! Expected: ${source.sha256}`)
+        process.exit(1)
+      }
+    } else {
+      logWarn('No checksum in sources.json - update it with the SHA256 above')
+    }
+
+    // Repackage
+    repackage(downloadPath, source.format, outputPath, version, platform)
+
+    // Final checksum
+    const outputSha256 = await calculateSha256(outputPath)
+    logInfo(`Output SHA256: ${outputSha256}`)
+  }
+
+  console.log()
+  logSuccess('Done!')
+  logInfo(`Output files in: ${resolve(outputDir)}`)
+}
+
+main().catch((err) => {
+  logError(err.message)
+  process.exit(1)
+})

--- a/builds/mongodb/sources.json
+++ b/builds/mongodb/sources.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "../../schemas/sources.schema.json",
+  "database": "mongodb",
+  "baseUrl": "https://fastdl.mongodb.org",
+  "versions": {
+    "8.2.3": {
+      "linux-x64": {
+        "url": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2204-8.2.3.tgz",
+        "format": "tar.gz",
+        "sha256": "f4050df7287ff027704801fe6bdafae6cf410d4451bc949147e87b376fc8c59a"
+      },
+      "linux-arm64": {
+        "url": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-ubuntu2204-8.2.3.tgz",
+        "format": "tar.gz",
+        "sha256": "639879f7629e519076b8adf439987a1fe15c0aaec4b4c373137003b87a60f207"
+      },
+      "darwin-x64": {
+        "url": "https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-8.2.3.tgz",
+        "format": "tar.gz",
+        "sha256": "da38cffaf3c072df9d7009fa4502caac3c80b0a4318f890bfb75e50d77d3d5c4"
+      },
+      "darwin-arm64": {
+        "url": "https://fastdl.mongodb.org/osx/mongodb-macos-arm64-8.2.3.tgz",
+        "format": "tar.gz",
+        "sha256": "a9455021ea2dd8d3b475dac45b98c496ee87572aa2c136d1d52e8a3362c9c15f"
+      },
+      "win32-x64": {
+        "url": "https://fastdl.mongodb.org/windows/mongodb-windows-x86_64-8.2.3.zip",
+        "format": "zip",
+        "sha256": "7993f73ed85b470352bd48087c4007a18607806f2acca16c41966f11c8fa89c8"
+      }
+    },
+    "8.0.17": {
+      "linux-x64": {
+        "url": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2204-8.0.17.tgz",
+        "format": "tar.gz",
+        "sha256": "4372a8e503a61814c565d4ccbc5f6765787944772e8969c13ba96c99cca11f75"
+      },
+      "linux-arm64": {
+        "url": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-ubuntu2204-8.0.17.tgz",
+        "format": "tar.gz",
+        "sha256": "2709ec6acd3de02666d02318d436f5d68dfb7d20b025d24a12a0914aacff4bd3"
+      },
+      "darwin-x64": {
+        "url": "https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-8.0.17.tgz",
+        "format": "tar.gz",
+        "sha256": "daca542b413f4322cef3199bdceed9c06e0b9999a246f6d72c42afb463349805"
+      },
+      "darwin-arm64": {
+        "url": "https://fastdl.mongodb.org/osx/mongodb-macos-arm64-8.0.17.tgz",
+        "format": "tar.gz",
+        "sha256": "e1ec5131b8d65f06d3a1a9f1a4bfe6f08a7d2f9c876436d33ab483d2e26840cb"
+      },
+      "win32-x64": {
+        "url": "https://fastdl.mongodb.org/windows/mongodb-windows-x86_64-8.0.17.zip",
+        "format": "zip",
+        "sha256": "39f0b72797f73e0909da3b454739d0f86bfcd5df436509f43d3df1aeeafc30e3"
+      }
+    },
+    "7.0.28": {
+      "linux-x64": {
+        "url": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2204-7.0.28.tgz",
+        "format": "tar.gz",
+        "sha256": "7fc16f46fb10753b982ab03bd9d7dd5920d18d181259f825c2462ca903c55d4d"
+      },
+      "linux-arm64": {
+        "url": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-ubuntu2204-7.0.28.tgz",
+        "format": "tar.gz",
+        "sha256": "28e4cefd35e933d5cf74cf3145c29f30b95d762088b7c23738817227954d5569"
+      },
+      "darwin-x64": {
+        "url": "https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-7.0.28.tgz",
+        "format": "tar.gz",
+        "sha256": "7b50602bba573cfb4dead78b604aa4c1ba809b3cc95879870efbe345ee465742"
+      },
+      "darwin-arm64": {
+        "url": "https://fastdl.mongodb.org/osx/mongodb-macos-arm64-7.0.28.tgz",
+        "format": "tar.gz",
+        "sha256": "1388a09743db960785de75aa4b5e077fca1767e9c948ccfaafef6280c862e239"
+      },
+      "win32-x64": {
+        "url": "https://fastdl.mongodb.org/windows/mongodb-windows-x86_64-7.0.28.zip",
+        "format": "zip",
+        "sha256": "79cd124714a0003f1d6109825bf5769a901ec03578bedd7845aede42da2801e0"
+      }
+    }
+  },
+  "notes": {
+    "sha256": "Set to null until we verify downloads and capture checksums",
+    "license": "SSPL-1.0 - Cannot be used in closed-source or commercial software. Use FerretDB as alternative.",
+    "ubuntu": "Linux binaries target Ubuntu 22.04 but work on glibc 2.35+ distros",
+    "cdn": "Official MongoDB CDN at fastdl.mongodb.org"
+  }
+}

--- a/databases.json
+++ b/databases.json
@@ -416,7 +416,7 @@
       "commercialUse": false,
       "protocol": null,
       "note": "TODO - disable if used commercially; use FerretDB as alternative",
-      "latestLts": "8.2",
+      "latestLts": "8.0",
       "versions": {
         "8.2.3": true,
         "8.0.17": true,
@@ -448,7 +448,7 @@
         "defaultUser": null,
         "queryLanguage": "MQL"
       },
-      "status": "pending"
+      "status": "in-progress"
     },
     "mysql": {
       "displayName": "MySQL",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hostdb",
-  "version": "0.2.0",
+  "version": "0.7.0",
   "description": "Pre-built database binaries for multiple platforms, distributed via GitHub Releases",
   "private": true,
   "type": "module",
@@ -15,6 +15,7 @@
     "checksums:populate": "tsx scripts/populate-checksums.ts",
     "dbs": "tsx scripts/list-databases.ts",
     "download:mariadb": "tsx builds/mariadb/download.ts",
+    "download:mongodb": "tsx builds/mongodb/download.ts",
     "download:mysql": "tsx builds/mysql/download.ts",
     "download:postgresql": "tsx builds/postgresql/download.ts",
     "download:redis": "tsx builds/redis/download.ts",


### PR DESCRIPTION
- Add release-mongodb.yml workflow with manual trigger for versions 8.2.3, 8.0.17, and 7.0.28
- Support all 5 platforms: linux-x64, linux-arm64, darwin-x64, darwin-arm64, win32-x64
- Add validation job to check version against databases.json and sources.json
- Add build job that downloads official MongoDB binaries from fastdl.mongodb.org CDN
- Add release job to create GitHub release with binaries and checksums
- Add updates