### PR TITLE
feat: add ClickHouse release workflow with official binaries and expe…

### DIFF
--- a/.github/workflows/release-clickhouse.yml
+++ b/.github/workflows/release-clickhouse.yml
@@ -1,0 +1,523 @@
+name: Release ClickHouse
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'ClickHouse version'
+        required: true
+        type: choice
+        options:
+          - 25.12.3.21
+        default: 25.12.3.21
+      platforms:
+        description: 'Platforms to build'
+        required: true
+        default: 'all'
+        type: choice
+        options:
+          - 'all'
+          - 'linux-x64'
+          - 'linux-arm64'
+          - 'darwin-x64'
+          - 'darwin-arm64'
+          - 'win32-x64'
+
+# Prevent concurrent runs that could conflict when updating releases.json
+concurrency:
+  group: release-clickhouse
+  cancel-in-progress: false
+
+jobs:
+  # Validate version against databases.json
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate version against databases.json
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          DB="clickhouse"
+
+          echo "Validating ClickHouse version: $VERSION"
+
+          # Check if version exists and is enabled in databases.json
+          ENABLED=$(jq -r ".databases.$DB.versions[\"$VERSION\"] // false" databases.json)
+          if [ "$ENABLED" != "true" ]; then
+            echo "::error::Version '$VERSION' is not enabled in databases.json"
+            echo ""
+            echo "Available versions:"
+            jq -r ".databases.$DB.versions | to_entries | map(select(.value == true)) | .[].key" databases.json
+            exit 1
+          fi
+
+          echo "✓ Version $VERSION is enabled in databases.json"
+
+      - name: Validate sources.json exists
+        run: |
+          DB="clickhouse"
+          if [ ! -f "builds/$DB/sources.json" ]; then
+            echo "::error::Missing builds/$DB/sources.json"
+            exit 1
+          fi
+          echo "✓ builds/$DB/sources.json exists"
+
+      - name: Validate version in sources.json
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          DB="clickhouse"
+
+          HAS_VERSION=$(jq -r ".versions[\"$VERSION\"] // empty" "builds/$DB/sources.json")
+          if [ -z "$HAS_VERSION" ]; then
+            echo "::error::Version '$VERSION' not found in builds/$DB/sources.json"
+            echo ""
+            echo "Available versions in sources.json:"
+            jq -r ".versions | keys[]" "builds/$DB/sources.json"
+            exit 1
+          fi
+
+          echo "✓ Version $VERSION found in sources.json"
+
+  # Determine which platforms to build based on input
+  prepare:
+    needs: validate
+    runs-on: ubuntu-latest
+    outputs:
+      download-matrix: ${{ steps.set-matrix.outputs.download-matrix }}
+      build-matrix: ${{ steps.set-matrix.outputs.build-matrix }}
+      has-downloads: ${{ steps.set-matrix.outputs.has-downloads }}
+      has-builds: ${{ steps.set-matrix.outputs.has-builds }}
+    steps:
+      - name: Set build matrix
+        id: set-matrix
+        run: |
+          PLATFORMS="${{ github.event.inputs.platforms }}"
+
+          # Download platforms (Linux + macOS - have official binaries)
+          DOWNLOAD_PLATFORMS='["linux-x64", "linux-arm64", "darwin-x64", "darwin-arm64"]'
+
+          # Build platforms (Windows - requires source build)
+          BUILD_PLATFORMS='["win32-x64"]'
+
+          if [ "$PLATFORMS" = "all" ]; then
+            # All platforms
+            DOWNLOAD_MATRIX='[
+              {"platform": "linux-x64", "runner": "ubuntu-latest"},
+              {"platform": "linux-arm64", "runner": "ubuntu-latest"},
+              {"platform": "darwin-x64", "runner": "macos-15-intel"},
+              {"platform": "darwin-arm64", "runner": "macos-14"}
+            ]'
+            BUILD_MATRIX='[
+              {"platform": "win32-x64", "runner": "windows-latest"}
+            ]'
+            HAS_DOWNLOADS="true"
+            HAS_BUILDS="true"
+          elif echo "$DOWNLOAD_PLATFORMS" | jq -e "index(\"$PLATFORMS\")" > /dev/null; then
+            # Single download platform
+            case "$PLATFORMS" in
+              linux-x64|linux-arm64)
+                DOWNLOAD_MATRIX="[{\"platform\": \"$PLATFORMS\", \"runner\": \"ubuntu-latest\"}]"
+                ;;
+              darwin-x64)
+                DOWNLOAD_MATRIX="[{\"platform\": \"$PLATFORMS\", \"runner\": \"macos-15-intel\"}]"
+                ;;
+              darwin-arm64)
+                DOWNLOAD_MATRIX="[{\"platform\": \"$PLATFORMS\", \"runner\": \"macos-14\"}]"
+                ;;
+            esac
+            BUILD_MATRIX='[]'
+            HAS_DOWNLOADS="true"
+            HAS_BUILDS="false"
+          elif echo "$BUILD_PLATFORMS" | jq -e "index(\"$PLATFORMS\")" > /dev/null; then
+            # Single build platform
+            DOWNLOAD_MATRIX='[]'
+            BUILD_MATRIX="[{\"platform\": \"$PLATFORMS\", \"runner\": \"windows-latest\"}]"
+            HAS_DOWNLOADS="false"
+            HAS_BUILDS="true"
+          else
+            echo "::error::Unknown platform: $PLATFORMS"
+            exit 1
+          fi
+
+          # Compact the JSON for output
+          DOWNLOAD_MATRIX=$(echo "$DOWNLOAD_MATRIX" | jq -c .)
+          BUILD_MATRIX=$(echo "$BUILD_MATRIX" | jq -c .)
+
+          echo "download-matrix=$DOWNLOAD_MATRIX" >> $GITHUB_OUTPUT
+          echo "build-matrix=$BUILD_MATRIX" >> $GITHUB_OUTPUT
+          echo "has-downloads=$HAS_DOWNLOADS" >> $GITHUB_OUTPUT
+          echo "has-builds=$HAS_BUILDS" >> $GITHUB_OUTPUT
+
+          echo "Download platforms: $DOWNLOAD_MATRIX"
+          echo "Build platforms: $BUILD_MATRIX"
+
+  # Download and repackage official binaries (Linux + macOS)
+  build-download:
+    needs: prepare
+    if: needs.prepare.outputs.has-downloads == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.prepare.outputs.download-matrix) }}
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download and repackage binary
+        id: download
+        timeout-minutes: 30
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          PLATFORM="${{ matrix.platform }}"
+
+          echo "Downloading ClickHouse $VERSION for $PLATFORM"
+
+          pnpm download:clickhouse -- \
+            --version "$VERSION" \
+            --platform "$PLATFORM" \
+            --output ./dist
+
+          # Check if artifact was created
+          shopt -s nullglob
+          FILES=(./dist/clickhouse-*.tar.gz)
+          if [ ${#FILES[@]} -eq 0 ]; then
+            echo "::error::No artifact created for $PLATFORM"
+            exit 1
+          fi
+          ls -la ./dist/
+
+      - name: Generate checksum
+        shell: bash
+        run: |
+          cd dist
+          shopt -s nullglob
+          for f in *.tar.gz *.zip; do
+            if [ -f "$f" ]; then
+              if command -v sha256sum &> /dev/null; then
+                sha256sum "$f" >> checksums.txt
+              else
+                # macOS uses shasum
+                shasum -a 256 "$f" >> checksums.txt
+              fi
+            fi
+          done
+          cat checksums.txt
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: clickhouse-${{ github.event.inputs.version }}-${{ matrix.platform }}
+          path: |
+            dist/*.tar.gz
+            dist/checksums.txt
+          retention-days: 1
+
+  # Build from source (Windows - EXPERIMENTAL)
+  build-source:
+    needs: prepare
+    if: needs.prepare.outputs.has-builds == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.prepare.outputs.build-matrix) }}
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Setup Cygwin for Windows builds (provides POSIX compatibility layer)
+      - name: Setup Cygwin
+        uses: cygwin/cygwin-install-action@master
+        with:
+          packages: >-
+            clang
+            llvm
+            cmake
+            ninja
+            git
+            curl
+            pkg-config
+            libssl-devel
+            zip
+            python3
+
+      # EXPERIMENTAL: Build ClickHouse for Windows using Cygwin
+      # This has never been done before and may fail!
+      - name: Build ClickHouse (Cygwin - EXPERIMENTAL)
+        id: build-windows
+        timeout-minutes: 360
+        shell: C:\cygwin\bin\bash.exe --login -eo pipefail -o igncr '{0}'
+        env:
+          CYGWIN: winsymlinks:native
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          PLATFORM="win32-x64"
+
+          echo "=========================================="
+          echo "EXPERIMENTAL: Building ClickHouse $VERSION for Windows (Cygwin)"
+          echo "This build is experimental and may fail!"
+          echo "=========================================="
+
+          cd "$(cygpath "$GITHUB_WORKSPACE")"
+
+          # Check Clang version
+          echo "Clang version:"
+          clang --version
+
+          # Clone ClickHouse source (shallow for speed)
+          echo "Cloning ClickHouse source..."
+          git clone --depth 1 --branch "v${VERSION}-stable" \
+            --recurse-submodules --shallow-submodules \
+            https://github.com/ClickHouse/ClickHouse.git
+
+          cd ClickHouse
+
+          # Configure with CMake
+          echo "Configuring with CMake..."
+          mkdir -p build && cd build
+
+          cmake .. \
+            -DCMAKE_C_COMPILER=clang \
+            -DCMAKE_CXX_COMPILER=clang++ \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DENABLE_TESTS=OFF \
+            -DENABLE_UTILS=OFF \
+            -GNinja || {
+              echo "::warning::CMake configuration failed. This is expected for experimental Windows builds."
+              echo "::warning::ClickHouse does not officially support Windows."
+              exit 1
+            }
+
+          # Build (this may fail with platform-specific errors)
+          echo "Building ClickHouse..."
+          ninja clickhouse || {
+            echo "::warning::Build failed. This is expected for experimental Windows builds."
+            echo "::warning::ClickHouse does not officially support Windows."
+            exit 1
+          }
+
+          # If we get here, the build succeeded! Package it.
+          echo "Build succeeded! Packaging..."
+
+          cd "$GITHUB_WORKSPACE"
+          mkdir -p install/clickhouse/bin
+
+          # Copy binary
+          cp ClickHouse/build/programs/clickhouse install/clickhouse/bin/
+
+          # Add metadata
+          printf '%s\n' \
+            '{' \
+            '  "name": "clickhouse",' \
+            "  \"version\": \"${VERSION}\"," \
+            "  \"platform\": \"${PLATFORM}\"," \
+            '  "source": "source-build",' \
+            '  "sourceUrl": "https://github.com/ClickHouse/ClickHouse",' \
+            '  "rehosted_by": "hostdb",' \
+            "  \"rehosted_at\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"," \
+            '  "note": "Experimental Cygwin build - may have limited functionality"' \
+            '}' > install/clickhouse/.hostdb-metadata.json
+
+          # Create zip (Windows convention)
+          mkdir -p dist
+          cd install
+          zip -r "../dist/clickhouse-${VERSION}-${PLATFORM}.zip" clickhouse
+
+          echo "Build complete:"
+          ls -la ../dist/
+
+      - name: Generate checksum (Windows)
+        if: steps.build-windows.outcome == 'success'
+        shell: C:\cygwin\bin\bash.exe --login -eo pipefail -o igncr '{0}'
+        run: |
+          cd "$(cygpath "$GITHUB_WORKSPACE")/dist"
+          for f in *.tar.gz *.zip; do
+            if [ -f "$f" ]; then
+              sha256sum "$f" >> checksums.txt
+            fi
+          done
+          cat checksums.txt
+
+      - name: Upload artifact
+        if: steps.build-windows.outcome == 'success'
+        uses: actions/upload-artifact@v4
+        with:
+          name: clickhouse-${{ github.event.inputs.version }}-${{ matrix.platform }}
+          path: |
+            dist/*.tar.gz
+            dist/*.zip
+            dist/checksums.txt
+          retention-days: 1
+
+  # Collect all artifacts and create release
+  release:
+    needs: [build-download, build-source]
+    if: always() && (needs.build-download.result == 'success' || needs.build-download.result == 'skipped') && (needs.build-source.result == 'success' || needs.build-source.result == 'skipped' || needs.build-source.result == 'failure')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check if any artifacts exist
+        id: check-artifacts
+        run: |
+          # We'll check after downloading
+          echo "Checking for artifacts..."
+
+      - name: Download download-job artifacts
+        if: needs.build-download.result == 'success'
+        uses: actions/download-artifact@v4
+        with:
+          path: ./artifacts
+          pattern: clickhouse-${{ github.event.inputs.version }}-*
+
+      - name: Prepare release assets
+        id: prepare
+        run: |
+          mkdir -p ./release-assets
+
+          # Move all artifacts to release-assets, flattening the directory structure
+          if [ -d ./artifacts ]; then
+            find ./artifacts -type f \( -name "*.tar.gz" -o -name "*.zip" \) -exec mv {} ./release-assets/ \; 2>/dev/null || true
+
+            # Combine all checksums
+            find ./artifacts -name "checksums.txt" -exec cat {} \; > ./release-assets/checksums.txt 2>/dev/null || true
+          fi
+
+          echo "Release assets:"
+          ls -la ./release-assets/ || echo "No release assets found"
+
+          # Check if we have at least one artifact
+          shopt -s nullglob
+          FILES=(./release-assets/*.tar.gz ./release-assets/*.zip)
+          if [ ${#FILES[@]} -eq 0 ]; then
+            echo "::error::No artifacts were created for any platform"
+            echo "has-artifacts=false" >> $GITHUB_OUTPUT
+            exit 1
+          fi
+
+          echo "has-artifacts=true" >> $GITHUB_OUTPUT
+
+          echo ""
+          echo "Checksums:"
+          cat ./release-assets/checksums.txt || echo "No checksums"
+
+      - name: Create Release
+        if: steps.prepare.outputs.has-artifacts == 'true'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: clickhouse-${{ github.event.inputs.version }}
+          name: ClickHouse ${{ github.event.inputs.version }}
+          body: |
+            ## ClickHouse ${{ github.event.inputs.version }}
+
+            ClickHouse binaries for hostdb.
+
+            ClickHouse is a column-oriented database for real-time analytics and big data processing.
+
+            ### Available Platforms
+            | Platform | Source |
+            |----------|--------|
+            | `linux-x64` | Official binary (GitHub releases) |
+            | `linux-arm64` | Official binary (GitHub releases) |
+            | `darwin-x64` | Official binary (GitHub releases) |
+            | `darwin-arm64` | Official binary (GitHub releases) |
+            | `win32-x64` | **EXPERIMENTAL** Source build (Cygwin) |
+
+            **Note:** Windows builds are experimental. ClickHouse does not officially support Windows. For production Windows use, consider WSL.
+
+            ### Usage
+            ```bash
+            # Download URL pattern
+            https://github.com/${{ github.repository }}/releases/download/clickhouse-${{ github.event.inputs.version }}/clickhouse-${{ github.event.inputs.version }}-<platform>.tar.gz
+            ```
+
+            ### Checksums
+            See `checksums.txt` for SHA256 checksums.
+
+            ### License
+            ClickHouse is licensed under Apache-2.0.
+
+            ### Sources
+            - **Official**: [github.com/ClickHouse/ClickHouse](https://github.com/ClickHouse/ClickHouse)
+          files: |
+            release-assets/*.tar.gz
+            release-assets/*.zip
+            release-assets/checksums.txt
+          fail_on_unmatched_files: false
+
+  # Update the releases manifest
+  update-manifest:
+    needs: release
+    if: needs.release.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Update releases.json
+        run: |
+          pnpm tsx scripts/update-releases.ts \
+            --database clickhouse \
+            --version "${{ github.event.inputs.version }}" \
+            --tag "clickhouse-${{ github.event.inputs.version }}"
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add releases.json
+          git diff --staged --quiet && echo "No changes to commit" && exit 0
+
+          git commit -m "chore: update releases.json for clickhouse-${{ github.event.inputs.version }}"
+
+          # Retry push with rebase if remote has changed
+          for i in 1 2 3; do
+            if git push; then
+              echo "Push succeeded"
+              exit 0
+            fi
+            echo "Push failed, attempting rebase (attempt $i/3)..."
+            git fetch origin main
+            if ! git rebase origin/main; then
+              echo "ERROR: Rebase failed due to conflicts. Manual intervention required."
+              git rebase --abort
+              exit 1
+            fi
+            sleep $((2**i))
+          done
+          echo "ERROR: Push failed after 3 attempts"
+          exit 1

--- a/builds/clickhouse/README.md
+++ b/builds/clickhouse/README.md
@@ -1,0 +1,106 @@
+# ClickHouse Build
+
+ClickHouse binaries for all 5 platforms.
+
+ClickHouse is a column-oriented database for real-time analytics and big data processing.
+
+## Sources
+
+| Platform | Source | Notes |
+|----------|--------|-------|
+| `linux-x64` | Official binary | GitHub releases (clickhouse-common-static tarball) |
+| `linux-arm64` | Official binary | GitHub releases (clickhouse-common-static tarball) |
+| `darwin-x64` | Official binary | GitHub releases (single executable) |
+| `darwin-arm64` | Official binary | GitHub releases (single executable) |
+| `win32-x64` | Source build | **EXPERIMENTAL** - Cygwin on windows-latest |
+
+**Note:** ClickHouse does not officially support Windows. Our Windows builds use Cygwin for POSIX compatibility and are experimental. These builds may fail or have limited functionality. For production Windows use, consider WSL.
+
+## Building
+
+### Download Linux/macOS binaries
+
+```bash
+# Download for current platform
+pnpm download:clickhouse -- --version 25.12.3.21
+
+# Download for specific platform
+pnpm download:clickhouse -- --version 25.12.3.21 --platform linux-x64
+
+# Download for all platforms (skips Windows)
+pnpm download:clickhouse -- --version 25.12.3.21 --all-platforms
+```
+
+### Windows build
+
+Windows builds are handled by the GitHub Actions workflow using Cygwin. They cannot be built locally with this script.
+
+## Versions
+
+Currently configured versions (from `databases.json`):
+
+- 25.12.3.21 (latest stable)
+
+## Binary Structure
+
+ClickHouse uses a single monolithic binary with subcommands:
+
+```
+clickhouse/
+├── bin/
+│   ├── clickhouse              # Main binary (~130-200MB)
+│   ├── clickhouse-server       # Symlink to clickhouse
+│   ├── clickhouse-client       # Symlink to clickhouse
+│   ├── clickhouse-local        # Symlink to clickhouse
+│   ├── clickhouse-benchmark    # Symlink to clickhouse
+│   ├── clickhouse-compressor   # Symlink to clickhouse
+│   ├── clickhouse-format       # Symlink to clickhouse
+│   └── clickhouse-obfuscator   # Symlink to clickhouse
+└── .hostdb-metadata.json
+```
+
+### Usage Modes
+
+The single `clickhouse` binary supports multiple modes via subcommands or symlinks:
+
+```bash
+# Start server
+./clickhouse server
+# or via symlink:
+./clickhouse-server
+
+# Connect as client
+./clickhouse client
+# or via symlink:
+./clickhouse-client
+
+# Run queries locally without server
+./clickhouse local
+# or via symlink:
+./clickhouse-local
+```
+
+## Build Notes
+
+### Linux
+
+Official tarballs from GitHub releases contain the binary at `usr/bin/clickhouse`. We extract and repackage into our standard `clickhouse/bin/` structure.
+
+### macOS
+
+GitHub releases provide single executable files (not tarballs). We wrap these in tar.gz archives with the standard directory structure and symlinks.
+
+### Windows (Experimental)
+
+No official Windows binaries exist. Our CI attempts to build ClickHouse using Cygwin's POSIX compatibility layer. This is highly experimental:
+
+- Cygwin provides Clang 20+ (meets ClickHouse's Clang 19+ requirement)
+- Build may fail due to Linux-specific code (epoll, io_uring, etc.)
+- Build time may exceed GitHub Actions limits (~6 hours)
+- Resulting binary requires Cygwin DLLs at runtime
+
+If the Windows build consistently fails, we may mark `win32-x64: false` and recommend WSL instead.
+
+## License
+
+ClickHouse is licensed under Apache-2.0, making it fully permissive for commercial use.

--- a/builds/clickhouse/download.ts
+++ b/builds/clickhouse/download.ts
@@ -1,0 +1,619 @@
+#!/usr/bin/env tsx
+/**
+ * Download official ClickHouse binaries for re-hosting
+ *
+ * ClickHouse uses a single binary with subcommands:
+ *   - clickhouse server  (or clickhouse-server symlink)
+ *   - clickhouse client  (or clickhouse-client symlink)
+ *   - clickhouse local   (or clickhouse-local symlink)
+ *
+ * Sources:
+ *   - Linux: clickhouse-common-static tarball from GitHub releases
+ *   - macOS: Single binary executable from GitHub releases
+ *   - Windows: build-required (no official binaries)
+ *
+ * Usage:
+ *   ./builds/clickhouse/download.ts [options]
+ *   pnpm tsx builds/clickhouse/download.ts [options]
+ *
+ * Options:
+ *   --version VERSION    ClickHouse version (default: 25.12.3.21)
+ *   --platform PLATFORM  Target platform (default: current platform)
+ *   --output DIR         Output directory (default: ./dist)
+ *   --all-platforms      Download for all platforms (skips build-required)
+ *   --help               Show help
+ */
+
+import {
+  createWriteStream,
+  createReadStream,
+  mkdirSync,
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  readdirSync,
+  rmSync,
+  chmodSync,
+  symlinkSync,
+} from 'node:fs'
+import { createHash } from 'node:crypto'
+import { resolve, dirname, basename } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { execFileSync } from 'node:child_process'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+type Platform =
+  | 'linux-x64'
+  | 'linux-arm64'
+  | 'darwin-x64'
+  | 'darwin-arm64'
+  | 'win32-x64'
+
+const VALID_PLATFORMS: Platform[] = [
+  'linux-x64',
+  'linux-arm64',
+  'darwin-x64',
+  'darwin-arm64',
+  'win32-x64',
+]
+
+function isValidPlatform(value: string): value is Platform {
+  return VALID_PLATFORMS.includes(value as Platform)
+}
+
+// Validate version format: X.Y.Z.W (ClickHouse uses 4-part versions)
+const VERSION_REGEX = /^\d+\.\d+\.\d+\.\d+$/
+
+function isValidVersion(value: string): boolean {
+  return VERSION_REGEX.test(value)
+}
+
+type DownloadableSource = {
+  url: string
+  format: 'tar.gz' | 'tar.xz' | 'zip'
+  sha256: string | null
+}
+
+type BuildRequiredSource = {
+  sourceType: 'build-required'
+  note?: string
+}
+
+type SourceEntry = DownloadableSource | BuildRequiredSource
+
+type Sources = {
+  database: string
+  versions: Record<string, Record<Platform, SourceEntry>>
+  notes: Record<string, string>
+}
+
+function isDownloadableSource(
+  source: SourceEntry,
+): source is DownloadableSource {
+  return 'url' in source
+}
+
+const colors = {
+  reset: '\x1b[0m',
+  red: '\x1b[31m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  blue: '\x1b[34m',
+  cyan: '\x1b[36m',
+}
+
+function log(color: keyof typeof colors, prefix: string, msg: string) {
+  console.log(`${colors[color]}[${prefix}]${colors.reset} ${msg}`)
+}
+
+function logInfo(msg: string) {
+  log('blue', 'INFO', msg)
+}
+function logSuccess(msg: string) {
+  log('green', 'OK', msg)
+}
+function logWarn(msg: string) {
+  log('yellow', 'WARN', msg)
+}
+function logError(msg: string) {
+  log('red', 'ERROR', msg)
+}
+
+function detectPlatform(): Platform {
+  const platform = process.platform
+  const arch = process.arch
+
+  if (platform === 'linux' && arch === 'x64') return 'linux-x64'
+  if (platform === 'linux' && arch === 'arm64') return 'linux-arm64'
+  if (platform === 'darwin' && arch === 'x64') return 'darwin-x64'
+  if (platform === 'darwin' && arch === 'arm64') return 'darwin-arm64'
+  if (platform === 'win32' && arch === 'x64') return 'win32-x64'
+
+  throw new Error(`Unsupported platform: ${platform}-${arch}`)
+}
+
+function loadSources(): Sources {
+  const sourcesPath = resolve(__dirname, 'sources.json')
+  const content = readFileSync(sourcesPath, 'utf-8')
+  try {
+    return JSON.parse(content) as Sources
+  } catch (error) {
+    throw new Error(`Failed to parse sources.json: invalid JSON`, {
+      cause: error,
+    })
+  }
+}
+
+async function downloadFile(url: string, destPath: string): Promise<void> {
+  logInfo(`Downloading: ${url}`)
+
+  const response = await fetch(url, { redirect: 'follow' })
+
+  if (!response.ok) {
+    throw new Error(
+      `Download failed: ${response.status} ${response.statusText}`,
+    )
+  }
+
+  const contentLength = response.headers.get('content-length')
+  const totalBytes = contentLength ? parseInt(contentLength, 10) : 0
+
+  mkdirSync(dirname(destPath), { recursive: true })
+
+  const fileStream = createWriteStream(destPath)
+  const reader = response.body?.getReader()
+
+  if (!reader) {
+    throw new Error('No response body')
+  }
+
+  let downloadedBytes = 0
+  const startTime = Date.now()
+
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+
+    const canContinue = fileStream.write(value)
+    downloadedBytes += value.length
+
+    // Handle backpressure - wait for drain if buffer is full
+    if (!canContinue) {
+      await new Promise<void>((resolve, reject) => {
+        const onDrain = () => {
+          fileStream.removeListener('error', onError)
+          resolve()
+        }
+        const onError = (err: Error) => {
+          fileStream.removeListener('drain', onDrain)
+          reject(err)
+        }
+        fileStream.once('drain', onDrain)
+        fileStream.once('error', onError)
+      })
+    }
+
+    // Progress update
+    if (totalBytes > 0) {
+      const percent = ((downloadedBytes / totalBytes) * 100).toFixed(1)
+      const mbDownloaded = (downloadedBytes / 1024 / 1024).toFixed(1)
+      const mbTotal = (totalBytes / 1024 / 1024).toFixed(1)
+      process.stdout.write(
+        `\r  ${mbDownloaded}MB / ${mbTotal}MB (${percent}%)    `,
+      )
+    } else {
+      const mbDownloaded = (downloadedBytes / 1024 / 1024).toFixed(1)
+      process.stdout.write(`\r  ${mbDownloaded}MB downloaded...    `)
+    }
+  }
+
+  // Wait for the file stream to fully close before proceeding
+  await new Promise<void>((resolve, reject) => {
+    fileStream.end()
+    fileStream.on('finish', resolve)
+    fileStream.on('error', reject)
+  })
+
+  console.log() // New line after progress
+
+  const duration = ((Date.now() - startTime) / 1000).toFixed(1)
+  logSuccess(
+    `Downloaded ${(downloadedBytes / 1024 / 1024).toFixed(1)}MB in ${duration}s`,
+  )
+}
+
+// Calculate SHA256 checksum using streaming to avoid loading large files into memory
+async function calculateSha256(filePath: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const hash = createHash('sha256')
+    const stream = createReadStream(filePath)
+
+    stream.on('data', (chunk) => hash.update(chunk))
+    stream.on('end', () => resolve(hash.digest('hex')))
+    stream.on('error', reject)
+  })
+}
+
+/**
+ * Repackage Linux tarball
+ * Linux tarballs contain: clickhouse-common-static-VERSION/usr/bin/clickhouse
+ */
+function repackageLinuxTarball(
+  tarballPath: string,
+  outputPath: string,
+  version: string,
+  platform: Platform,
+): void {
+  const tempDir = resolve(dirname(tarballPath), 'temp-extract')
+  mkdirSync(tempDir, { recursive: true })
+
+  logInfo('Extracting tarball...')
+
+  // Extract the tarball
+  execFileSync('tar', ['-xzf', tarballPath, '-C', tempDir], { stdio: 'inherit' })
+
+  // Find extracted directory (clickhouse-common-static-VERSION/)
+  const extractedDirs = readdirSync(tempDir)
+  const clickhouseDir = extractedDirs.find((d) =>
+    d.startsWith('clickhouse-common-static'),
+  )
+
+  if (!clickhouseDir) {
+    // Check if it extracted directly to usr/bin
+    if (existsSync(resolve(tempDir, 'usr', 'bin', 'clickhouse'))) {
+      // Tarball extracted directly - create our structure
+      const finalDir = resolve(tempDir, 'clickhouse')
+      mkdirSync(resolve(finalDir, 'bin'), { recursive: true })
+
+      // Move binary
+      execFileSync('mv', [
+        resolve(tempDir, 'usr', 'bin', 'clickhouse'),
+        resolve(finalDir, 'bin', 'clickhouse'),
+      ])
+
+      // Create symlinks
+      createClickhouseSymlinks(resolve(finalDir, 'bin'))
+
+      // Add metadata
+      addMetadata(finalDir, version, platform, 'official')
+
+      // Create output tarball
+      createOutputTarball(tempDir, outputPath)
+
+      // Cleanup
+      rmSync(tempDir, { recursive: true, force: true })
+      return
+    }
+
+    throw new Error(
+      `Could not find extracted ClickHouse directory. Found: ${extractedDirs.join(', ')}`,
+    )
+  }
+
+  const extractedPath = resolve(tempDir, clickhouseDir)
+
+  // Create final directory structure
+  const finalDir = resolve(tempDir, 'clickhouse')
+  mkdirSync(resolve(finalDir, 'bin'), { recursive: true })
+
+  // Find and move the clickhouse binary
+  const binaryPath = resolve(extractedPath, 'usr', 'bin', 'clickhouse')
+  if (!existsSync(binaryPath)) {
+    throw new Error(`ClickHouse binary not found at expected path: ${binaryPath}`)
+  }
+
+  execFileSync('mv', [binaryPath, resolve(finalDir, 'bin', 'clickhouse')])
+
+  // Create symlinks for common commands
+  createClickhouseSymlinks(resolve(finalDir, 'bin'))
+
+  // Add metadata
+  addMetadata(finalDir, version, platform, 'official')
+
+  // Remove extracted directory
+  rmSync(extractedPath, { recursive: true, force: true })
+
+  // Create output tarball
+  createOutputTarball(tempDir, outputPath)
+
+  // Cleanup
+  rmSync(tempDir, { recursive: true, force: true })
+
+  logSuccess(`Created: ${outputPath}`)
+}
+
+/**
+ * Package macOS binary
+ * macOS downloads are single executable files, not tarballs
+ */
+function packageMacOSBinary(
+  binaryPath: string,
+  outputPath: string,
+  version: string,
+  platform: Platform,
+): void {
+  const tempDir = resolve(dirname(binaryPath), 'temp-package')
+  const finalDir = resolve(tempDir, 'clickhouse')
+
+  mkdirSync(resolve(finalDir, 'bin'), { recursive: true })
+
+  logInfo('Creating package from binary...')
+
+  // Copy binary to bin directory
+  execFileSync('cp', [binaryPath, resolve(finalDir, 'bin', 'clickhouse')])
+
+  // Make executable
+  chmodSync(resolve(finalDir, 'bin', 'clickhouse'), 0o755)
+
+  // Create symlinks for common commands
+  createClickhouseSymlinks(resolve(finalDir, 'bin'))
+
+  // Add metadata
+  addMetadata(finalDir, version, platform, 'official')
+
+  // Create output tarball
+  createOutputTarball(tempDir, outputPath)
+
+  // Cleanup
+  rmSync(tempDir, { recursive: true, force: true })
+
+  logSuccess(`Created: ${outputPath}`)
+}
+
+/**
+ * Create symlinks for ClickHouse subcommands
+ * ClickHouse uses a single binary with subcommands, but supports
+ * running as clickhouse-server, clickhouse-client, etc.
+ */
+function createClickhouseSymlinks(binDir: string): void {
+  const symlinks = [
+    'clickhouse-server',
+    'clickhouse-client',
+    'clickhouse-local',
+    'clickhouse-benchmark',
+    'clickhouse-compressor',
+    'clickhouse-format',
+    'clickhouse-obfuscator',
+  ]
+
+  for (const link of symlinks) {
+    const linkPath = resolve(binDir, link)
+    if (!existsSync(linkPath)) {
+      try {
+        symlinkSync('clickhouse', linkPath)
+      } catch {
+        // Symlink creation may fail on some systems, log warning but continue
+        logWarn(`Could not create symlink: ${link}`)
+      }
+    }
+  }
+}
+
+function addMetadata(
+  dir: string,
+  version: string,
+  platform: Platform,
+  source: string,
+): void {
+  const metadata = {
+    name: 'clickhouse',
+    version,
+    platform,
+    source,
+    sourceUrl: 'https://github.com/ClickHouse/ClickHouse/releases',
+    rehosted_by: 'hostdb',
+    rehosted_at: new Date().toISOString(),
+  }
+  writeFileSync(
+    resolve(dir, '.hostdb-metadata.json'),
+    JSON.stringify(metadata, null, 2),
+  )
+}
+
+function createOutputTarball(tempDir: string, outputPath: string): void {
+  mkdirSync(dirname(outputPath), { recursive: true })
+
+  logInfo(`Creating: ${basename(outputPath)}`)
+
+  execFileSync('tar', ['-czvf', outputPath, 'clickhouse'], {
+    cwd: tempDir,
+    stdio: 'inherit',
+  })
+}
+
+function parseArgs(): {
+  version: string
+  platforms: Platform[]
+  outputDir: string
+} {
+  const args = process.argv.slice(2)
+  let version = '25.12.3.21'
+  let platforms: Platform[] = []
+  let outputDir = './dist'
+  let allPlatforms = false
+
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case '--':
+        // Ignore -- (end of options delimiter from pnpm)
+        break
+      case '--version': {
+        if (i + 1 >= args.length || args[i + 1].startsWith('-')) {
+          logError('--version requires a value')
+          process.exit(1)
+        }
+        const versionValue = args[++i]
+        if (!isValidVersion(versionValue)) {
+          logError(`Invalid version format: ${versionValue}`)
+          logError('Version must be in format: X.Y.Z.W (e.g., 25.12.3.21)')
+          process.exit(1)
+        }
+        version = versionValue
+        break
+      }
+      case '--platform': {
+        if (i + 1 >= args.length || args[i + 1].startsWith('-')) {
+          logError('--platform requires a value')
+          process.exit(1)
+        }
+        const platformValue = args[++i]
+        if (!isValidPlatform(platformValue)) {
+          logError(`Invalid platform: ${platformValue}`)
+          logError(`Valid platforms: ${VALID_PLATFORMS.join(', ')}`)
+          process.exit(1)
+        }
+        platforms.push(platformValue)
+        break
+      }
+      case '--output':
+        if (i + 1 >= args.length || args[i + 1].startsWith('-')) {
+          logError('--output requires a value')
+          process.exit(1)
+        }
+        outputDir = args[++i]
+        break
+      case '--all-platforms':
+        allPlatforms = true
+        break
+      case '--help':
+      case '-h':
+        console.log(`
+Usage: ./builds/clickhouse/download.ts [options]
+
+Options:
+  --version VERSION    ClickHouse version (default: 25.12.3.21)
+  --platform PLATFORM  Target platform (default: current)
+  --output DIR         Output directory (default: ./dist)
+  --all-platforms      Download for all platforms (skips build-required)
+  --help               Show this help
+
+Platforms: linux-x64, linux-arm64, darwin-x64, darwin-arm64, win32-x64
+
+Sources:
+  - Linux: Official clickhouse-common-static tarball from GitHub releases
+  - macOS: Official single binary from GitHub releases
+  - Windows: build-required (experimental Cygwin build in CI)
+
+Examples:
+  ./builds/clickhouse/download.ts
+  ./builds/clickhouse/download.ts --version 25.12.3.21 --platform linux-x64
+  ./builds/clickhouse/download.ts --all-platforms
+`)
+        process.exit(0)
+        break // unreachable, but required for no-fallthrough rule
+    }
+  }
+
+  if (allPlatforms) {
+    platforms = [...VALID_PLATFORMS]
+  } else if (platforms.length === 0) {
+    platforms = [detectPlatform()]
+  }
+
+  return { version, platforms, outputDir }
+}
+
+async function main() {
+  const { version, platforms, outputDir } = parseArgs()
+  const sources = loadSources()
+
+  console.log()
+  logInfo(`ClickHouse Download Script`)
+  logInfo(`Version: ${version}`)
+  logInfo(`Platforms: ${platforms.join(', ')}`)
+  logInfo(`Output: ${outputDir}`)
+  console.log()
+
+  const versionSources = sources.versions[version]
+  if (!versionSources) {
+    logError(`Version ${version} not found in sources.json`)
+    logInfo(`Available versions: ${Object.keys(sources.versions).join(', ')}`)
+    process.exit(1)
+  }
+
+  let downloadedCount = 0
+  let skippedCount = 0
+
+  for (const platform of platforms) {
+    console.log()
+    logInfo(`=== ${platform} ===`)
+
+    const source = versionSources[platform]
+    if (!source) {
+      logWarn(`No source entry for ${platform}, skipping`)
+      skippedCount++
+      continue
+    }
+
+    // Handle build-required sources
+    if (!isDownloadableSource(source)) {
+      logWarn(`${platform} requires building from source (no binary available)`)
+      if (source.note) {
+        logInfo(`Note: ${source.note}`)
+      }
+      logInfo('Windows builds are handled by GitHub Actions workflow')
+      skippedCount++
+      continue
+    }
+
+    const outputPath = resolve(outputDir, `clickhouse-${version}-${platform}.tar.gz`)
+    const isMacOS = platform.startsWith('darwin')
+
+    // For macOS, the URL points to a raw binary, not a tarball
+    const downloadExt = isMacOS ? 'bin' : 'tgz'
+    const downloadPath = resolve(
+      outputDir,
+      'downloads',
+      `clickhouse-${version}-${platform}-original.${downloadExt}`,
+    )
+
+    // Download
+    if (existsSync(downloadPath)) {
+      logInfo(`Using cached download: ${downloadPath}`)
+    } else {
+      await downloadFile(source.url, downloadPath)
+    }
+
+    // Verify checksum if available
+    const actualSha256 = await calculateSha256(downloadPath)
+    logInfo(`SHA256: ${actualSha256}`)
+
+    if (source.sha256) {
+      if (actualSha256 === source.sha256) {
+        logSuccess('Checksum verified')
+      } else {
+        logError(`Checksum mismatch! Expected: ${source.sha256}`)
+        process.exit(1)
+      }
+    } else {
+      logWarn('No checksum in sources.json - update it with the SHA256 above')
+    }
+
+    // Repackage based on platform
+    if (isMacOS) {
+      packageMacOSBinary(downloadPath, outputPath, version, platform)
+    } else {
+      repackageLinuxTarball(downloadPath, outputPath, version, platform)
+    }
+
+    // Final checksum
+    const outputSha256 = await calculateSha256(outputPath)
+    logInfo(`Output SHA256: ${outputSha256}`)
+
+    downloadedCount++
+  }
+
+  console.log()
+  logSuccess('Done!')
+  logInfo(`Downloaded: ${downloadedCount} platform(s)`)
+  if (skippedCount > 0) {
+    logInfo(`Skipped: ${skippedCount} platform(s)`)
+  }
+  logInfo(`Output files in: ${resolve(outputDir)}`)
+}
+
+main().catch((err) => {
+  logError(err.message)
+  process.exit(1)
+})

