### PR TITLE
replace zonky io builds with build pg from source

### DIFF
--- a/.github/workflows/release-postgresql.yml
+++ b/.github/workflows/release-postgresql.yml
@@ -14,7 +14,7 @@ on:
           - 15.15.0
         default: 18.1.0
       platforms:
-        description: 'Platforms'
+        description: 'Platforms to build'
         required: true
         default: 'all'
         type: choice
@@ -32,6 +32,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Validate version against databases.json
   validate:
     runs-on: ubuntu-latest
     steps:
@@ -82,11 +83,67 @@ jobs:
 
           echo "✓ Version $VERSION found in sources.json"
 
-  build:
+  # Determine which platforms to build based on input
+  prepare:
     needs: validate
     runs-on: ubuntu-latest
     outputs:
-      artifact_names: ${{ steps.build.outputs.artifact_names }}
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      source_version: ${{ steps.parse-version.outputs.source_version }}
+    steps:
+      - name: Parse version for source download
+        id: parse-version
+        run: |
+          # databases.json uses 3-part versions (18.1.0) but PostgreSQL source uses 2-part (18.1)
+          VERSION="${{ github.event.inputs.version }}"
+          # Remove trailing .0 if present (18.1.0 -> 18.1)
+          SOURCE_VERSION=$(echo "$VERSION" | sed 's/\.0$//')
+          echo "source_version=$SOURCE_VERSION" >> $GITHUB_OUTPUT
+          echo "Source version: $SOURCE_VERSION (from $VERSION)"
+
+      - name: Set build matrix
+        id: set-matrix
+        run: |
+          PLATFORMS="${{ github.event.inputs.platforms }}"
+          if [ "$PLATFORMS" = "all" ]; then
+            # All 5 platforms with their appropriate runners
+            MATRIX='[
+              {"platform": "linux-x64", "runner": "ubuntu-latest", "build_type": "docker"},
+              {"platform": "linux-arm64", "runner": "ubuntu-latest", "build_type": "docker"},
+              {"platform": "darwin-x64", "runner": "macos-15-intel", "build_type": "native"},
+              {"platform": "darwin-arm64", "runner": "macos-14", "build_type": "native"},
+              {"platform": "win32-x64", "runner": "ubuntu-latest", "build_type": "download"}
+            ]'
+          else
+            # Single platform - determine runner and build type
+            case "$PLATFORMS" in
+              linux-x64|linux-arm64)
+                MATRIX="[{\"platform\": \"$PLATFORMS\", \"runner\": \"ubuntu-latest\", \"build_type\": \"docker\"}]"
+                ;;
+              darwin-x64)
+                MATRIX="[{\"platform\": \"$PLATFORMS\", \"runner\": \"macos-15-intel\", \"build_type\": \"native\"}]"
+                ;;
+              darwin-arm64)
+                MATRIX="[{\"platform\": \"$PLATFORMS\", \"runner\": \"macos-14\", \"build_type\": \"native\"}]"
+                ;;
+              win32-x64)
+                MATRIX="[{\"platform\": \"$PLATFORMS\", \"runner\": \"ubuntu-latest\", \"build_type\": \"download\"}]"
+                ;;
+            esac
+          fi
+          # Compact the JSON for output
+          MATRIX=$(echo "$MATRIX" | jq -c .)
+          echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
+          echo "Building platforms: $MATRIX"
+
+  # Build each platform in parallel
+  build:
+    needs: prepare
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.prepare.outputs.matrix) }}
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -103,52 +160,241 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Download and repackage PostgreSQL
-        id: build
+      # Set up QEMU for cross-platform Docker builds (required for linux-arm64 on x64 runners)
+      - name: Set up QEMU
+        if: matrix.build_type == 'docker'
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        if: matrix.build_type == 'docker'
+        uses: docker/setup-buildx-action@v3
+
+      # For Linux: use Docker-based source builds
+      - name: Build for Linux (Docker)
+        if: matrix.build_type == 'docker'
+        id: build-linux
+        timeout-minutes: 120
         run: |
-          VERSION="${{ github.event.inputs.version }}"
-          PLATFORMS="${{ github.event.inputs.platforms }}"
+          VERSION="${{ needs.prepare.outputs.source_version }}"
+          PLATFORM="${{ matrix.platform }}"
 
-          if [ "$PLATFORMS" = "all" ]; then
-            pnpm download:postgresql -- --version "$VERSION" --all-platforms --output ./dist
-          else
-            pnpm download:postgresql -- --version "$VERSION" --platform "$PLATFORMS" --output ./dist
-          fi
+          echo "Building PostgreSQL $VERSION for $PLATFORM"
 
-          # List created artifacts
-          ls -la ./dist/
+          ./builds/postgresql/build-local.sh \
+            --version "$VERSION" \
+            --platform "$PLATFORM" \
+            --output ./dist \
+            --cleanup
 
-          # Create artifact names output (handle case where no files exist)
+          # Check if artifact was created
           shopt -s nullglob
