### PR TITLE
chore: change MySQL release workflow default version from 9.5.0 to 8.…

### DIFF
--- a/.github/workflows/release-mysql.yml
+++ b/.github/workflows/release-mysql.yml
@@ -11,7 +11,7 @@ on:
           - 9.5.0
           - 8.4.7
           - 8.0.40
-        default: 9.5.0
+        default: 8.4.7
       platforms:
         description: 'Platforms'
         required: true

--- a/builds/mysql/sources.json
+++ b/builds/mysql/sources.json
@@ -86,7 +86,7 @@
   },
   "notes": {
     "glibc": "Linux binaries require glibc 2.28+ (Ubuntu 20.04+, Debian 10+, RHEL 8+)",
-    "macos": "macOS binaries target macOS 14 (Sonoma) but may work on earlier versions",
+    "macos": "macOS binaries target macos14 (Sonoma) for 8.x versions; MySQL 9.5.0+ targets macos15 (Sequoia). Binaries may work on earlier macOS versions.",
     "cdn": "Use cdn.mysql.com/archives/ for direct downloads (dev.mysql.com redirects require auth)"
   }
 }


### PR DESCRIPTION
…4.7 LTS and clarify macOS binary compatibility notes

- Change default version in release-mysql.yml from 9.5.0 (Innovation) to 8.4.7 (LTS)
- Update sources.json macOS note to specify macos14 target for 8.x versions and macos15 for 9.5.0+
- Clarify that binaries may work on earlier macOS versions than their target platform