### PR TITLE
chore: undefine NO_ERROR Windows macro in ClickHouse compatibility he…

### DIFF
--- a/.github/workflows/release-clickhouse.yml
+++ b/.github/workflows/release-clickhouse.yml
@@ -388,6 +388,9 @@ jobs:
             '#ifdef ERROR' \
             '#undef ERROR' \
             '#endif' \
+            '#ifdef NO_ERROR' \
+            '#undef NO_ERROR' \
+            '#endif' \
             '' \
             '#ifndef _SC_PAGESIZE' \
             '#define _SC_PAGESIZE 1' \


### PR DESCRIPTION
…ader

- Add NO_ERROR macro undef to Windows compatibility header
- Prevents Windows.h NO_ERROR constant from conflicting with code
- Follows same pattern as other Windows macro undefs (ERROR, OPTIONAL, IN, OUT, near, far)