### PR TITLE
feat: add SQLite support with 5-platform coverage and source builds for linux arm64

### DIFF
--- a/.github/workflows/release-sqlite.yml
+++ b/.github/workflows/release-sqlite.yml
@@ -1,0 +1,309 @@
+name: Release SQLite
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'SQLite version'
+        required: true
+        type: choice
+        options:
+          - 3.51.2
+        default: 3.51.2
+      platforms:
+        description: 'Platforms'
+        required: true
+        default: 'all'
+        type: choice
+        options:
+          - 'all'
+          - 'linux-x64'
+          - 'linux-arm64'
+          - 'darwin-x64'
+          - 'darwin-arm64'
+          - 'win32-x64'
+
+# Prevent concurrent runs that could conflict when updating releases.json
+concurrency:
+  group: release-sqlite
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ github.event.inputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate version against databases.json
+        run: |
+          DB="sqlite"
+
+          echo "Validating SQLite version: $VERSION"
+
+          # Check if version exists and is enabled in databases.json
+          ENABLED=$(jq -r ".databases.$DB.versions[\"$VERSION\"] // false" databases.json)
+          if [ "$ENABLED" != "true" ]; then
+            echo "::error::Version '$VERSION' is not enabled in databases.json"
+            echo ""
+            echo "Available versions:"
+            jq -r ".databases.$DB.versions | to_entries | map(select(.value == true)) | .[].key" databases.json
+            exit 1
+          fi
+
+          echo "✓ Version $VERSION is enabled in databases.json"
+
+      - name: Validate sources.json exists
+        run: |
+          DB="sqlite"
+          if [ ! -f "builds/$DB/sources.json" ]; then
+            echo "::error::Missing builds/$DB/sources.json"
+            exit 1
+          fi
+          echo "✓ builds/$DB/sources.json exists"
+
+      - name: Validate version in sources.json
+        run: |
+          DB="sqlite"
+
+          HAS_VERSION=$(jq -r ".versions[\"$VERSION\"] // empty" "builds/$DB/sources.json")
+          if [ -z "$HAS_VERSION" ]; then
+            echo "::error::Version '$VERSION' not found in builds/$DB/sources.json"
+            echo ""
+            echo "Available versions in sources.json:"
+            jq -r ".versions | keys[]" "builds/$DB/sources.json"
+            exit 1
+          fi
+
+          echo "✓ Version $VERSION found in sources.json"
+
+  # Build linux-arm64 from source (no official binary available)
+  build-arm64:
+    needs: validate
+    if: github.event.inputs.platforms == 'all' || github.event.inputs.platforms == 'linux-arm64'
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ github.event.inputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build SQLite for linux-arm64
+        run: |
+          mkdir -p dist
+
+          # Build Docker image for ARM64
+          docker buildx build \
+            --platform linux/arm64 \
+            --build-arg VERSION="$VERSION" \
+            --load \
+            -t sqlite-builder:$VERSION \
+            builds/sqlite/
+
+          # Extract artifact
+          docker run --rm \
+            --platform linux/arm64 \
+            -v "$(pwd)/dist:/dist" \
+            sqlite-builder:$VERSION
+
+          ls -la dist/
+
+      - name: Upload arm64 artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sqlite-arm64-${{ github.event.inputs.version }}
+          path: dist/*.tar.gz
+          retention-days: 1
+
+  # Download official binaries for other platforms
+  build-download:
+    needs: validate
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ github.event.inputs.version }}
+      PLATFORMS: ${{ github.event.inputs.platforms }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download and repackage SQLite
+        run: |
+          # Download for all platforms except linux-arm64 (built separately)
+          if [ "$PLATFORMS" = "all" ]; then
+            for platform in linux-x64 darwin-x64 darwin-arm64 win32-x64; do
+              pnpm download:sqlite -- --version "$VERSION" --platform "$platform" --output ./dist
+            done
+          elif [ "$PLATFORMS" != "linux-arm64" ]; then
+            pnpm download:sqlite -- --version "$VERSION" --platform "$PLATFORMS" --output ./dist
+          fi
+
+          ls -la ./dist/ || echo "No downloads (linux-arm64 only build)"
+
+      - name: Upload download artifacts
+        if: github.event.inputs.platforms != 'linux-arm64'
+        uses: actions/upload-artifact@v4
+        with:
+          name: sqlite-downloads-${{ github.event.inputs.version }}
+          path: |
+            dist/*.tar.gz
+            dist/*.zip
+          retention-days: 1
+
+  release:
+    needs: [build-arm64, build-download]
+    if: always() && (needs.build-arm64.result == 'success' || needs.build-arm64.result == 'skipped') && (needs.build-download.result == 'success' || needs.build-download.result == 'skipped')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download arm64 artifacts
+        if: needs.build-arm64.result == 'success'
+        uses: actions/download-artifact@v4
+        with:
+          name: sqlite-arm64-${{ github.event.inputs.version }}
+          path: ./release-assets
+
+      - name: Download other artifacts
+        if: needs.build-download.result == 'success' && github.event.inputs.platforms != 'linux-arm64'
+        uses: actions/download-artifact@v4
+        with:
+          name: sqlite-downloads-${{ github.event.inputs.version }}
+          path: ./release-assets
+
+      - name: Generate checksums
+        run: |
+          cd release-assets
+          sha256sum *.tar.gz *.zip 2>/dev/null > checksums.txt || sha256sum *.tar.gz > checksums.txt || echo "No files to checksum"
+          cat checksums.txt || true
+
+      - name: List release assets
+        run: ls -la ./release-assets/
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: sqlite-${{ github.event.inputs.version }}
+          name: SQLite ${{ github.event.inputs.version }}
+          body: |
+            ## SQLite ${{ github.event.inputs.version }}
+
+            SQLite command-line tools repackaged for hostdb.
+
+            SQLite is a self-contained, serverless, zero-configuration SQL database engine.
+
+            ### License
+
+            SQLite is in the **public domain**. No restrictions on use, modification, or distribution.
+
+            ### Included Tools
+
+            - `sqlite3` - Interactive command-line shell
+            - `sqldiff` - Database diff utility
+            - `sqlite3_analyzer` - Storage analyzer
+            - `sqlite3_rsync` - Remote database sync
+
+            ### Platforms
+            - `linux-x64` - Linux x86_64 (official binary)
+            - `linux-arm64` - Linux ARM64 (source build)
+            - `darwin-x64` - macOS Intel (official binary)
+            - `darwin-arm64` - macOS Apple Silicon (official binary)
+            - `win32-x64` - Windows x64 (official binary)
+
+            ### Usage
+            ```bash
+            # Download URL pattern
+            https://github.com/${{ github.repository }}/releases/download/sqlite-${{ github.event.inputs.version }}/sqlite-${{ github.event.inputs.version }}-<platform>.tar.gz
+            ```
+
+            ### Checksums
+            See `checksums.txt` for SHA256 checksums.
+
+            ### Source
+            Official binaries from [sqlite.org](https://sqlite.org/download.html). Linux ARM64 built from source.
+          files: |
+            release-assets/*.tar.gz
+            release-assets/*.zip
+            release-assets/checksums.txt
+          fail_on_unmatched_files: false
+
+  update-manifest:
+    needs: release
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ github.event.inputs.version }}
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Update releases.json
+        run: |
+          pnpm tsx scripts/update-releases.ts \
+            --database sqlite \
+            --version "$VERSION" \
+            --tag "sqlite-$VERSION"
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add releases.json
+          git diff --staged --quiet && echo "No changes to commit" && exit 0
+
+          git commit -m "chore: update releases.json for sqlite-$VERSION"
+
+          # Retry push with rebase if remote has changed
+          for i in 1 2 3; do
+            if git push; then
+              echo "Push succeeded"
+              exit 0
+            fi
+            echo "Push failed, attempting rebase (attempt $i/3)..."
+            git fetch origin main
+            if ! git rebase origin/main; then
+              echo "ERROR: Rebase failed due to conflicts. Manual intervention required."
+              git rebase --abort
+              exit 1
+            fi
+            sleep $((2**i))
+          done
+          echo "ERROR: Push failed after 3 attempts"
+          exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.9.0] - 2026-01-10
+
+### Added
+
+- **SQLite support** with full 5-platform coverage
+  - Version 3.51.2 (latest stable)
+  - Official binaries from `sqlite.org` for linux-x64, darwin-x64, darwin-arm64, win32-x64
+  - Source build from amalgamation for linux-arm64 (no official binary available)
+  - Includes sqlite3 CLI, sqldiff, sqlite3_analyzer, sqlite3_rsync
+  - Public domain license (no restrictions)
+
+- **Checksums documentation** added to CLAUDE.md
+  - Most databases use SHA-256 (auto-populated via `pnpm checksums:populate`)
+  - SQLite uses SHA3-256 (copied manually from vendor)
+  - Guidance for handling different checksum algorithms
+
+### Changed
+
+- **MongoDB database-tools** updated from 100.13.0 to 100.14.0
+
 ## [0.8.0] - 2026-01-10
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,6 +229,17 @@ When adding a new version to an existing database:
 
 **That's it.** The prep script handles syncing workflow dropdowns and populating SHA256 checksums automatically.
 
+## Checksums
+
+Most databases use **SHA-256** checksums. The `pnpm checksums:populate` script downloads files and computes checksums automatically.
+
+**Exception - SQLite**: SQLite uses **SHA3-256** checksums (different algorithm). These are provided directly on [sqlite.org/download.html](https://sqlite.org/download.html) and must be copied manually to `sources.json` using the `sha3_256` field instead of `sha256`.
+
+When adding a new database:
+1. Check the vendor's download page for checksum format (SHA-256, SHA3-256, SHA-512, etc.)
+2. If SHA-256, use `pnpm checksums:populate <database>` to auto-populate
+3. If different algorithm, copy checksums manually and use appropriate field name (e.g., `sha3_256`)
+
 ```bash
 # Sync all workflows
 pnpm sync:versions

--- a/builds/sqlite/Dockerfile
+++ b/builds/sqlite/Dockerfile
@@ -1,0 +1,69 @@
+# Build SQLite tools from source for Linux ARM64
+#
+# SQLite doesn't provide official ARM64 binaries, so we build from the amalgamation.
+# The amalgamation is a single sqlite3.c file that compiles everything.
+#
+# Usage:
+#   docker build --build-arg VERSION=3.51.2 -t sqlite-builder .
+#   docker run --rm -v $(pwd)/dist:/dist sqlite-builder
+#
+# Output: /dist/sqlite-3.51.2-linux-arm64.tar.gz
+
+ARG UBUNTU_VERSION=22.04
+FROM ubuntu:${UBUNTU_VERSION}
+
+ARG VERSION=3.51.2
+
+# Convert version to SQLite's filename format: 3.51.2 -> 3510200
+# Formula: MAJOR*1000000 + MINOR*1000 + PATCH*100
+RUN VERSION_NUM=$(echo "${VERSION}" | awk -F. '{printf "%d%03d%02d", $1, $2, $3*100}') && \
+    echo "VERSION_NUM=${VERSION_NUM}" > /tmp/version_env
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    wget \
+    ca-certificates \
+    libreadline-dev \
+    zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+# Download and extract amalgamation
+RUN . /tmp/version_env && \
+    wget -q "https://sqlite.org/2026/sqlite-autoconf-${VERSION_NUM}.tar.gz" -O sqlite.tar.gz && \
+    tar -xzf sqlite.tar.gz && \
+    rm sqlite.tar.gz && \
+    mv sqlite-autoconf-* sqlite-src
+
+WORKDIR /build/sqlite-src
+
+# Configure and build with recommended options
+# See: https://sqlite.org/compile.html
+RUN ./configure \
+    --prefix=/build/output \
+    --disable-static \
+    --enable-readline \
+    CFLAGS="-O2 -DSQLITE_ENABLE_FTS5 -DSQLITE_ENABLE_JSON1 -DSQLITE_ENABLE_RTREE"
+
+RUN make -j$(nproc)
+RUN make install
+
+# Create the final package structure
+WORKDIR /build/package
+ARG VERSION
+RUN mkdir -p sqlite/bin && \
+    cp /build/output/bin/sqlite3 sqlite/bin/ && \
+    chmod 755 sqlite/bin/sqlite3 && \
+    # Add metadata \
+    echo "{\n  \"name\": \"sqlite\",\n  \"version\": \"${VERSION}\",\n  \"platform\": \"linux-arm64\",\n  \"source\": \"source-build\",\n  \"tools\": [\"sqlite3\"],\n  \"rehosted_by\": \"hostdb\",\n  \"rehosted_at\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"\n}" > sqlite/.hostdb-metadata.json
+
+# Create tarball
+RUN tar -czf /build/sqlite-${VERSION}-linux-arm64.tar.gz sqlite
+
+# Copy to output on container run
+ARG VERSION
+CMD cp /build/sqlite-${VERSION}-linux-arm64.tar.gz /dist/

--- a/builds/sqlite/README.md
+++ b/builds/sqlite/README.md
@@ -1,0 +1,92 @@
+# SQLite
+
+SQLite is a self-contained, serverless, zero-configuration SQL database engine. It's the most widely deployed database in the world.
+
+## Versions
+
+| Version | Notes |
+|---------|-------|
+| **3.51.2** | Latest stable |
+
+SQLite doesn't have LTS versions - they expect everyone to use the latest due to extreme backward compatibility.
+
+## Platforms
+
+| Platform | Source | Notes |
+|----------|--------|-------|
+| linux-x64 | Official binary | From sqlite.org |
+| linux-arm64 | **Source build** | No official binary available |
+| darwin-x64 | Official binary | From sqlite.org |
+| darwin-arm64 | Official binary | From sqlite.org |
+| win32-x64 | Official binary | From sqlite.org |
+
+## Included Tools
+
+The SQLite tools package includes:
+
+| Tool | Description |
+|------|-------------|
+| `sqlite3` | Interactive command-line shell |
+| `sqldiff` | Database diff utility |
+| `sqlite3_analyzer` | Storage analyzer |
+| `sqlite3_rsync` | Remote database sync |
+
+## Usage
+
+```bash
+# Download for current platform
+pnpm download:sqlite
+
+# Download specific version
+pnpm download:sqlite -- --version 3.51.2
+
+# Download for specific platform
+pnpm download:sqlite -- --version 3.51.2 --platform darwin-arm64
+
+# Download for all platforms (skips linux-arm64 which needs source build)
+pnpm download:sqlite -- --all-platforms
+```
+
+## Building linux-arm64
+
+Since SQLite doesn't provide ARM64 Linux binaries, we build from source:
+
+```bash
+# Local Docker build
+./builds/sqlite/build-local.sh --version 3.51.2
+
+# Or via GitHub Actions workflow
+# (automatically handles linux-arm64 with Docker build)
+```
+
+## Output Structure
+
+```
+sqlite/
+├── bin/
+│   ├── sqlite3           # Main CLI
+│   ├── sqldiff           # Diff tool
+│   ├── sqlite3_analyzer  # Analyzer
+│   └── sqlite3_rsync     # Sync tool
+└── .hostdb-metadata.json
+```
+
+## Checksums
+
+SQLite uses **SHA3-256** checksums (not SHA-256). The download script verifies against the `sha3_256` field in `sources.json`.
+
+## License
+
+SQLite is in the **public domain**. No restrictions on use, modification, or distribution.
+
+## Sources
+
+- [SQLite Download Page](https://sqlite.org/download.html)
+- [SQLite Documentation](https://sqlite.org/docs.html)
+- [Source Repository](https://github.com/sqlite/sqlite)
+
+## Notes
+
+- SQLite is an embedded database - no server process required
+- The CLI tools are statically linked and self-contained
+- Version numbering in filenames: 3.51.2 → 3510200 (MAJOR×1000000 + MINOR×1000 + PATCH×100)

--- a/builds/sqlite/build-local.sh
+++ b/builds/sqlite/build-local.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+#
+# Build SQLite from source locally using Docker
+#
+# Usage:
+#   ./builds/sqlite/build-local.sh
+#   ./builds/sqlite/build-local.sh --version 3.51.2
+#   ./builds/sqlite/build-local.sh --version 3.51.2 --platform linux-arm64
+#
+# This script builds SQLite for linux-arm64 (the only platform requiring source build).
+# Other platforms have official binaries available via download.ts.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VERSION="3.51.2"
+PLATFORM="linux-arm64"
+
+show_help() {
+    cat << EOF
+Usage: $0 [options]
+
+Build SQLite from source using Docker.
+
+Options:
+    --version VERSION    SQLite version (default: $VERSION)
+    --platform PLATFORM  Target platform (default: $PLATFORM)
+                         Only linux-arm64 is supported for source builds
+    --help               Show this help message
+
+Examples:
+    $0
+    $0 --version 3.51.2
+EOF
+    exit "${1:-0}"
+}
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --version)
+            VERSION="$2"
+            shift 2
+            ;;
+        --platform)
+            PLATFORM="$2"
+            shift 2
+            ;;
+        --help)
+            show_help 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            show_help 1
+            ;;
+    esac
+done
+
+# Validate platform
+if [[ "$PLATFORM" != "linux-arm64" ]]; then
+    echo "Error: Only linux-arm64 requires source build"
+    echo "Use 'pnpm download:sqlite' for other platforms"
+    exit 1
+fi
+
+# Validate version format
+if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Error: Invalid version format: $VERSION"
+    echo "Expected format: X.Y.Z (e.g., 3.51.2)"
+    exit 1
+fi
+
+echo "Building SQLite $VERSION for $PLATFORM"
+echo "========================================"
+
+# Create output directory
+OUTPUT_DIR="$SCRIPT_DIR/../../dist"
+mkdir -p "$OUTPUT_DIR"
+
+# Build Docker image
+echo "Building Docker image..."
+docker build \
+    --build-arg VERSION="$VERSION" \
+    --platform linux/arm64 \
+    -t sqlite-builder:$VERSION \
+    "$SCRIPT_DIR"
+
+# Run container to extract artifact
+echo "Extracting artifact..."
+docker run --rm \
+    --platform linux/arm64 \
+    -v "$OUTPUT_DIR:/dist" \
+    sqlite-builder:$VERSION
+
+echo ""
+echo "Build complete!"
+echo "Output: $OUTPUT_DIR/sqlite-$VERSION-$PLATFORM.tar.gz"

--- a/builds/sqlite/download.ts
+++ b/builds/sqlite/download.ts
@@ -1,0 +1,505 @@
+#!/usr/bin/env tsx
+/**
+ * Download official SQLite binaries for re-hosting
+ *
+ * Usage:
+ *   ./builds/sqlite/download.ts [options]
+ *   pnpm tsx builds/sqlite/download.ts [options]
+ *
+ * Options:
+ *   --version VERSION    SQLite version (default: 3.51.2)
+ *   --platform PLATFORM  Target platform (default: current platform)
+ *   --output DIR         Output directory (default: ./dist)
+ *   --all-platforms      Download for all platforms
+ *   --help               Show help
+ *
+ * Note: linux-arm64 requires source build (not implemented in this script)
+ */
+
+import {
+  createWriteStream,
+  createReadStream,
+  mkdirSync,
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  chmodSync,
+} from 'node:fs'
+import { createHash } from 'node:crypto'
+import { resolve, dirname, basename } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { execFileSync } from 'node:child_process'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+type Platform =
+  | 'linux-x64'
+  | 'linux-arm64'
+  | 'darwin-x64'
+  | 'darwin-arm64'
+  | 'win32-x64'
+
+const VALID_PLATFORMS: Platform[] = [
+  'linux-x64',
+  'linux-arm64',
+  'darwin-x64',
+  'darwin-arm64',
+  'win32-x64',
+]
+
+function isValidPlatform(value: string): value is Platform {
+  return VALID_PLATFORMS.includes(value as Platform)
+}
+
+// Validate version format (e.g., "3.51.2")
+const VERSION_REGEX = /^\d+\.\d+\.\d+$/
+
+function isValidVersion(value: string): boolean {
+  return VERSION_REGEX.test(value)
+}
+
+type SourceEntry = {
+  url?: string
+  format?: 'zip'
+  sha3_256?: string
+  sourceType?: 'build-required'
+  sourceUrl?: string
+}
+
+type Sources = {
+  database: string
+  versions: Record<string, Record<Platform, SourceEntry>>
+  notes: Record<string, string>
+}
+
+const colors = {
+  reset: '\x1b[0m',
+  red: '\x1b[31m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  blue: '\x1b[34m',
+  cyan: '\x1b[36m',
+}
+
+function log(color: keyof typeof colors, prefix: string, msg: string) {
+  console.log(`${colors[color]}[${prefix}]${colors.reset} ${msg}`)
+}
+
+function logInfo(msg: string) {
+  log('blue', 'INFO', msg)
+}
+function logSuccess(msg: string) {
+  log('green', 'OK', msg)
+}
+function logWarn(msg: string) {
+  log('yellow', 'WARN', msg)
+}
+function logError(msg: string) {
+  log('red', 'ERROR', msg)
+}
+
+function detectPlatform(): Platform {
+  const platform = process.platform
+  const arch = process.arch
+
+  if (platform === 'linux' && arch === 'x64') return 'linux-x64'
+  if (platform === 'linux' && arch === 'arm64') return 'linux-arm64'
+  if (platform === 'darwin' && arch === 'x64') return 'darwin-x64'
+  if (platform === 'darwin' && arch === 'arm64') return 'darwin-arm64'
+  if (platform === 'win32' && arch === 'x64') return 'win32-x64'
+
+  throw new Error(`Unsupported platform: ${platform}-${arch}`)
+}
+
+function loadSources(): Sources {
+  const sourcesPath = resolve(__dirname, 'sources.json')
+  const content = readFileSync(sourcesPath, 'utf-8')
+  try {
+    return JSON.parse(content) as Sources
+  } catch (error) {
+    throw new Error(`Failed to parse sources.json: invalid JSON`, {
+      cause: error,
+    })
+  }
+}
+
+async function downloadFile(
+  url: string,
+  destPath: string,
+  timeoutMs: number = 300000,
+): Promise<void> {
+  logInfo(`Downloading: ${url}`)
+
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
+
+  let response: Response
+  try {
+    response = await fetch(url, { redirect: 'follow', signal: controller.signal })
+  } catch (error) {
+    clearTimeout(timeoutId)
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error(`Download timed out after ${timeoutMs / 1000}s: ${url}`)
+    }
+    throw error
+  }
+
+  if (!response.ok) {
+    clearTimeout(timeoutId)
+    throw new Error(
+      `Download failed: ${response.status} ${response.statusText}`,
+    )
+  }
+
+  const contentLength = response.headers.get('content-length')
+  const totalBytes = contentLength ? parseInt(contentLength, 10) : 0
+
+  mkdirSync(dirname(destPath), { recursive: true })
+
+  const fileStream = createWriteStream(destPath)
+  const reader = response.body?.getReader()
+
+  if (!reader) {
+    clearTimeout(timeoutId)
+    throw new Error('No response body')
+  }
+
+  let downloadedBytes = 0
+  const startTime = Date.now()
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+
+      const canContinue = fileStream.write(value)
+      downloadedBytes += value.length
+
+      if (!canContinue) {
+        await new Promise<void>((resolve, reject) => {
+          const onDrain = () => {
+            fileStream.removeListener('error', onError)
+            resolve()
+          }
+          const onError = (err: Error) => {
+            fileStream.removeListener('drain', onDrain)
+            reject(err)
+          }
+          fileStream.once('drain', onDrain)
+          fileStream.once('error', onError)
+        })
+      }
+
+      if (totalBytes > 0) {
+        const percent = ((downloadedBytes / totalBytes) * 100).toFixed(1)
+        const mbDownloaded = (downloadedBytes / 1024 / 1024).toFixed(1)
+        const mbTotal = (totalBytes / 1024 / 1024).toFixed(1)
+        process.stdout.write(
+          `\r  ${mbDownloaded}MB / ${mbTotal}MB (${percent}%)    `,
+        )
+      } else {
+        const mbDownloaded = (downloadedBytes / 1024 / 1024).toFixed(1)
+        process.stdout.write(`\r  ${mbDownloaded}MB downloaded...    `)
+      }
+    }
+
+    await new Promise<void>((resolve, reject) => {
+      fileStream.end()
+      fileStream.on('finish', resolve)
+      fileStream.on('error', reject)
+    })
+  } finally {
+    clearTimeout(timeoutId)
+  }
+
+  console.log()
+
+  const duration = ((Date.now() - startTime) / 1000).toFixed(1)
+  logSuccess(
+    `Downloaded ${(downloadedBytes / 1024 / 1024).toFixed(1)}MB in ${duration}s`,
+  )
+}
+
+// Calculate SHA3-256 checksum (SQLite uses SHA3-256, not SHA-256)
+async function calculateSha3_256(filePath: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const hash = createHash('sha3-256')
+    const stream = createReadStream(filePath)
+
+    stream.on('data', (chunk) => hash.update(chunk))
+    stream.on('end', () => resolve(hash.digest('hex')))
+    stream.on('error', reject)
+  })
+}
+
+function verifyCommand(command: string): void {
+  const findCmd = process.platform === 'win32' ? 'where' : 'which'
+  try {
+    execFileSync(findCmd, [command], { stdio: 'pipe' })
+  } catch {
+    throw new Error(`Required command not found: ${command}`)
+  }
+}
+
+function repackage(
+  sourcePath: string,
+  outputPath: string,
+  version: string,
+  platform: Platform,
+): void {
+  // All SQLite downloads are zip format
+  verifyCommand('unzip')
+  if (platform.startsWith('win32')) {
+    verifyCommand('zip')
+  }
+
+  const tempDir = resolve(dirname(sourcePath), 'temp-extract')
+  rmSync(tempDir, { recursive: true, force: true })
+  mkdirSync(tempDir, { recursive: true })
+
+  logInfo('Extracting archive...')
+
+  // Extract zip
+  execFileSync('unzip', ['-q', sourcePath, '-d', tempDir], { stdio: 'inherit' })
+
+  // SQLite extracts files directly (no nested directory)
+  // Create sqlite directory and move files into it
+  const sqliteDir = resolve(tempDir, 'sqlite')
+  const binDir = resolve(sqliteDir, 'bin')
+  mkdirSync(binDir, { recursive: true })
+
+  // Move all executables to bin/
+  const files = readdirSync(tempDir)
+  for (const file of files) {
+    if (file === 'sqlite') continue // Skip our created directory
+    const srcPath = resolve(tempDir, file)
+    const destPath = resolve(binDir, file)
+    renameSync(srcPath, destPath)
+    // Make executable on Unix
+    if (!platform.startsWith('win32')) {
+      try {
+        chmodSync(destPath, 0o755)
+      } catch {
+        // Ignore chmod errors on Windows
+      }
+    }
+  }
+
+  // Add metadata file
+  const metadata = {
+    name: 'sqlite',
+    version,
+    platform,
+    source: 'official',
+    tools: ['sqlite3', 'sqldiff', 'sqlite3_analyzer', 'sqlite3_rsync'],
+    rehosted_by: 'hostdb',
+    rehosted_at: new Date().toISOString(),
+  }
+  writeFileSync(
+    resolve(sqliteDir, '.hostdb-metadata.json'),
+    JSON.stringify(metadata, null, 2),
+  )
+
+  // Create output archive
+  mkdirSync(dirname(outputPath), { recursive: true })
+
+  logInfo(`Creating: ${basename(outputPath)}`)
+
+  if (platform.startsWith('win32')) {
+    execFileSync('zip', ['-rq', outputPath, 'sqlite'], {
+      stdio: 'inherit',
+      cwd: tempDir,
+    })
+  } else {
+    execFileSync('tar', ['-czf', outputPath, '-C', tempDir, 'sqlite'], {
+      stdio: 'inherit',
+    })
+  }
+
+  // Cleanup temp
+  rmSync(tempDir, { recursive: true, force: true })
+
+  logSuccess(`Created: ${outputPath}`)
+}
+
+function parseArgs(): {
+  version: string
+  platforms: Platform[]
+  outputDir: string
+} {
+  const args = process.argv.slice(2)
+  let version = '3.51.2'
+  let platforms: Platform[] = []
+  let outputDir = './dist'
+  let allPlatforms = false
+
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case '--version': {
+        if (i + 1 >= args.length || args[i + 1].startsWith('-')) {
+          logError('--version requires a value')
+          process.exit(1)
+        }
+        const versionValue = args[++i]
+        if (!isValidVersion(versionValue)) {
+          logError(`Invalid version format: ${versionValue}`)
+          logError('Version must be in format: X.Y.Z (e.g., 3.51.2)')
+          process.exit(1)
+        }
+        version = versionValue
+        break
+      }
+      case '--platform': {
+        if (i + 1 >= args.length || args[i + 1].startsWith('-')) {
+          logError('--platform requires a value')
+          process.exit(1)
+        }
+        const platformValue = args[++i]
+        if (!isValidPlatform(platformValue)) {
+          logError(`Invalid platform: ${platformValue}`)
+          logError(`Valid platforms: ${VALID_PLATFORMS.join(', ')}`)
+          process.exit(1)
+        }
+        platforms.push(platformValue)
+        break
+      }
+      case '--output':
+        if (i + 1 >= args.length || args[i + 1].startsWith('-')) {
+          logError('--output requires a value')
+          process.exit(1)
+        }
+        outputDir = args[++i]
+        break
+      case '--all-platforms':
+        allPlatforms = true
+        break
+      case '--help':
+      case '-h':
+        console.log(`
+Usage: ./builds/sqlite/download.ts [options]
+
+Options:
+  --version VERSION    SQLite version (default: 3.51.2)
+  --platform PLATFORM  Target platform (default: current)
+  --output DIR         Output directory (default: ./dist)
+  --all-platforms      Download for all platforms
+  --help               Show this help
+
+Platforms: linux-x64, linux-arm64, darwin-x64, darwin-arm64, win32-x64
+
+Note: linux-arm64 requires source build (use Docker workflow)
+
+Examples:
+  ./builds/sqlite/download.ts
+  ./builds/sqlite/download.ts --version 3.51.2 --platform linux-x64
+  ./builds/sqlite/download.ts --all-platforms
+`)
+        process.exit(0)
+    }
+  }
+
+  if (allPlatforms) {
+    platforms = [...VALID_PLATFORMS]
+  } else if (platforms.length === 0) {
+    platforms = [detectPlatform()]
+  }
+
+  return { version, platforms, outputDir }
+}
+
+async function main() {
+  const { version, platforms, outputDir } = parseArgs()
+  const sources = loadSources()
+
+  console.log()
+  logInfo(`SQLite Download Script`)
+  logInfo(`Version: ${version}`)
+  logInfo(`Platforms: ${platforms.join(', ')}`)
+  logInfo(`Output: ${outputDir}`)
+  console.log()
+
+  const versionSources = sources.versions[version]
+  if (!versionSources) {
+    logError(`Version ${version} not found in sources.json`)
+    logInfo(`Available versions: ${Object.keys(sources.versions).join(', ')}`)
+    process.exit(1)
+  }
+
+  let successCount = 0
+  let skipCount = 0
+
+  for (const platform of platforms) {
+    console.log()
+    logInfo(`=== ${platform} ===`)
+
+    const source = versionSources[platform]
+    if (!source) {
+      logWarn(`No source for ${platform}, skipping`)
+      skipCount++
+      continue
+    }
+
+    // Check if build is required (linux-arm64)
+    if (source.sourceType === 'build-required') {
+      logWarn(`${platform} requires source build - skipping download`)
+      logInfo(`Use the Docker workflow to build for ${platform}`)
+      skipCount++
+      continue
+    }
+
+    if (!source.url) {
+      logWarn(`No download URL for ${platform}, skipping`)
+      skipCount++
+      continue
+    }
+
+    const ext = platform.startsWith('win32') ? 'zip' : 'tar.gz'
+    const downloadPath = resolve(
+      outputDir,
+      'downloads',
+      `sqlite-${version}-${platform}-original.zip`,
+    )
+    const outputPath = resolve(outputDir, `sqlite-${version}-${platform}.${ext}`)
+
+    // Download
+    if (existsSync(downloadPath)) {
+      logInfo(`Using cached download: ${basename(downloadPath)}`)
+    } else {
+      await downloadFile(source.url, downloadPath)
+    }
+
+    // Verify checksum (SHA3-256)
+    const actualSha3 = await calculateSha3_256(downloadPath)
+    logInfo(`SHA3-256: ${actualSha3}`)
+
+    if (source.sha3_256) {
+      if (actualSha3 === source.sha3_256) {
+        logSuccess('Checksum verified')
+      } else {
+        logError(`Checksum mismatch!`)
+        logError(`Expected: ${source.sha3_256}`)
+        logError(`Actual:   ${actualSha3}`)
+        process.exit(1)
+      }
+    } else {
+      logWarn('No checksum in sources.json - update it with the SHA3-256 above')
+    }
+
+    // Repackage
+    repackage(downloadPath, outputPath, version, platform)
+
+    successCount++
+  }
+
+  console.log()
+  logSuccess(`Done! ${successCount} downloaded, ${skipCount} skipped`)
+  logInfo(`Output files in: ${resolve(outputDir)}`)
+}
+
+main().catch((err) => {
+  logError(err.message)
+  process.exit(1)
+})