-          FILES=(./dist/*.tar.gz ./dist/*.zip)
+          FILES=(./dist/postgresql-*.tar.gz)
           if [ ${#FILES[@]} -eq 0 ]; then
-            echo "ERROR: No artifacts were created"
+            echo "::error::No artifact created for $PLATFORM"
             exit 1
           fi
-          ARTIFACTS=$(printf '%s\n' "${FILES[@]}" | xargs -n1 basename | tr '\n' ',' | sed 's/,$//')
-          echo "artifact_names=$ARTIFACTS" >> $GITHUB_OUTPUT
+          ls -la ./dist/
 
-      - name: Generate checksums
+      # For Windows: download official EDB binary
+      - name: Download for Windows (official EDB binary)
+        if: matrix.build_type == 'download'
+        id: build-windows
         run: |
-          shopt -s nullglob
+          VERSION="${{ github.event.inputs.version }}"
+          SOURCE_VERSION="${{ needs.prepare.outputs.source_version }}"
+
+          echo "Downloading PostgreSQL $SOURCE_VERSION for win32-x64 from EDB"
+
+          # Read download URL from sources.json (EDB uses non-predictable file IDs)
+          URL=$(jq -r ".versions[\"$VERSION\"][\"win32-x64\"].url" builds/postgresql/sources.json)
+
+          if [ -z "$URL" ] || [ "$URL" = "null" ]; then
+            echo "::error::No download URL found in sources.json for version $VERSION win32-x64"
+            exit 1
+          fi
+
+          echo "Download URL: $URL"
+
+          mkdir -p dist/downloads dist/temp
+
+          # Download with retry
+          for i in 1 2 3; do
+            if curl -fsSL "$URL" -o "dist/downloads/postgresql-${SOURCE_VERSION}-win32-x64-original.zip"; then
+              echo "Download succeeded"
+              break
+            fi
+            echo "Download attempt $i failed, retrying..."
+            sleep $((2**i))
+          done
+
+          if [ ! -f "dist/downloads/postgresql-${SOURCE_VERSION}-win32-x64-original.zip" ]; then
+            echo "::error::Failed to download Windows binary from EDB"
+            exit 1
+          fi
+
+          # Extract and repackage
+          cd dist/temp
+          unzip -q ../downloads/postgresql-${SOURCE_VERSION}-win32-x64-original.zip
+
+          # EDB ZIP extracts to 'pgsql' directory - rename to 'postgresql' for consistency
+          mv pgsql postgresql
+
+          # Add metadata
+          cat > postgresql/.hostdb-metadata.json << EOF
+          {
+            "name": "postgresql",
+            "version": "${SOURCE_VERSION}",
+            "platform": "win32-x64",
+            "source": "official",
+            "sourceUrl": "https://www.enterprisedb.com/",
+            "rehosted_by": "hostdb",
+            "rehosted_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          }
+          EOF
+
+          # Create zip with consistent naming
+          zip -rq "../postgresql-${SOURCE_VERSION}-win32-x64.zip" postgresql
+
+          cd ..
+          rm -rf temp downloads
+
+          ls -la .
+
+      # For macOS: native build with Homebrew dependencies
+      - name: Install macOS build dependencies
+        if: matrix.build_type == 'native'
+        run: |
+          brew install openssl@3 readline libxml2 libxslt icu4c pkg-config
+
+      - name: Build for macOS (native)
+        if: matrix.build_type == 'native'
+        id: build-macos
+        timeout-minutes: 90
+        run: |
+          VERSION="${{ needs.prepare.outputs.source_version }}"
+          PLATFORM="${{ matrix.platform }}"
+
+          echo "Building PostgreSQL $VERSION for $PLATFORM (native macOS build)"
+
+          # Get Homebrew prefix (differs between ARM64 and Intel macOS)
+          BREW_PREFIX=$(brew --prefix)
+          OPENSSL_PREFIX=$(brew --prefix openssl@3)
+          ICU_PREFIX=$(brew --prefix icu4c)
+
+          echo "Using OpenSSL at: $OPENSSL_PREFIX"
+          echo "Using ICU at: $ICU_PREFIX"
+
+          # Clean up any previous build artifacts
+          rm -rf postgresql-source.tar.gz postgresql-${VERSION} install dist
+
+          # Download source
+          curl -fsSL "https://ftp.postgresql.org/pub/source/v${VERSION}/postgresql-${VERSION}.tar.gz" \
+            -o postgresql-source.tar.gz
+          tar -xzf postgresql-source.tar.gz
+
+          cd postgresql-${VERSION}
+
+          # Fix for Xcode 16+ SDK/toolchain mismatch issues
+          # Force latest Xcode as the active developer directory
+          XCODE_PATH=$(ls -d /Applications/Xcode*.app 2>/dev/null | sort -V | tail -1)
+          echo "Using Xcode: $XCODE_PATH"
+          sudo xcode-select -s "$XCODE_PATH/Contents/Developer"
+
+          # Get SDK and toolchain paths
+          export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
+          XCODE_TOOLCHAIN=$(xcode-select -p)/Toolchains/XcodeDefault.xctoolchain
+
+          echo "Using Xcode SDK (SDKROOT): $SDKROOT"
+          echo "Using Xcode Toolchain: $XCODE_TOOLCHAIN"
+
+          # Set compiler environment variables to force correct SDK
+          export CC="$XCODE_TOOLCHAIN/usr/bin/clang"
+          export CXX="$XCODE_TOOLCHAIN/usr/bin/clang++"
+          export CFLAGS="--sysroot=$SDKROOT -I${OPENSSL_PREFIX}/include -I${ICU_PREFIX}/include"
+          export CPPFLAGS="$CFLAGS"
+          export LDFLAGS="--sysroot=$SDKROOT -L${OPENSSL_PREFIX}/lib -L${ICU_PREFIX}/lib"
+          export PKG_CONFIG_PATH="${OPENSSL_PREFIX}/lib/pkgconfig:${ICU_PREFIX}/lib/pkgconfig"
+
+          # Verify clang uses correct SDK
+          echo "Clang SDK check:"
+          $CC --version
+          $CC -v -E -x c /dev/null 2>&1 | grep "selected sysroot" || true
+
+          # Configure PostgreSQL
+          ./configure \
+            --prefix="$GITHUB_WORKSPACE/install/postgresql" \
+            --with-openssl \
+            --with-readline \
+            --with-libxml \
+            --with-libxslt \
+            --with-icu \
+            --without-systemd
+
+          # Build
+          make -j$(sysctl -n hw.ncpu)
+
+          # Install
+          make install
+
+          # Build and install contrib modules
+          cd contrib
+          make -j$(sysctl -n hw.ncpu)
+          make install
+          cd ..
+
+          # Add metadata
+          cd "$GITHUB_WORKSPACE/install"
+          cat > postgresql/.hostdb-metadata.json << EOF
+          {
+            "name": "postgresql",
+            "version": "${VERSION}",
+            "platform": "${PLATFORM}",
+            "source": "source-build",
+            "sourceUrl": "https://ftp.postgresql.org/",
+            "rehosted_by": "hostdb",
+            "rehosted_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          }
+          EOF
+
+          # Verify key binaries exist
+          test -f postgresql/bin/postgres || { echo "::error::postgres binary not found"; exit 1; }
+          test -f postgresql/bin/psql || { echo "::error::psql binary not found"; exit 1; }
+          test -f postgresql/lib/pg_stat_statements.so || echo "::warning::pg_stat_statements.so not found"
+
+          # Create tarball
+          mkdir -p "$GITHUB_WORKSPACE/dist"
+          tar -czvf "$GITHUB_WORKSPACE/dist/postgresql-${VERSION}-${PLATFORM}.tar.gz" postgresql
+
+          echo "Build complete:"
+          ls -la "$GITHUB_WORKSPACE/dist/"
+
+      - name: Generate checksum
+        run: |
           cd dist
+          shopt -s nullglob
           for f in *.tar.gz *.zip; do
             if [ -f "$f" ]; then
-              sha256sum "$f" >> checksums.txt
+              if command -v sha256sum &> /dev/null; then
+                sha256sum "$f" >> checksums.txt
+              else
+                # macOS uses shasum
+                shasum -a 256 "$f" >> checksums.txt
+              fi
             fi
           done
           cat checksums.txt
 
-      - name: Upload artifacts
+      - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: postgresql-${{ github.event.inputs.version }}
+          name: postgresql-${{ github.event.inputs.version }}-${{ matrix.platform }}
           path: |
             dist/*.tar.gz
             dist/*.zip
             dist/checksums.txt
           retention-days: 1
 
+  # Collect all artifacts and create release
   release:
     needs: build
     runs-on: ubuntu-latest
@@ -158,14 +404,36 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Download artifacts
+      - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
-          name: postgresql-${{ github.event.inputs.version }}
-          path: ./release-assets
+          path: ./artifacts
+          pattern: postgresql-${{ github.event.inputs.version }}-*
 
-      - name: List release assets
-        run: ls -la ./release-assets/
+      - name: Prepare release assets
+        run: |
+          mkdir -p ./release-assets
+
+          # Move all artifacts to release-assets, flattening the directory structure
+          find ./artifacts -type f \( -name "*.tar.gz" -o -name "*.zip" \) -exec mv {} ./release-assets/ \;
+
+          # Combine all checksums
+          find ./artifacts -name "checksums.txt" -exec cat {} \; > ./release-assets/checksums.txt
+
+          echo "Release assets:"
+          ls -la ./release-assets/
+
+          # Verify we have at least one artifact
+          shopt -s nullglob
+          FILES=(./release-assets/*.tar.gz ./release-assets/*.zip)
+          if [ ${#FILES[@]} -eq 0 ]; then
+            echo "ERROR: No artifacts were created for any platform"
+            exit 1
+          fi
+
+          echo ""
+          echo "Checksums:"
+          cat ./release-assets/checksums.txt
 
       - name: Create Release
         uses: softprops/action-gh-release@v2
@@ -175,14 +443,20 @@ jobs:
           body: |
             ## PostgreSQL ${{ github.event.inputs.version }}
 
-            PostgreSQL binaries from [zonky.io embedded-postgres-binaries](https://github.com/zonkyio/embedded-postgres-binaries), repackaged for hostdb.
+            PostgreSQL binaries built from source for hostdb.
 
-            ### Platforms
-            - `linux-x64` - Linux x86_64
-            - `linux-arm64` - Linux ARM64
-            - `darwin-x64` - macOS x86_64
-            - `darwin-arm64` - macOS Apple Silicon
-            - `win32-x64` - Windows x64
+            ### Available Platforms
+            | Platform | Source |
+            |----------|--------|
+            | `linux-x64` | Built from source (Docker) |
+            | `linux-arm64` | Built from source (Docker/QEMU) |
+            | `darwin-x64` | Built from source (native macOS) |
+            | `darwin-arm64` | Built from source (native macOS) |
+            | `win32-x64` | Official EDB binary |
+
+            ### Features
+            - All contrib modules included (pg_stat_statements, etc.)
+            - Built with SSL, readline, XML, XSLT, and ICU support
 
             ### Usage
             ```bash
@@ -193,14 +467,16 @@ jobs:
             ### Checksums
             See `checksums.txt` for SHA256 checksums.
 
-            ### Source
-            Binaries from [zonky.io embedded-postgres-binaries](https://github.com/zonkyio/embedded-postgres-binaries) (Maven Central)
+            ### Sources
+            - **Source Builds**: [ftp.postgresql.org](https://ftp.postgresql.org/pub/source/)
+            - **Windows Binary**: [EnterpriseDB](https://www.enterprisedb.com/)
           files: |
             release-assets/*.tar.gz
             release-assets/*.zip
             release-assets/checksums.txt
           fail_on_unmatched_files: false
 
+  # Update the releases manifest
   update-manifest:
     needs: release
     runs-on: ubuntu-latest

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -327,6 +327,7 @@ The sync script automatically updates the version dropdown in the workflow file.
 | releases.json not updated | Check update-manifest job permissions |
 | "Version not enabled" error | Add version to databases.json with `true` |
 | "Version not in sources.json" | Add version URLs to builds/<db>/sources.json |
+| PostgreSQL EDB file ID unknown | Run `pnpm edb:fileids -- --update` to fetch latest IDs |
 
 ### Testing Commands
 
@@ -357,4 +358,8 @@ pnpm sync:versions --check
 
 # Scaffold new database
 pnpm add:engine <database-key>
+
+# PostgreSQL: Fetch EDB Windows file IDs
+pnpm edb:fileids                  # Show available file IDs
+pnpm edb:fileids -- --update      # Update sources.json
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,9 +12,9 @@ This repository exists to solve one problem: **database binaries should be avail
 
 When adding a database, source binaries in this order:
 
-1. **Official binaries** - Direct from vendor CDNs (Oracle for MySQL, MariaDB Foundation, etc.)
-2. **Third-party repositories** - Trusted sources like [zonky.io](https://github.com/zonkyio/embedded-postgres-binaries) for PostgreSQL or [MariaDB4j](https://github.com/MariaDB4j/MariaDB4j) Maven JARs
-3. **Build from source** - Docker builds for Linux, native GitHub Actions builds for macOS/Windows
+1. **Official binaries** - Direct from vendor CDNs (Oracle for MySQL, MariaDB Foundation, EnterpriseDB for PostgreSQL Windows, etc.)
+2. **Third-party repositories** - Trusted sources like [MariaDB4j](https://github.com/MariaDB4j/MariaDB4j) Maven JARs
+3. **Build from source** - Docker builds for Linux, native GitHub Actions builds for macOS
 
 ### Key Principles
 
@@ -61,10 +61,11 @@ hostdb/
 │   ├── mariadb/
 │   └── ...
 ├── scripts/
-│   ├── add-engine.ts       # pnpm add:engine - scaffold new database
-│   ├── list-databases.ts   # pnpm dbs
-│   ├── sync-versions.ts    # pnpm sync:versions - sync workflow dropdowns
-│   └── update-releases.ts  # Updates releases.json after GH Release
+│   ├── add-engine.ts         # pnpm add:engine - scaffold new database
+│   ├── fetch-edb-fileids.ts  # pnpm edb:fileids - fetch PostgreSQL Windows file IDs
+│   ├── list-databases.ts     # pnpm dbs
+│   ├── sync-versions.ts      # pnpm sync:versions - sync workflow dropdowns
+│   └── update-releases.ts    # Updates releases.json after GH Release
 └── .github/workflows/
     ├── release-mysql.yml
     ├── release-postgresql.yml
@@ -134,7 +135,7 @@ Maps versions and platforms to download URLs:
 
 **Source types:**
 - `official` - Direct from vendor CDN
-- `mariadb4j`, `zonky` - Third-party repositories
+- `mariadb4j` - Third-party repository (MariaDB4j Maven JARs)
 - `build-required` - Must build from source
 
 ## GitHub Actions Workflows
@@ -250,6 +251,10 @@ pnpm download:mariadb -- --version 11.8.5 --build-fallback
 pnpm add:engine redis              # Scaffold new database
 pnpm sync:versions                 # Sync workflow dropdowns with databases.json
 pnpm checksums:populate <database> # Populate missing SHA256 checksums
+
+# PostgreSQL: Fetch EDB Windows file IDs
+pnpm edb:fileids                   # Show available file IDs from EDB
+pnpm edb:fileids -- --update       # Update sources.json with latest IDs
 ```
 
 ## Querying Available Binaries

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ This repository exists to solve one problem: **database binaries should be avail
 
 When adding a database, we source binaries in this order:
 
-1. **Official binaries** - Direct from vendor CDNs (Oracle for MySQL, MariaDB Foundation, etc.)
-2. **Third-party repositories** - Trusted sources like [zonky.io](https://github.com/zonkyio/embedded-postgres-binaries) for PostgreSQL or [MariaDB4j](https://github.com/MariaDB4j/MariaDB4j) Maven JARs
-3. **Build from source** - Docker builds for Linux, native GitHub Actions builds for macOS/Windows
+1. **Official binaries** - Direct from vendor CDNs (Oracle for MySQL, MariaDB Foundation, EnterpriseDB for PostgreSQL Windows, etc.)
+2. **Third-party repositories** - Trusted sources like [MariaDB4j](https://github.com/MariaDB4j/MariaDB4j) Maven JARs
+3. **Build from source** - Docker builds for Linux, native GitHub Actions builds for macOS
 
 ### What This Means
 
@@ -129,7 +129,7 @@ Auto-generated manifest updated after each GitHub Release. Structure:
 | Database | Status | Versions | Notes |
 |----------|--------|----------|-------|
 | MySQL | Completed | 8.4.7, 8.0.40 | Official binaries for all platforms |
-| PostgreSQL | In Progress | 18.1.0, 17.7.0, 16.11.0, 15.15.0 | Via zonky.io binaries |
+| PostgreSQL | In Progress | 18.1.0, 17.7.0, 16.11.0, 15.15.0 | Source builds + EDB (Windows) |
 | MariaDB | Completed | 11.8.5, 11.4.5, 10.11.15 | Official + source builds |
 | Redis | Completed | 8.4.0, 7.4.7 | Source builds |
 | SQLite | In Progress | 3.51.1 | Official amalgamation |
@@ -184,10 +184,11 @@ hostdb/
 │   ├── mariadb/
 │   └── ...
 ├── scripts/
-│   ├── add-engine.ts       # pnpm add:engine - scaffold new database
-│   ├── list-databases.ts   # pnpm dbs
-│   ├── sync-versions.ts    # pnpm sync:versions - sync workflow dropdowns
-│   └── update-releases.ts  # Updates releases.json after release
+│   ├── add-engine.ts         # pnpm add:engine - scaffold new database
+│   ├── fetch-edb-fileids.ts  # pnpm edb:fileids - fetch PostgreSQL Windows file IDs
+│   ├── list-databases.ts     # pnpm dbs
+│   ├── sync-versions.ts      # pnpm sync:versions - sync workflow dropdowns
+│   └── update-releases.ts    # Updates releases.json after release
 └── .github/workflows/
     ├── release-mysql.yml
     ├── release-postgresql.yml
@@ -219,8 +220,8 @@ pnpm add:engine sqlite   # Then follow printed instructions
 
 ## Inspiration
 
-- [embedded-postgres-binaries](https://github.com/zonkyio/embedded-postgres-binaries) - PostgreSQL binaries built from source
 - [MariaDB4j](https://github.com/MariaDB4j/MariaDB4j) - Embedded MariaDB for Java
+- [embedded-postgres-binaries](https://github.com/zonkyio/embedded-postgres-binaries) - PostgreSQL binaries (we previously used this, now build from source)
 
 ## License
 

--- a/builds/postgresql/Dockerfile
+++ b/builds/postgresql/Dockerfile
@@ -1,0 +1,122 @@
+# PostgreSQL Build Dockerfile
+# Builds PostgreSQL from source for Linux platforms
+#
+# Usage:
+#   docker buildx build --platform linux/amd64 \
+#     --build-arg VERSION=17.7 \
+#     --output type=local,dest=./dist \
+#     -f builds/postgresql/Dockerfile .
+#
+# Build time: ~15-30 minutes depending on platform and resources
+
+ARG VERSION=17.7
+
+# =============================================================================
+# Stage 1: Builder
+# =============================================================================
+FROM ubuntu:22.04 AS builder
+
+ARG VERSION
+ARG TARGETARCH
+
+# Avoid interactive prompts during package installation
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install build dependencies
+# PostgreSQL requires fewer dependencies than MariaDB
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    curl \
+    flex \
+    bison \
+    libreadline-dev \
+    libssl-dev \
+    zlib1g-dev \
+    libxml2-dev \
+    libxslt1-dev \
+    libicu-dev \
+    pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+# Download PostgreSQL source
+# Source tarballs are at ftp.postgresql.org/pub/source/v{VERSION}/
+RUN curl -fsSL "https://ftp.postgresql.org/pub/source/v${VERSION}/postgresql-${VERSION}.tar.gz" \
+    -o postgresql.tar.gz \
+    && tar -xzf postgresql.tar.gz \
+    && rm postgresql.tar.gz \
+    && mv postgresql-${VERSION} postgresql-src
+
+WORKDIR /build/postgresql-src
+
+# Configure PostgreSQL build
+# - Enable SSL for encrypted connections
+# - Enable readline for psql history/editing
+# - Enable XML support for XML functions
+# - Enable ICU for internationalization
+RUN ./configure \
+    --prefix=/opt/postgresql \
+    --with-openssl \
+    --with-readline \
+    --with-libxml \
+    --with-libxslt \
+    --with-icu \
+    --without-systemd
+
+# Build PostgreSQL
+RUN make -j$(nproc)
+
+# Install to /opt/postgresql
+RUN make install
+
+# Build and install contrib modules (pg_stat_statements, etc.)
+RUN cd contrib && make -j$(nproc) && make install
+
+# =============================================================================
+# Stage 2: Package
+# =============================================================================
+FROM ubuntu:22.04 AS packager
+
+ARG VERSION
+ARG TARGETARCH
+
+# Install minimal runtime dependencies for verification
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libssl3 \
+    libreadline8 \
+    libxml2 \
+    libxslt1.1 \
+    libicu70 \
+    zlib1g \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy built PostgreSQL
+COPY --from=builder /opt/postgresql /opt/postgresql
+
+WORKDIR /opt/postgresql
+
+# Map Docker TARGETARCH to hostdb platform naming
+RUN PLATFORM="linux-x64"; \
+    if [ "$TARGETARCH" = "arm64" ]; then PLATFORM="linux-arm64"; fi; \
+    printf '{\n  "name": "postgresql",\n  "version": "%s",\n  "platform": "%s",\n  "source": "source-build",\n  "sourceUrl": "https://ftp.postgresql.org/",\n  "rehosted_by": "hostdb",\n  "rehosted_at": "%s"\n}\n' \
+        "${VERSION}" "${PLATFORM}" "$(date -Iseconds)" \
+        > /opt/postgresql/.hostdb-metadata.json
+
+# Verify key binaries exist
+RUN test -f /opt/postgresql/bin/postgres \
+    && test -f /opt/postgresql/bin/psql \
+    && test -f /opt/postgresql/bin/pg_dump \
+    && test -f /opt/postgresql/bin/initdb \
+    && echo "Build verification passed"
+
+# Verify contrib modules are installed
+RUN test -f /opt/postgresql/lib/pg_stat_statements.so \
+    && echo "Contrib modules verification passed"
+
+# =============================================================================
+# Stage 3: Export (scratch image for minimal output)
+# =============================================================================
+FROM scratch AS export
+
+COPY --from=packager /opt/postgresql /postgresql

--- a/builds/postgresql/README.md
+++ b/builds/postgresql/README.md
@@ -1,0 +1,173 @@
+# PostgreSQL Builds
+
+Build PostgreSQL from source for distribution via GitHub Releases.
+
+## Platform Coverage
+
+**All 5 platforms are fully supported for all versions.**
+
+| Platform | Method | Runner | Build Time |
+|----------|--------|--------|------------|
+| linux-x64 | Docker source build | ubuntu-latest | ~15-25 min |
+| linux-arm64 | Docker source build (QEMU) | ubuntu-latest | ~45-90 min |
+| darwin-x64 | Native source build | macos-15-intel | ~20-40 min |
+| darwin-arm64 | Native source build | macos-14 | ~15-30 min |
+| win32-x64 | Official EDB binary | ubuntu-latest | ~2-5 min |
+
+## Binary Sources
+
+| Source | Platforms | Notes |
+|--------|-----------|-------|
+| Source Build (Docker) | linux-x64, linux-arm64 | Built from official source tarball |
+| Source Build (Native macOS) | darwin-x64, darwin-arm64 | Built with Homebrew dependencies |
+| EnterpriseDB (EDB) | win32-x64 | Official Windows binary ZIP |
+
+### Source Builds (ftp.postgresql.org)
+
+For Linux and macOS, we build PostgreSQL from source using the official tarballs:
+
+**URL pattern:**
+```
+https://ftp.postgresql.org/pub/source/v{VERSION}/postgresql-{VERSION}.tar.gz
+```
+
+**Features included:**
+- SSL support (`--with-openssl`)
+- Readline support (`--with-readline`)
+- XML support (`--with-libxml`, `--with-libxslt`)
+- ICU support (`--with-icu`)
+- All contrib modules (pg_stat_statements, etc.)
+
+### EnterpriseDB Windows Binaries
+
+Windows binaries are downloaded from EnterpriseDB's download portal. EDB uses non-predictable file IDs for downloads.
+
+**To fetch current file IDs:**
+```bash
+pnpm edb:fileids              # Show available file IDs
+pnpm edb:fileids -- --update  # Update sources.json with latest IDs
+```
+
+## Usage
+
+```bash
+# Local Docker build for Linux
+./builds/postgresql/build-local.sh --version 17.7 --platform linux-x64
+
+# Build linux-arm64 (requires QEMU or ARM host)
+./builds/postgresql/build-local.sh --version 17.7 --platform linux-arm64
+
+# Build without Docker cache
+./builds/postgresql/build-local.sh --version 17.7 --no-cache
+
+# Auto-cleanup extracted files after tarball creation
+./builds/postgresql/build-local.sh --version 17.7 --cleanup
+```
+
+Note: macOS builds run natively on GitHub Actions runners (macos-14 for ARM64, macos-15-intel for x64).
+
+## Output
+
+Builds are saved to `./dist/`:
+
+```
+dist/
+├── postgresql-17.7-linux-x64/
+│   └── postgresql/           (extracted build)
+└── postgresql-17.7-linux-x64.tar.gz  (final tarball)
+```
+
+Archives contain:
+- PostgreSQL binaries in a `postgresql/` directory
+- All contrib modules in `postgresql/lib/` and `postgresql/share/extension/`
+- `.hostdb-metadata.json` with provenance information
+
+## Supported Versions
+
+| Version | Type | Notes |
+|---------|------|-------|
+| 18.1 | Latest | PostgreSQL 18 |
+| 17.7 | Current | PostgreSQL 17 |
+| 16.11 | Supported | PostgreSQL 16 |
+| 15.15 | Supported | PostgreSQL 15 |
+
+## Platform Coverage Matrix
+
+**Full coverage: 5 platforms × 4 versions = 20 binaries**
+
+| Platform | 18.1 | 17.7 | 16.11 | 15.15 | Method |
+|----------|------|------|-------|-------|--------|
+| linux-x64 | ✅ | ✅ | ✅ | ✅ | Docker source build |
+| linux-arm64 | ✅ | ✅ | ✅ | ✅ | Docker source build (QEMU) |
+| darwin-x64 | ✅ | ✅ | ✅ | ✅ | Native macOS build |
+| darwin-arm64 | ✅ | ✅ | ✅ | ✅ | Native macOS build |
+| win32-x64 | ✅ | ✅ | ✅ | ✅ | Official EDB binary |
+
+## GitHub Actions
+
+The release workflow builds all platforms in parallel:
+
+1. Go to Actions → "Release PostgreSQL" → Run workflow
+2. Select version and platforms (default: all)
+3. Click "Run workflow"
+
+| Platform | Runner | Build Type |
+|----------|--------|------------|
+| linux-x64 | ubuntu-latest | Docker source build |
+| linux-arm64 | ubuntu-latest | Docker source build (QEMU) |
+| darwin-x64 | macos-15-intel | Native source build |
+| darwin-arm64 | macos-14 | Native source build |
+| win32-x64 | ubuntu-latest | Download EDB binary |
+
+## Adding New Versions
+
+1. Add version to `databases.json`:
+   ```json
+   "versions": { "19.0.0": true, "18.1.0": true, ... }
+   ```
+
+2. Fetch EDB file ID for Windows:
+   ```bash
+   pnpm edb:fileids -- --update
+   ```
+
+3. Sync workflow and populate checksums:
+   ```bash
+   pnpm prep
+   ```
+
+4. Commit changes and run the workflow
+
+## Why Source Builds?
+
+Previously, PostgreSQL binaries were sourced from [zonky.io embedded-postgres-binaries](https://github.com/zonkyio/embedded-postgres-binaries). We switched to source builds to address:
+
+1. **Missing contrib modules**: zonky.io binaries didn't include pg_stat_statements and other contrib modules
+2. **Dependency issues**: Runtime library incompatibilities on some platforms
+3. **Reliability**: No dependency on third-party binary availability
+
+## Build Dependencies
+
+### Docker (Linux)
+
+The Dockerfile installs these dependencies on Ubuntu 22.04:
+- build-essential, flex, bison
+- libreadline-dev, libssl-dev, zlib1g-dev
+- libxml2-dev, libxslt1-dev, libicu-dev
+- pkg-config
+
+### macOS (Native)
+
+GitHub Actions installs via Homebrew:
+- openssl@3, readline
+- libxml2, libxslt
+- icu4c, pkg-config
+
+The macOS builds include the Xcode SDK fix for Xcode 16+ to prevent header conflicts.
+
+## Related Links
+
+- [PostgreSQL Downloads](https://www.postgresql.org/download/)
+- [PostgreSQL FTP](https://ftp.postgresql.org/pub/source/)
+- [EnterpriseDB Downloads](https://www.enterprisedb.com/downloads)
+- [EDB Binary Archives](https://www.enterprisedb.com/download-postgresql-binaries)

--- a/builds/postgresql/build-local.sh
+++ b/builds/postgresql/build-local.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+#
+# Local Docker build script for PostgreSQL
+#
+# Usage:
+#   ./builds/postgresql/build-local.sh [options]
+#
+# Options:
+#   --version VERSION    PostgreSQL version to build (default: 17.7)
+#   --platform PLATFORM  Target platform: linux-x64, linux-arm64 (default: linux-x64)
+#   --output DIR         Output directory (default: ./dist)
+#   --no-cache           Build without Docker cache
+#   --cleanup            Remove extracted directory after creating tarball
+#   --no-cleanup         Keep extracted directory (default in non-interactive/CI)
+#   --help               Show this help message
+#
+# Environment:
+#   CLEANUP=1            Same as --cleanup
+#   CI=true              Implies --no-cleanup unless --cleanup is specified
+#
+# Examples:
+#   ./builds/postgresql/build-local.sh
+#   ./builds/postgresql/build-local.sh --version 18.1 --platform linux-arm64
+#   ./builds/postgresql/build-local.sh --no-cache --cleanup
+#
+# Build time: ~15-30 minutes depending on platform and resources
+
+set -euo pipefail
+
+# Default values
+VERSION="17.7"
+PLATFORM="linux-x64"
+OUTPUT_DIR="./dist"
+NO_CACHE=""
+CLEANUP_MODE=""  # "", "yes", or "no"
+
+# Script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+# Color output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+log_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
+log_success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+
+show_help() {
+    head -30 "$0" | tail -25 | sed 's/^#//' | sed 's/^ //'
+    exit 0
+}
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --version)
+            VERSION="$2"
+            shift 2
+            ;;
+        --platform)
+            PLATFORM="$2"
+            shift 2
+            ;;
+        --output)
+            OUTPUT_DIR="$2"
+            shift 2
+            ;;
+        --no-cache)
+            NO_CACHE="--no-cache"
+            shift
+            ;;
+        --cleanup)
+            CLEANUP_MODE="yes"
+            shift
+            ;;
+        --no-cleanup)
+            CLEANUP_MODE="no"
+            shift
+            ;;
+        --help|-h)
+            show_help
+            ;;
+        *)
+            log_error "Unknown option: $1"
+            show_help
+            ;;
+    esac
+done
+
+# Map platform to Docker platform
+case $PLATFORM in
+    linux-x64)
+        DOCKER_PLATFORM="linux/amd64"
+        ;;
+    linux-arm64)
+        DOCKER_PLATFORM="linux/arm64"
+        ;;
+    *)
+        log_error "Unsupported platform for source builds: $PLATFORM"
+        log_error "Source builds only support: linux-x64, linux-arm64"
+        log_error "For darwin platforms, build natively on macOS"
+        exit 1
+        ;;
+esac
+
+# Check Docker is available
+if ! command -v docker &> /dev/null; then
+    log_error "Docker is not installed or not in PATH"
+    exit 1
+fi
+
+# Check Docker buildx is available (needed for multi-platform builds)
+if ! docker buildx version &> /dev/null; then
+    log_error "Docker buildx is not available"
+    log_error "Install with: docker buildx install"
+    exit 1
+fi
+
+# Create output directory
+OUTPUT_PATH="${OUTPUT_DIR}/postgresql-${VERSION}-${PLATFORM}"
+mkdir -p "$OUTPUT_PATH"
+
+log_info "Building PostgreSQL ${VERSION} for ${PLATFORM}"
+log_info "Docker platform: ${DOCKER_PLATFORM}"
+log_info "Output directory: ${OUTPUT_PATH}"
+echo ""
+
+# Build start time
+START_TIME=$(date +%s)
+
+# Run Docker build
+log_info "Starting Docker build (this may take 15-30+ minutes)..."
+echo ""
+
+docker buildx build \
+    --platform "${DOCKER_PLATFORM}" \
+    --build-arg VERSION="${VERSION}" \
+    --output "type=local,dest=${OUTPUT_PATH}" \
+    --progress=plain \
+    ${NO_CACHE} \
+    -f "${SCRIPT_DIR}/Dockerfile" \
+    "${PROJECT_ROOT}"
+
+# Build end time
+END_TIME=$(date +%s)
+ELAPSED_SECS=$((END_TIME - START_TIME))
+ELAPSED_MINS=$((ELAPSED_SECS / 60))
+ELAPSED_REMAINDER=$((ELAPSED_SECS % 60))
+
+echo ""
+log_success "Build completed in ${ELAPSED_MINS}m ${ELAPSED_REMAINDER}s"
+
+# Verify output
+if [[ -f "${OUTPUT_PATH}/postgresql/bin/postgres" ]]; then
+    log_success "postgres binary found"
+else
+    log_error "postgres binary NOT found - build may have failed"
+    exit 1
+fi
+
+if [[ -f "${OUTPUT_PATH}/postgresql/bin/psql" ]]; then
+    log_success "psql client binary found"
+else
+    log_warn "psql client binary not found"
+fi
+
+if [[ -f "${OUTPUT_PATH}/postgresql/lib/pg_stat_statements.so" ]]; then
+    log_success "pg_stat_statements contrib module found"
+else
+    log_warn "pg_stat_statements contrib module not found"
+fi
+
+# Create tarball
+TARBALL="${OUTPUT_DIR}/postgresql-${VERSION}-${PLATFORM}.tar.gz"
+log_info "Creating tarball: ${TARBALL}"
+
+tar -czvf "${TARBALL}" -C "${OUTPUT_PATH}" postgresql
+
+# Show tarball info
+TARBALL_SIZE=$(du -h "${TARBALL}" | cut -f1)
+log_success "Created: ${TARBALL} (${TARBALL_SIZE})"
+
+# Calculate SHA256
+SHA256=$(sha256sum "${TARBALL}" | cut -d' ' -f1)
+log_info "SHA256: ${SHA256}"
+
+# Determine cleanup behavior
+# Priority: CLI flag > CLEANUP env var > interactive prompt (if tty) > no cleanup
+if [[ -z "$CLEANUP_MODE" ]]; then
+    # Check CLEANUP environment variable
+    if [[ "${CLEANUP:-}" == "1" || "${CLEANUP:-}" == "true" ]]; then
+        CLEANUP_MODE="yes"
+    elif [[ -t 0 ]] && [[ -z "${CI:-}" ]]; then
+        # Interactive terminal and not CI - prompt user
+        read -p "Remove extracted directory ${OUTPUT_PATH}? [y/N] " -n 1 -r
+        echo
+        if [[ $REPLY =~ ^[Yy]$ ]]; then
+            CLEANUP_MODE="yes"
+        else
+            CLEANUP_MODE="no"
+        fi
+    else
+        # Non-interactive or CI - default to no cleanup
+        CLEANUP_MODE="no"
+    fi
+fi
+
+if [[ "$CLEANUP_MODE" == "yes" ]]; then
+    rm -rf "${OUTPUT_PATH}"
+    log_info "Removed ${OUTPUT_PATH}"
+fi
+
+echo ""
+log_success "PostgreSQL ${VERSION} for ${PLATFORM} built successfully!"
+log_info "Tarball: ${TARBALL}"

--- a/builds/postgresql/sources.json
+++ b/builds/postgresql/sources.json
@@ -4,116 +4,92 @@
   "versions": {
     "18.1.0": {
       "linux-x64": {
-        "url": "https://repo1.maven.org/maven2/io/zonky/test/postgres/embedded-postgres-binaries-linux-amd64/18.1.0/embedded-postgres-binaries-linux-amd64-18.1.0.jar",
-        "format": "jar",
-        "sha256": "65d0723e0274ad3ec6230dcbdfe034af6ee096fce15a77b0f9b8be71d2702934"
+        "sourceType": "build-required"
       },
       "linux-arm64": {
-        "url": "https://repo1.maven.org/maven2/io/zonky/test/postgres/embedded-postgres-binaries-linux-arm64v8/18.1.0/embedded-postgres-binaries-linux-arm64v8-18.1.0.jar",
-        "format": "jar",
-        "sha256": "ea0f16b754fc0a10d9d8993bbd426c20f8c709b318b28e49b42d9cac1c958b8f"
+        "sourceType": "build-required"
       },
       "darwin-x64": {
-        "url": "https://repo1.maven.org/maven2/io/zonky/test/postgres/embedded-postgres-binaries-darwin-amd64/18.1.0/embedded-postgres-binaries-darwin-amd64-18.1.0.jar",
-        "format": "jar",
-        "sha256": "3b4f16dcf57250d8f9c5e9270a7dfc3921b66d66534d00f8f366e8263e862d11"
+        "sourceType": "build-required"
       },
       "darwin-arm64": {
-        "url": "https://repo1.maven.org/maven2/io/zonky/test/postgres/embedded-postgres-binaries-darwin-arm64v8/18.1.0/embedded-postgres-binaries-darwin-arm64v8-18.1.0.jar",
-        "format": "jar",
-        "sha256": "7398c6c19d11594a944dc0ddc79fdbb611164312e1f509a8c86b09724027401e"
+        "sourceType": "build-required"
       },
       "win32-x64": {
-        "url": "https://repo1.maven.org/maven2/io/zonky/test/postgres/embedded-postgres-binaries-windows-amd64/18.1.0/embedded-postgres-binaries-windows-amd64-18.1.0.jar",
-        "format": "jar",
-        "sha256": "0a7e951660cbbee3f382f8b44b2c3ae26c4a17817c3a972dee3378c80fc9b23b"
+        "url": "https://sbp.enterprisedb.com/getfile.jsp?fileid=1259913",
+        "format": "zip",
+        "sourceType": "official",
+        "sha256": "a05155fc413d8a9c250b04e9535cfe788c9e24acb3e7050140087987f81cf495"
       }
     },
     "17.7.0": {
       "linux-x64": {
-        "url": "https://repo1.maven.org/maven2/io/zonky/test/postgres/embedded-postgres-binaries-linux-amd64/17.7.0/embedded-postgres-binaries-linux-amd64-17.7.0.jar",
-        "format": "jar",
-        "sha256": "ceb1c01cf5e71d6f906b8614982f6ed61e96b3740dd30758fa6262f97e752b69"
+        "sourceType": "build-required"
       },
       "linux-arm64": {
-        "url": "https://repo1.maven.org/maven2/io/zonky/test/postgres/embedded-postgres-binaries-linux-arm64v8/17.7.0/embedded-postgres-binaries-linux-arm64v8-17.7.0.jar",
-        "format": "jar",
-        "sha256": "85622d56a394c424db4b15185bad31f51848809cb0810fe87059ec38be23caad"
+        "sourceType": "build-required"
       },
       "darwin-x64": {
-        "url": "https://repo1.maven.org/maven2/io/zonky/test/postgres/embedded-postgres-binaries-darwin-amd64/17.7.0/embedded-postgres-binaries-darwin-amd64-17.7.0.jar",
-        "format": "jar",
-        "sha256": "9540ede93642d7301c0a9b19a21df5c3c696db5d59396fc54898be48114baac8"
+        "sourceType": "build-required"
       },
       "darwin-arm64": {
-        "url": "https://repo1.maven.org/maven2/io/zonky/test/postgres/embedded-postgres-binaries-darwin-arm64v8/17.7.0/embedded-postgres-binaries-darwin-arm64v8-17.7.0.jar",
-        "format": "jar",
-        "sha256": "f3478bea63e3ed5328bbfbb1d894883a9686f8ca34445daf067995daa60d0cc1"
+        "sourceType": "build-required"
       },
       "win32-x64": {
-        "url": "https://repo1.maven.org/maven2/io/zonky/test/postgres/embedded-postgres-binaries-windows-amd64/17.7.0/embedded-postgres-binaries-windows-amd64-17.7.0.jar",
-        "format": "jar",
-        "sha256": "c488d0a4c94b1fcb525e6503c93fc7a0023092ab33762719c7283418f7bddd15"
+        "url": "https://sbp.enterprisedb.com/getfile.jsp?fileid=1259911",
+        "format": "zip",
+        "sourceType": "official",
+        "sha256": "f256b0df079182965808d886ef132901e67f847a4ce1d439702dea8d55265998"
       }
     },
     "16.11.0": {
       "linux-x64": {
-        "url": "https://repo1.maven.org/maven2/io/zonky/test/postgres/embedded-postgres-binaries-linux-amd64/16.11.0/embedded-postgres-binaries-linux-amd64-16.11.0.jar",
-        "format": "jar",
-        "sha256": "7f78235db9c0d94e933e81ec43d00708a5533841d7eb3a9b6b86bb1fd465ae2f"
+        "sourceType": "build-required"
       },
       "linux-arm64": {
-        "url": "https://repo1.maven.org/maven2/io/zonky/test/postgres/embedded-postgres-binaries-linux-arm64v8/16.11.0/embedded-postgres-binaries-linux-arm64v8-16.11.0.jar",
-        "format": "jar",
-        "sha256": "dd0c8f80a5b96fb1223ff4f7e36b3cc476d86d865bff131a9fbd757eab232af2"
+        "sourceType": "build-required"
       },
       "darwin-x64": {
-        "url": "https://repo1.maven.org/maven2/io/zonky/test/postgres/embedded-postgres-binaries-darwin-amd64/16.11.0/embedded-postgres-binaries-darwin-amd64-16.11.0.jar",
-        "format": "jar",
-        "sha256": "eabf2b625d3e108bd41fc41434d887afdccf514a691e78808d5e7eeb4a16f7ab"
+        "sourceType": "build-required"
       },
       "darwin-arm64": {
-        "url": "https://repo1.maven.org/maven2/io/zonky/test/postgres/embedded-postgres-binaries-darwin-arm64v8/16.11.0/embedded-postgres-binaries-darwin-arm64v8-16.11.0.jar",
-        "format": "jar",
-        "sha256": "424c1b4d37aebe80c3bc7a50b63594a8416c4c42e708c34e879f34f4b726f7b8"
+        "sourceType": "build-required"
       },
       "win32-x64": {
-        "url": "https://repo1.maven.org/maven2/io/zonky/test/postgres/embedded-postgres-binaries-windows-amd64/16.11.0/embedded-postgres-binaries-windows-amd64-16.11.0.jar",
-        "format": "jar",
-        "sha256": "8563af4423177595d5f9463d986cd4aaf0c161af7d4277154f45e7ce4fecd355"
+        "url": "https://sbp.enterprisedb.com/getfile.jsp?fileid=1259906",
+        "format": "zip",
+        "sourceType": "official",
+        "sha256": "579f70755723259d85d80301f1b793559edc31516cdeb3bcf34f1ec9d140cebb"
       }
     },
     "15.15.0": {
       "linux-x64": {
-        "url": "https://repo1.maven.org/maven2/io/zonky/test/postgres/embedded-postgres-binaries-linux-amd64/15.15.0/embedded-postgres-binaries-linux-amd64-15.15.0.jar",
-        "format": "jar",
-        "sha256": "7c73da91870b0615b37a8ceb84871bd42f28c3600f87a97ca9747f4a0b8d2dbb"
+        "sourceType": "build-required"
       },
       "linux-arm64": {
-        "url": "https://repo1.maven.org/maven2/io/zonky/test/postgres/embedded-postgres-binaries-linux-arm64v8/15.15.0/embedded-postgres-binaries-linux-arm64v8-15.15.0.jar",
-        "format": "jar",
-        "sha256": "623ee4c35cfdccd585d4473ff9b51942d465a7f8280687e6b960f56066f58909"
+        "sourceType": "build-required"
       },
       "darwin-x64": {
-        "url": "https://repo1.maven.org/maven2/io/zonky/test/postgres/embedded-postgres-binaries-darwin-amd64/15.15.0/embedded-postgres-binaries-darwin-amd64-15.15.0.jar",
-        "format": "jar",
-        "sha256": "e025db76c3b9a02cb70af0fe596079035e9a559c15f98280462e9f5ebb05069e"
+        "sourceType": "build-required"
       },
       "darwin-arm64": {
-        "url": "https://repo1.maven.org/maven2/io/zonky/test/postgres/embedded-postgres-binaries-darwin-arm64v8/15.15.0/embedded-postgres-binaries-darwin-arm64v8-15.15.0.jar",
-        "format": "jar",
-        "sha256": "c9611126d7b87e86423ec147b65da41a12c4e247097264496fc4af6fba8a828b"
+        "sourceType": "build-required"
       },
       "win32-x64": {
-        "url": "https://repo1.maven.org/maven2/io/zonky/test/postgres/embedded-postgres-binaries-windows-amd64/15.15.0/embedded-postgres-binaries-windows-amd64-15.15.0.jar",
-        "format": "jar",
-        "sha256": "718c3a29e3c729d3e2cd60a7dfddc6c61ce9d829d76ef7ece38c7cd5a66bb1a0"
+        "url": "https://sbp.enterprisedb.com/getfile.jsp?fileid=1259903",
+        "format": "zip",
+        "sourceType": "official",
+        "sha256": "b4bd6c844fc2659411af825f70957e2bcebf74142d015ee972c8361e941e8cd8"
       }
     }
   },
   "notes": {
-    "source": "Binaries from zonky.io embedded-postgres-binaries project (Maven Central)",
-    "format": "JAR files containing .txz archives of PostgreSQL binaries",
-    "repository": "https://github.com/zonkyio/embedded-postgres-binaries"
+    "source": "Linux and macOS built from official source at ftp.postgresql.org, Windows from EnterpriseDB",
+    "linux-x64": "Built from source via Docker on ubuntu-latest",
+    "linux-arm64": "Built from source via Docker with QEMU emulation",
+    "darwin-x64": "Built from source natively on macos-15-intel runner",
+    "darwin-arm64": "Built from source natively on macos-14 runner",
+    "win32-x64": "Official binary ZIP from EnterpriseDB (EDB)",
+    "windows-update": "Run 'pnpm edb:fileids --update' to fetch latest file IDs when adding new versions"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "download:postgresql": "tsx builds/postgresql/download.ts",
     "download:redis": "tsx builds/redis/download.ts",
     "download:valkey": "tsx builds/valkey/download.ts",
+    "edb:fileids": "tsx scripts/fetch-edb-fileids.ts",
     "format": "prettier --write .",
     "lint": "tsc --noEmit && eslint .",
     "prep": "tsx scripts/prep.ts",

--- a/scripts/fetch-edb-fileids.ts
+++ b/scripts/fetch-edb-fileids.ts
@@ -1,0 +1,163 @@
+#!/usr/bin/env tsx
+/**
+ * Fetches PostgreSQL Windows binary file IDs from EDB's download page
+ *
+ * Usage:
+ *   pnpm tsx scripts/fetch-edb-fileids.ts
+ *   pnpm tsx scripts/fetch-edb-fileids.ts --update  # Update sources.json
+ *
+ * EDB uses non-predictable file IDs for their downloads, so we need to scrape
+ * the download page to get the current file IDs for each version.
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const EDB_BINARIES_URL = 'https://www.enterprisedb.com/download-postgresql-binaries'
+
+type VersionFileIds = Record<
+  string,
+  {
+    windows?: string
+    macos?: string
+  }
+>
+
+async function fetchEdbPage(): Promise<string> {
+  console.log(`Fetching ${EDB_BINARIES_URL}...`)
+  const response = await fetch(EDB_BINARIES_URL)
+  if (!response.ok) {
+    throw new Error(`Failed to fetch EDB page: ${response.status} ${response.statusText}`)
+  }
+  return response.text()
+}
+
+function parseFileIds(html: string): VersionFileIds {
+  const results: VersionFileIds = {}
+
+  // Pattern to find file IDs with their platform
+  // Windows: alt="Windows x86-64" ... href="https://sbp.enterprisedb.com/getfile.jsp?fileid=1259913"
+  // macOS: alt="Mac OS X" ... href="https://sbp.enterprisedb.com/getfile.jsp?fileid=1259821"
+  const linkPattern =
+    /<a\s+href="https:\/\/sbp\.enterprisedb\.com\/getfile\.jsp\?fileid=(\d+)"[^>]*>.*?<img\s+alt="([^"]+)"/gs
+
+  // Split by version sections
+  const sections = html.split(/Binaries from installer/)
+
+  for (const section of sections) {
+    // Find version in this section
+    const versionMatch = section.match(/Version\s*(?:<!--.*?-->\s*)?(\d+\.\d+(?:\.\d+)?)/)
+    if (!versionMatch) continue
+
+    const version = versionMatch[1]
+
+    // Skip unsupported versions
+    if (section.includes('Not supported')) continue
+
+    // Find all links in this section
+    const links = [...section.matchAll(linkPattern)]
+
+    const fileIds: { windows?: string; macos?: string } = {}
+
+    for (const [, fileId, platform] of links) {
+      if (platform === 'Windows x86-64') {
+        fileIds.windows = fileId
+      } else if (platform === 'Mac OS X') {
+        fileIds.macos = fileId
+      }
+    }
+
+    if (fileIds.windows || fileIds.macos) {
+      results[version] = fileIds
+    }
+  }
+
+  return results
+}
+
+function updateSourcesJson(fileIds: VersionFileIds): boolean {
+  const sourcesPath = join(import.meta.dirname, '..', 'builds', 'postgresql', 'sources.json')
+  const sources = JSON.parse(readFileSync(sourcesPath, 'utf-8'))
+
+  let updated = false
+
+  for (const [version, ids] of Object.entries(fileIds)) {
+    // Convert 2-part version to 3-part (18.1 -> 18.1.0)
+    const version3Part = version.includes('.', version.indexOf('.') + 1)
+      ? version
+      : `${version}.0`
+
+    if (!sources.versions[version3Part]) {
+      console.log(`  Skipping ${version} - not in sources.json`)
+      continue
+    }
+
+    if (ids.windows) {
+      const currentUrl = sources.versions[version3Part]['win32-x64']?.url
+      const newUrl = `https://sbp.enterprisedb.com/getfile.jsp?fileid=${ids.windows}`
+
+      if (currentUrl !== newUrl) {
+        console.log(`  Updating ${version3Part}/win32-x64: fileid=${ids.windows}`)
+        sources.versions[version3Part]['win32-x64'] = {
+          url: newUrl,
+          format: 'zip',
+          sourceType: 'official',
+          sha256: null, // Will be populated by checksums:populate
+        }
+        updated = true
+      }
+    }
+  }
+
+  if (updated) {
+    writeFileSync(sourcesPath, JSON.stringify(sources, null, 2) + '\n')
+    console.log(`\nUpdated ${sourcesPath}`)
+    console.log('Run "pnpm checksums:populate postgresql" to fetch checksums')
+  }
+
+  return updated
+}
+
+async function main() {
+  const shouldUpdate = process.argv.includes('--update')
+
+  try {
+    const html = await fetchEdbPage()
+    const fileIds = parseFileIds(html)
+
+    console.log('\nEDB PostgreSQL Windows Binary File IDs:')
+    console.log('========================================')
+
+    const sortedVersions = Object.keys(fileIds).sort((a, b) => {
+      const [aMajor, aMinor] = a.split('.').map(Number)
+      const [bMajor, bMinor] = b.split('.').map(Number)
+      return bMajor - aMajor || bMinor - aMinor
+    })
+
+    for (const version of sortedVersions) {
+      const ids = fileIds[version]
+      console.log(`  ${version}:`)
+      if (ids.windows) {
+        console.log(`    Windows x64: https://sbp.enterprisedb.com/getfile.jsp?fileid=${ids.windows}`)
+      }
+      if (ids.macos) {
+        console.log(`    macOS:       https://sbp.enterprisedb.com/getfile.jsp?fileid=${ids.macos}`)
+      }
+    }
+
+    if (shouldUpdate) {
+      console.log('\nUpdating sources.json...')
+      const updated = updateSourcesJson(fileIds)
+      if (!updated) {
+        console.log('No updates needed - all file IDs are current')
+      }
+    } else {
+      console.log('\nRun with --update to update sources.json')
+    }
+  } catch (error) {
+    console.error('Error:', error instanceof Error ? error.message : error)
+    process.exit(1)
+  }
+}
+
+main()


### PR DESCRIPTION
chore: refactor PostgreSQL workflow to support multi-platform matrix builds with Docker, native, and download strategies

- Add prepare job to generate build matrix based on platform selection
- Add matrix strategy to build job with platform-specific runners and build types
- Add Docker-based source builds for Linux (x64 and arm64 with QEMU)
- Add native macOS builds with Homebrew dependencies and Xcode 16+ SDK fixes
- Add Windows download support using official EDB binaries from sources.json