### PR TITLE
chore: fix SQLite version encoding formula and improve metadata generation

### DIFF
--- a/.github/workflows/release-sqlite.yml
+++ b/.github/workflows/release-sqlite.yml
@@ -211,7 +211,6 @@ jobs:
         with:
           name: sqlite-linux-x64-${{ github.event.inputs.version }}
           path: ./release-assets
-        continue-on-error: true
 
       - name: Download linux-arm64 artifacts
         if: needs.build-linux.result == 'success' && (github.event.inputs.platforms == 'all' || github.event.inputs.platforms == 'linux-arm64')
@@ -219,7 +218,6 @@ jobs:
         with:
           name: sqlite-linux-arm64-${{ github.event.inputs.version }}
           path: ./release-assets
-        continue-on-error: true
 
       - name: Download non-Linux artifacts
         if: needs.build-download.result == 'success'

--- a/builds/sqlite/Dockerfile
+++ b/builds/sqlite/Dockerfile
@@ -74,8 +74,18 @@ RUN . /tmp/platform_env && \
     mkdir -p sqlite/bin && \
     cp /build/output/bin/sqlite3 sqlite/bin/ && \
     chmod 755 sqlite/bin/sqlite3 && \
-    # Add metadata \
-    echo "{\n  \"name\": \"sqlite\",\n  \"version\": \"${VERSION}\",\n  \"platform\": \"${PLATFORM}\",\n  \"source\": \"source-build\",\n  \"tools\": [\"sqlite3\"],\n  \"rehosted_by\": \"hostdb\",\n  \"rehosted_at\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"\n}" > sqlite/.hostdb-metadata.json
+    # Add metadata
+    cat <<EOF > sqlite/.hostdb-metadata.json
+{
+  "name": "sqlite",
+  "version": "${VERSION}",
+  "platform": "${PLATFORM}",
+  "source": "source-build",
+  "tools": ["sqlite3"],
+  "rehosted_by": "hostdb",
+  "rehosted_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+EOF
 
 # Create tarball with architecture-specific name
 RUN . /tmp/platform_env && \

--- a/builds/sqlite/README.md
+++ b/builds/sqlite/README.md
@@ -94,7 +94,7 @@ SQLite is in the **public domain**. No restrictions on use, modification, or dis
 
 - SQLite is an embedded database - no server process required
 - The CLI tools are statically linked and self-contained
-- Version numbering in filenames: 3.51.2 → 3510200 (MAJOR×1000000 + MINOR×1000 + PATCH×100)
+- Version numbering in filenames: 3.51.2 → 3510200 (MAJOR×1000000 + MINOR×10000 + PATCH×100)
 
 ## Known Limitations
 

--- a/builds/sqlite/sources.json
+++ b/builds/sqlite/sources.json
@@ -36,6 +36,6 @@
     "checksums": "SQLite uses SHA3-256 checksums (not SHA-256). The sha3_256 field contains these values.",
     "linux-builds": "Both linux-x64 and linux-arm64 are built from source on Ubuntu 20.04 for GLIBC 2.31 compatibility. Official binaries require GLIBC 2.38+ which breaks Ubuntu 22.04 and older.",
     "tools": "The tools package includes sqlite3 (CLI), sqldiff, sqlite3_analyzer, and sqlite3_rsync",
-    "version-format": "SQLite version 3.51.2 = 3510200 in filenames (MAJOR*1000000 + MINOR*1000 + PATCH*100)"
+    "version-format": "SQLite version 3.51.2 = 3510200 in filenames (MAJOR*1000000 + MINOR*10000 + PATCH*100)"
   }
 }

--- a/schemas/sources.schema.json
+++ b/schemas/sources.schema.json
@@ -63,6 +63,11 @@
               "pattern": "^[a-fA-F0-9]{64}$",
               "description": "SHA256 checksum (null if not yet verified)"
             },
+            "sha3_256": {
+              "type": "string",
+              "pattern": "^[a-fA-F0-9]{64}$",
+              "description": "SHA3-256 checksum (used by SQLite instead of SHA256)"
+            },
             "sourceType": {
               "type": "string",
               "enum": ["official", "mariadb4j"],
@@ -80,6 +85,25 @@
               "type": "string",
               "enum": ["build-required"],
               "description": "No binary available, must build from source"
+            },
+            "sourceUrl": {
+              "type": "string",
+              "format": "uri",
+              "description": "URL to download source code for building"
+            },
+            "sha3_256": {
+              "type": "string",
+              "pattern": "^[a-fA-F0-9]{64}$",
+              "description": "SHA3-256 checksum of source archive (used by SQLite)"
+            },
+            "sha256": {
+              "type": ["string", "null"],
+              "pattern": "^[a-fA-F0-9]{64}$",
+              "description": "SHA256 checksum of source archive"
+            },
+            "note": {
+              "type": "string",
+              "description": "Explanation for why source build is required"
             }
           },
           "additionalProperties": false


### PR DESCRIPTION
- Correct version formula in README and sources.json from MINOR×1000 to MINOR×10000 (3.51.2 → 3510200)
- Replace echo with heredoc for cleaner JSON metadata generation in Dockerfile
- Add sha3_256 field to sources.schema.json for SQLite's SHA3-256 checksums
- Add sourceUrl, note, and checksum fields to schema for source build entries
- Remove continue-on-error from Linux artifact downloads in release workflow