### PR TITLE
chore: undefine Windows macros that pollute namespace in ClickHouse W…

### DIFF
--- a/.github/workflows/release-clickhouse.yml
+++ b/.github/workflows/release-clickhouse.yml
@@ -366,6 +366,31 @@ jobs:
             '#pragma once' \
             '#ifdef _WIN32' \
             '#include <windows.h>' \
+            '' \
+            '// Undefine Windows macros that pollute the namespace and break code' \
+            '// OPTIONAL is defined in Windows SAL annotations, breaks LLVM enums' \
+            '#ifdef OPTIONAL' \
+            '#undef OPTIONAL' \
+            '#endif' \
+            '#ifdef IN' \
+            '#undef IN' \
+            '#endif' \
+            '#ifdef OUT' \
+            '#undef OUT' \
+            '#endif' \
+            '#ifdef near' \
+            '#undef near' \
+            '#endif' \
+            '#ifdef far' \
+            '#undef far' \
+            '#endif' \
+            '#ifdef DELETE' \
+            '#undef DELETE' \
+            '#endif' \
+            '#ifdef ERROR' \
+            '#undef ERROR' \
+            '#endif' \
+            '' \
             '#ifndef _SC_PAGESIZE' \
             '#define _SC_PAGESIZE 1' \
             '#endif' \


### PR DESCRIPTION
…indows build

- Add macro undefs for OPTIONAL, IN, OUT, near, far, DELETE, ERROR in Windows compatibility header
- Prevents Windows.h macros from breaking LLVM enums and other code
- OPTIONAL macro from Windows SAL annotations conflicts with LLVM enum values