### PR TITLE
chore: override CMAKE_SYSTEM_PROCESSOR to x86_64 in ClickHouse Window…

### DIFF
--- a/.github/workflows/release-clickhouse.yml
+++ b/.github/workflows/release-clickhouse.yml
@@ -307,10 +307,12 @@ jobs:
           mkdir -p build && cd build
 
           # Use MSYS2's clang from CLANG64 environment
+          # Override CMAKE_SYSTEM_PROCESSOR because Windows reports AMD64 instead of x86_64
           cmake .. \
             -DCMAKE_C_COMPILER=clang \
             -DCMAKE_CXX_COMPILER=clang++ \
             -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_SYSTEM_PROCESSOR=x86_64 \
             -DENABLE_TESTS=OFF \
             -DENABLE_UTILS=OFF \
             -DENABLE_EMBEDDED_COMPILER=OFF \


### PR DESCRIPTION
…s build

- Add -DCMAKE_SYSTEM_PROCESSOR=x86_64 flag to cmake configuration
- Windows reports AMD64 instead of x86_64, causing architecture detection issues
- Add inline comment explaining the override reason