### PR TITLE
chore: configure LLD linker explicitly in ClickHouse Windows build

### DIFF
--- a/.github/workflows/release-clickhouse.yml
+++ b/.github/workflows/release-clickhouse.yml
@@ -339,6 +339,8 @@ jobs:
           cmake .. \
             -DCMAKE_C_COMPILER=clang \
             -DCMAKE_CXX_COMPILER=clang++ \
+            -DCMAKE_LINKER=ld.lld \
+            -DLINKER_NAME=ld.lld \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_SYSTEM_PROCESSOR=x86_64 \
             -DCOMPILER_CACHE=disabled \


### PR DESCRIPTION
- Add -DCMAKE_LINKER=ld.lld flag to cmake configuration
- Add -DLINKER_NAME=ld.lld flag to cmake configuration
- Ensures LLVM linker is used for Windows builds with MSYS2 CLANG64