### PR TITLE
chore: allow custom CMAKE_CXX_FLAGS in ClickHouse Windows build confi…

### DIFF
--- a/.github/workflows/release-clickhouse.yml
+++ b/.github/workflows/release-clickhouse.yml
@@ -345,6 +345,13 @@ jobs:
           echo "Patched target.cmake:"
           grep -n -A2 "Windows" cmake/target.cmake || true
 
+          # Patch PreLoad.cmake to allow custom CMAKE_CXX_FLAGS
+          # ClickHouse normally rejects any custom flags, but we need -include for our compat header
+          echo ""
+          echo "Patching PreLoad.cmake to allow custom flags..."
+          sed -i 's/message(FATAL_ERROR/message(WARNING/' PreLoad.cmake
+          echo "Patched PreLoad.cmake (changed FATAL_ERROR to WARNING)"
+
           # Create Windows compatibility header with POSIX stubs
           echo ""
           echo "Creating Windows compatibility header..."


### PR DESCRIPTION
…guration

- Patch PreLoad.cmake to downgrade FATAL_ERROR to WARNING for custom flags
- Enables -include flag needed for Windows compatibility header
- ClickHouse normally rejects custom CMAKE_CXX_FLAGS, this patch allows them