### PR TITLE
chore: ignore double-dash delimiter in SQLite download script argumen…

### DIFF
--- a/builds/sqlite/download.ts
+++ b/builds/sqlite/download.ts
@@ -399,6 +399,9 @@ Examples:
 `)
         process.exit(0)
         break // unreachable, but required for no-fallthrough rule
+      case '--':
+        // Ignore -- (end of options delimiter from pnpm)
+        break
       default:
         if (args[i].startsWith('-')) {
           logError(`Unknown option: ${args[i]}`)


### PR DESCRIPTION
…t parser

- Add case for '--' option to ignore end-of-options delimiter passed by pnpm
- Add comment explaining '--' is intentionally ignored as it's a delimiter, not an actual option