### PR TITLE
chore: disable SSH support in ClickHouse Windows build configuration

### DIFF
--- a/.github/workflows/release-clickhouse.yml
+++ b/.github/workflows/release-clickhouse.yml
@@ -372,6 +372,7 @@ jobs:
             -DENABLE_POSTGRESQL=OFF \
             -DENABLE_LIBURING=OFF \
             -DENABLE_PARQUET=OFF \
+            -DENABLE_SSH=OFF \
             -GNinja || {
               echo "::warning::CMake configuration failed. This is expected for experimental Windows builds."
               echo "::warning::ClickHouse does not officially support Windows."


### PR DESCRIPTION
- Add -DENABLE_SSH=OFF flag to cmake configuration
- Disables Linux-specific SSH feature for Windows builds with MSYS2 CLANG64