### PR TITLE
chore: clarify environment check comment in ClickHouse Windows build …

### DIFF
--- a/.github/workflows/release-clickhouse.yml
+++ b/.github/workflows/release-clickhouse.yml
@@ -277,7 +277,7 @@ jobs:
           echo "This build is experimental and may fail!"
           echo "=========================================="
 
-          # Check environment
+          # Check build environment
           echo "Environment:"
           echo "MSYSTEM: $MSYSTEM"
           echo "PATH: $PATH"


### PR DESCRIPTION
…workflow

- Update comment from "Check environment" to "Check build environment" for clarity