### PR TITLE
feat: add MySQL 9.5.0 Innovation release with macOS 15 Sequoia binaries

### DIFF
--- a/.github/workflows/release-mysql.yml
+++ b/.github/workflows/release-mysql.yml
@@ -8,9 +8,10 @@ on:
         required: true
         type: choice
         options:
+          - 9.5.0
           - 8.4.7
           - 8.0.40
-        default: 8.4.7
+        default: 9.5.0
       platforms:
         description: 'Platforms'
         required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.9.1] - 2026-01-11
+
+### Added
+
+- **MySQL 9.5.0** (Innovation release) - First MySQL 9.x version
+  - Official binaries from Oracle CDN for all 5 platforms
+  - Uses `macos15` (Sequoia) binaries instead of `macos14` (Sonoma)
+  - Note: MySQL 9.x is an Innovation release with shorter support window (~3-6 months)
+  - LTS users should continue using 8.4.x
+
 ## [0.9.0] - 2026-01-10
 
 ### Added

--- a/builds/mysql/sources.json
+++ b/builds/mysql/sources.json
@@ -2,31 +2,31 @@
   "$schema": "../../schemas/sources.schema.json",
   "database": "mysql",
   "versions": {
-    "9.1.0": {
+    "9.5.0": {
       "linux-x64": {
-        "url": "https://cdn.mysql.com/archives/mysql-9.1/mysql-9.1.0-linux-glibc2.28-x86_64.tar.xz",
+        "url": "https://cdn.mysql.com/Downloads/MySQL-9.5/mysql-9.5.0-linux-glibc2.28-x86_64.tar.xz",
         "format": "tar.xz",
-        "sha256": "6f059725574a60e8d742f22f943b28a05fbbc36e2a3341535e85713f74e2015b"
+        "sha256": "c2aa65cd87f6ed685bf78d88dabca11e888999d0bed23dfbaf7de0f008b1fa9e"
       },
       "linux-arm64": {
-        "url": "https://cdn.mysql.com/archives/mysql-9.1/mysql-9.1.0-linux-glibc2.28-aarch64.tar.xz",
+        "url": "https://cdn.mysql.com/Downloads/MySQL-9.5/mysql-9.5.0-linux-glibc2.28-aarch64.tar.xz",
         "format": "tar.xz",
-        "sha256": null
+        "sha256": "ce20c0e78bccb697b79c18d78f5d35fd4c98c8e7e07b4573be61122b4e145a6d"
       },
       "darwin-x64": {
-        "url": "https://cdn.mysql.com/archives/mysql-9.1/mysql-9.1.0-macos14-x86_64.tar.gz",
+        "url": "https://cdn.mysql.com/Downloads/MySQL-9.5/mysql-9.5.0-macos15-x86_64.tar.gz",
         "format": "tar.gz",
-        "sha256": "5116fd0178ebbd15ae379a803a798820f296b837a33fcf2e3f6c2da9071f6415"
+        "sha256": "c67db65a22311c1b1fc5972c3edd1dfcd60e87e5c7be1cc88606ab7dcd5cfaf3"
       },
       "darwin-arm64": {
-        "url": "https://cdn.mysql.com/archives/mysql-9.1/mysql-9.1.0-macos14-arm64.tar.gz",
+        "url": "https://cdn.mysql.com/Downloads/MySQL-9.5/mysql-9.5.0-macos15-arm64.tar.gz",
         "format": "tar.gz",
-        "sha256": "ecf95d05977dae03626e54d44a9139ac2cd5259e2e7e55c6f1cff002a6de15f2"
+        "sha256": "077a1c8441629564dc11f149b89358befb2664d79b313876bf46715972ad6ca2"
       },
       "win32-x64": {
-        "url": "https://cdn.mysql.com/archives/mysql-9.1/mysql-9.1.0-winx64.zip",
+        "url": "https://cdn.mysql.com/Downloads/MySQL-9.5/mysql-9.5.0-winx64.zip",
         "format": "zip",
-        "sha256": "0c00b1b37b8ea8f58a095208bf34b568cba37e72f2ecedaa663d1f34bbcc406b"
+        "sha256": "c45a838c5960f9e533b88a48c71779dd5a74d96d1e2473a54d8c97b636baa438"
       }
     },
     "8.4.3": {

--- a/databases.json
+++ b/databases.json
@@ -536,6 +536,7 @@
       "note": "",
       "latestLts": "8.4",
       "versions": {
+        "9.5.0": true,
         "8.4.7": true,
         "8.0.40": true
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hostdb",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Pre-built database binaries for multiple platforms, distributed via GitHub Releases",
   "private": true,
   "type": "module",


### PR DESCRIPTION
- Add MySQL 9.5.0 to databases.json and release workflow (new default version)
- Update sources.json with official binaries from Oracle CDN for all 5 platforms
- Switch macOS binaries from macos14 (Sonoma) to macos15 (Sequoia) builds
- Update version to 0.9.1 in package.json
- Add CHANGELOG entry noting MySQL 9.x is Innovation release with shorter support window (~3-6 months)
- LTS users should continue using 8.4.x series