--- a/builds/sqlite/sources.json
+++ b/builds/sqlite/sources.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "../../schemas/sources.schema.json",
+  "database": "sqlite",
+  "versions": {
+    "3.51.2": {
+      "linux-x64": {
+        "url": "https://sqlite.org/2026/sqlite-tools-linux-x64-3510200.zip",
+        "format": "zip",
+        "sha3_256": "cd04740c391542745fec69f930714471e17d67dd454dc19fbdb6d1be61ec822e"
+      },
+      "linux-arm64": {
+        "sourceType": "build-required",
+        "sourceUrl": "https://sqlite.org/2026/sqlite-amalgamation-3510200.zip",
+        "sha3_256": "9a9dd4eef7a97809bfacd84a7db5080a5c0eff7aaf1fc1aca20a6dc9a0c26f96"
+      },
+      "darwin-x64": {
+        "url": "https://sqlite.org/2026/sqlite-tools-osx-x64-3510200.zip",
+        "format": "zip",
+        "sha3_256": "273a53d3779c5a18a2d20c838ba08bd1e1b93c086a5079424d5d5058a7dda120"
+      },
+      "darwin-arm64": {
+        "url": "https://sqlite.org/2026/sqlite-tools-osx-arm64-3510200.zip",
+        "format": "zip",
+        "sha3_256": "437d2ea93086ceb2c85b30544bb639a601d4f5ef786df50669721707cb423117"
+      },
+      "win32-x64": {
+        "url": "https://sqlite.org/2026/sqlite-tools-win-x64-3510200.zip",
+        "format": "zip",
+        "sha3_256": "376f112fd7534b13cb0aa6a0ac8de6613085d6415015de84fd0dfdfc9e92e5c3"
+      }
+    }
+  },
+  "notes": {
+    "license": "Public Domain - SQLite is released into the public domain with no restrictions on use",
+    "checksums": "SQLite uses SHA3-256 checksums (not SHA-256). The sha3_256 field contains these values.",
+    "linux-arm64": "No official prebuilt binary available; requires source build from amalgamation",
+    "tools": "The tools package includes sqlite3 (CLI), sqldiff, sqlite3_analyzer, and sqlite3_rsync",
+    "version-format": "SQLite version 3.51.2 = 3510200 in filenames (MAJOR*1000000 + MINOR*1000 + PATCH*100)"
+  }
+}

