### PR TITLE
chore: add NASM package to ClickHouse Windows build dependencies

### DIFF
--- a/.github/workflows/release-clickhouse.yml
+++ b/.github/workflows/release-clickhouse.yml
@@ -259,6 +259,7 @@ jobs:
             mingw-w64-clang-x86_64-xz
             mingw-w64-clang-x86_64-libxml2
             mingw-w64-clang-x86_64-python
+            mingw-w64-clang-x86_64-nasm
             git
             zip
 


### PR DESCRIPTION
- Add mingw-w64-clang-x86_64-nasm to MSYS2 package installation
- Required for assembly optimizations in Windows builds