### PR TITLE
Fix broken binary

### DIFF
--- a/.github/workflows/release-postgresql.yml
+++ b/.github/workflows/release-postgresql.yml
@@ -230,22 +230,37 @@ jobs:
           cd dist/temp
           tar -xzf ../downloads/postgresql-original.tar.gz
 
-          # Verify extracted layout - Percona extracts to percona-postgresql-X.X
+          # Verify extracted layout - Percona extracts to multiple dirs including percona-postgresqlXX
           echo "Extracted contents:"
           ls -la
 
-          # Find the extracted directory (handle various naming patterns)
-          EXTRACTED_DIR=$(ls -d percona-postgresql-* 2>/dev/null || ls -d postgresql-* 2>/dev/null || echo "")
+          # Find the PostgreSQL directory (Percona uses percona-postgresql{major_version} naming)
+          # e.g., percona-postgresql18, percona-postgresql17, etc.
+          EXTRACTED_DIR=$(ls -d percona-postgresql[0-9]* 2>/dev/null | head -1)
 
           if [ -z "$EXTRACTED_DIR" ]; then
-            echo "::error::Unexpected tarball layout"
+            # Fallback to other patterns
+            EXTRACTED_DIR=$(ls -d percona-postgresql-* 2>/dev/null | head -1)
+          fi
+
+          if [ -z "$EXTRACTED_DIR" ]; then
+            EXTRACTED_DIR=$(ls -d postgresql-* 2>/dev/null | head -1)
+          fi
+
+          if [ -z "$EXTRACTED_DIR" ]; then
+            echo "::error::Could not find PostgreSQL directory in tarball"
             echo "Contents:"
             find . -maxdepth 2 -type d
             exit 1
           fi
 
-          echo "Found extracted directory: $EXTRACTED_DIR"
+          echo "Found PostgreSQL directory: $EXTRACTED_DIR"
           mv "$EXTRACTED_DIR" postgresql
+
+          # Clean up other Percona components we don't need
+          rm -rf percona-etcd percona-haproxy percona-patroni percona-perl \
+                 percona-pgbackrest percona-pgbadger percona-pgbouncer \
+                 percona-pgpool-II percona-python3 percona-tcl 2>/dev/null || true
 
           # Add metadata
           cat > postgresql/.hostdb-metadata.json << EOF

--- a/builds/postgresql/build-local.sh
+++ b/builds/postgresql/build-local.sh
@@ -54,7 +54,7 @@ log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
 show_help() {
     # Extract help text between HELP_START and HELP_END markers
     sed -n '/^# HELP_START$/,/^# HELP_END$/p' "$0" | sed '1d;$d' | sed 's/^# \?//'
-    exit 0
+    exit "${1:-0}"
 }
 
 # Parse arguments
@@ -63,7 +63,7 @@ while [[ $# -gt 0 ]]; do
         --version)
             if [[ -z "${2:-}" || "${2:-}" == -* ]]; then
                 log_error "Missing value for --version"
-                show_help
+                show_help 1
             fi
             VERSION="$2"
             shift 2
@@ -71,7 +71,7 @@ while [[ $# -gt 0 ]]; do
         --platform)
             if [[ -z "${2:-}" || "${2:-}" == -* ]]; then
                 log_error "Missing value for --platform"
-                show_help
+                show_help 1
             fi
             PLATFORM="$2"
             shift 2
@@ -79,7 +79,7 @@ while [[ $# -gt 0 ]]; do
         --output)
             if [[ -z "${2:-}" || "${2:-}" == -* ]]; then
                 log_error "Missing value for --output"
-                show_help
+                show_help 1
             fi
             OUTPUT_DIR="$2"
             shift 2
@@ -101,7 +101,7 @@ while [[ $# -gt 0 ]]; do
             ;;
         *)
             log_error "Unknown option: $1"
-            show_help
+            show_help 1
             ;;
     esac
 done


### PR DESCRIPTION
chore: improve PostgreSQL ARM64 tarball extraction to handle Percona's multi-component layout

- Update directory detection to prioritize percona-postgresql{major_version} naming pattern (e.g., percona-postgresql18)
- Add fallback chain for directory detection: percona-postgresql[0-9]* → percona-postgresql-* → postgresql-*
- Add cleanup step to remove unused Percona components (etcd, haproxy, patroni, perl, pgbackrest, pgbadger, pgbouncer, pgpool-II, python3, tcl)
- Improve error messages