### PR TITLE
chore: fix SQLite release workflow condition and add VERSION environm…

### DIFF
--- a/.github/workflows/release-sqlite.yml
+++ b/.github/workflows/release-sqlite.yml
@@ -171,7 +171,7 @@ jobs:
 
   release:
     needs: [build-arm64, build-download]
-    if: always() && (needs.build-arm64.result == 'success' || needs.build-download.result == 'success')
+    if: always() && (needs.build-arm64.result == 'success' || needs.build-arm64.result == 'skipped') && (needs.build-download.result == 'success' || needs.build-download.result == 'skipped')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/builds/sqlite/Dockerfile
+++ b/builds/sqlite/Dockerfile
@@ -56,6 +56,7 @@ RUN make install
 # Create the final package structure
 WORKDIR /build/package
 ARG VERSION
+ENV VERSION=${VERSION}
 RUN mkdir -p sqlite/bin && \
     cp /build/output/bin/sqlite3 sqlite/bin/ && \
     chmod 755 sqlite/bin/sqlite3 && \


### PR DESCRIPTION
…ent variable to Dockerfile

- Change release job condition to require both build-arm64 and build-download to succeed or be skipped (was OR logic)
- Add ENV directive to persist VERSION build arg as environment variable in Dockerfile
- Ensures release only runs when both build jobs complete successfully or are intentionally skipped
- Prevents release from running if either build job fails