### PR TITLE
chore: remove DELETE macro undef from Windows compatibility header in…

### DIFF
--- a/.github/workflows/release-clickhouse.yml
+++ b/.github/workflows/release-clickhouse.yml
@@ -384,9 +384,7 @@ jobs:
             '#ifdef far' \
             '#undef far' \
             '#endif' \
-            '#ifdef DELETE' \
-            '#undef DELETE' \
-            '#endif' \
+            '// Note: DELETE is a legitimate Windows API constant (0x00010000L) - do not undef' \
             '#ifdef ERROR' \
             '#undef ERROR' \
             '#endif' \


### PR DESCRIPTION
… ClickHouse build

- Remove DELETE macro undef - it's a legitimate Windows API constant (0x00010000L)
- Add comment explaining DELETE should not be undefined
- Keep other Windows macro undefs (OPTIONAL, IN, OUT, near, far, ERROR)