### PR TITLE
chore: disable additional features in ClickHouse Windows build config…

### DIFF
--- a/.github/workflows/release-clickhouse.yml
+++ b/.github/workflows/release-clickhouse.yml
@@ -357,6 +357,18 @@ jobs:
             -DENABLE_CLICKHOUSE_DISKS=OFF \
             -DENABLE_LDAP=OFF \
             -DENABLE_ISA_L=OFF \
+            -DENABLE_HDFS=OFF \
+            -DENABLE_KAFKA=OFF \
+            -DENABLE_NATS=OFF \
+            -DENABLE_AMQPCPP=OFF \
+            -DENABLE_CASSANDRA=OFF \
+            -DENABLE_S3=OFF \
+            -DENABLE_AZURE_BLOB_STORAGE=OFF \
+            -DENABLE_GRPC=OFF \
+            -DENABLE_MYSQL=OFF \
+            -DENABLE_MONGODB=OFF \
+            -DENABLE_POSTGRESQL=OFF \
+            -DENABLE_LIBURING=OFF \
             -GNinja || {
               echo "::warning::CMake configuration failed. This is expected for experimental Windows builds."
               echo "::warning::ClickHouse does not officially support Windows."


### PR DESCRIPTION
…uration

- Add -DENABLE_HDFS=OFF, -DENABLE_KAFKA=OFF, -DENABLE_NATS=OFF flags
- Add -DENABLE_AMQPCPP=OFF, -DENABLE_CASSANDRA=OFF, -DENABLE_S3=OFF flags
- Add -DENABLE_AZURE_BLOB_STORAGE=OFF, -DENABLE_GRPC=OFF flags
- Add -DENABLE_MYSQL=OFF, -DENABLE_MONGODB=OFF, -DENABLE_POSTGRESQL=OFF flags
- Add -DENABLE_LIBURING=OFF flag
- Disables Linux-specific and external service integrations for Windows builds with MSYS2 CLANG64