--- a/databases.json
+++ b/databases.json
@@ -803,7 +803,7 @@
       "note": "",
       "latestLts": "3.51",
       "versions": {
-        "3.51.1": true
+        "3.51.2": true
       },
       "platforms": {
         "linux-x64": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hostdb",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Pre-built database binaries for multiple platforms, distributed via GitHub Releases",
   "private": true,
   "type": "module",
@@ -19,6 +19,7 @@
     "download:mysql": "tsx builds/mysql/download.ts",
     "download:postgresql": "tsx builds/postgresql/download.ts",
     "download:redis": "tsx builds/redis/download.ts",
+    "download:sqlite": "tsx builds/sqlite/download.ts",
     "download:valkey": "tsx builds/valkey/download.ts",
     "edb:fileids": "tsx scripts/fetch-edb-fileids.ts",
     "format": "prettier --write .",

--- a/scripts/populate-checksums.ts
+++ b/scripts/populate-checksums.ts
@@ -67,6 +67,11 @@ type SourcesJson = {
   notes: Record<string, string>
 }
 
+// Databases that use non-SHA256 checksums (must be populated manually)
+const SKIP_DATABASES = new Set([
+  'sqlite', // Uses SHA3-256, checksums provided by vendor
+])
+
 
 const FETCH_TIMEOUT_MS = 10 * 60 * 1000 // 10 minutes for large files
 
@@ -139,6 +144,14 @@ ${colors.yellow}Examples:${colors.reset}
   const force = args.includes('--force')
   const verify = args.includes('--verify')
   const processAll = args.includes('--all')
+
+  // Check if database uses a different checksum algorithm
+  if (SKIP_DATABASES.has(database)) {
+    logError(`${database} uses a non-SHA256 checksum algorithm.`)
+    logInfo(`Checksums must be copied manually from the vendor's download page.`)
+    logInfo(`See builds/${database}/sources.json for the correct field name (e.g., sha3_256).`)
+    process.exit(1)
+  }
 
   // Get enabled versions from databases.json
   const enabledVersions = getEnabledVersions(database)

--- a/scripts/prep.ts
+++ b/scripts/prep.ts
@@ -76,6 +76,7 @@ function runCommand(
 type SourceEntry = {
   url?: string
   sha256?: string | null
+  sha3_256?: string | null // SQLite uses SHA3-256
   sourceType?: string
 }
 
@@ -111,7 +112,9 @@ function findMissingChecksums(): Array<{ database: string; version: string; plat
 
         for (const [platform, entry] of Object.entries(platforms)) {
           // Only check entries with URLs (not build-required)
-          if (entry.url && (entry.sha256 === null || entry.sha256 === undefined)) {
+          // Accept either sha256 or sha3_256 (SQLite uses SHA3-256)
+          const hasChecksum = entry.sha256 || entry.sha3_256
+          if (entry.url && !hasChecksum) {
             missing.push({ database, version, platform })
           }
         }


### PR DESCRIPTION
- Add SQLite 3.51.2 (latest stable) to databases.json with all 5 platforms enabled
- Add release-sqlite.yml workflow with validation, build-arm64, build-download, release, and update-manifest jobs
- Add Dockerfile for building SQLite from amalgamation source for linux-arm64 (no official binary available)
- Add download-sqlite.ts script to download and repackage official binaries from sqlite.org
- Add sources