--- a/builds/clickhouse/sources.json
+++ b/builds/clickhouse/sources.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "../../schemas/sources.schema.json",
+  "database": "clickhouse",
+  "versions": {
+    "25.12.3.21": {
+      "linux-x64": {
+        "url": "https://github.com/ClickHouse/ClickHouse/releases/download/v25.12.3.21-stable/clickhouse-common-static-25.12.3.21-amd64.tgz",
+        "format": "tar.gz",
+        "sha256": "dc8da37814b7c24a4b1ee8d3d63ff668e8c8fcfe45dfa69d80fde87d92f0b552"
+      },
+      "linux-arm64": {
+        "url": "https://github.com/ClickHouse/ClickHouse/releases/download/v25.12.3.21-stable/clickhouse-common-static-25.12.3.21-arm64.tgz",
+        "format": "tar.gz",
+        "sha256": "74fe5a5c13b5d06179a337aebd71ec734f7ed6e57c8b6a912b5a52ddcb2336a1"
+      },
+      "darwin-x64": {
+        "url": "https://github.com/ClickHouse/ClickHouse/releases/download/v25.12.3.21-stable/clickhouse-macos",
+        "format": "tar.gz",
+        "sha256": "77de677b774ab499aec42fb1d88c52b50cd51e1dbc60733b6ae389e743dc9b64"
+      },
+      "darwin-arm64": {
+        "url": "https://github.com/ClickHouse/ClickHouse/releases/download/v25.12.3.21-stable/clickhouse-macos-aarch64",
+        "format": "tar.gz",
+        "sha256": "6023fd26d38612389ec332841166a8684393ed025b5f61dfbb3fcd0344965525"
+      },
+      "win32-x64": {
+        "sourceType": "build-required",
+        "note": "Experimental Cygwin build - no official Windows binaries available"
+      }
+    }
+  },
+  "notes": {
+    "license": "Apache-2.0 - Fully permissive for commercial use",
+    "github-releases": "Official binaries from GitHub Releases at https://github.com/ClickHouse/ClickHouse/releases",
+    "linux": "Linux binaries from clickhouse-common-static tarball contain the main clickhouse binary",
+    "macos": "macOS binaries are single monolithic executables (not tarballs), wrapped in tar.gz by download.ts",
+    "windows": "No official Windows support - experimental Cygwin build attempted in CI",
+    "checksums": "ClickHouse provides SHA-512 checksums; sha256 field left null for now",
+    "single-binary": "ClickHouse uses a single binary with subcommands: clickhouse server, clickhouse client, clickhouse local"
+  }
+}

--- a/databases.json
+++ b/databases.json
@@ -87,18 +87,17 @@
       "license": "Apache-2.0",
       "commercialUse": true,
       "protocol": null,
-      "note": "No native Windows support; requires WSL",
-      "latestLts": "25.8",
+      "note": "Windows build is experimental (Cygwin); may require WSL for production use",
+      "latestLts": "25.12",
       "versions": {
-        "25.8.13.73-lts": true,
-        "25.3.11.20-lts": false
+        "25.12.3.21": true
       },
       "platforms": {
         "linux-x64": true,
         "linux-arm64": true,
         "darwin-x64": true,
         "darwin-arm64": true,
-        "win32-x64": false
+        "win32-x64": true
       },
       "cliTools": {
         "server": "clickhouse-server",
@@ -114,7 +113,7 @@
         "defaultUser": "default",
         "queryLanguage": "SQL"
       },
-      "status": "unsupported"
+      "status": "in-progress"
     },
     "cockroachdb": {
       "displayName": "CockroachDB",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "add:engine": "tsx scripts/add-engine.ts",
     "checksums:populate": "tsx scripts/populate-checksums.ts",
     "dbs": "tsx scripts/list-databases.ts",
+    "download:clickhouse": "tsx builds/clickhouse/download.ts",
     "download:mariadb": "tsx builds/mariadb/download.ts",
     "download:mongodb": "tsx builds/mongodb/download.ts",
     "download:mysql": "tsx builds/mysql/download.ts",


### PR DESCRIPTION
…rimental Windows builds

- Add release-clickhouse.yml workflow with version 25.12.3.21 as default
- Support platform selection: all, linux-x64, linux-arm64, darwin-x64, darwin-arm64, win32-x64
- Add validation steps to check version against databases.json and sources.json
- Add prepare job to determine download vs build platforms based on input
- Add build-download job for Linux/macOS platforms using official GitHub release binaries
- Add build-source