### PR TITLE
chore: add Cygwin DLL bundling for Valkey Windows builds and improve …

### DIFF
--- a/.github/workflows/release-valkey.yml
+++ b/.github/workflows/release-valkey.yml
@@ -326,6 +326,18 @@ jobs:
             "  \"rehosted_at\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"" \
             '}' > valkey/.hostdb-metadata.json
 
+          # Copy required Cygwin DLLs to the bin directory
+          # These are needed for the executables to run on Windows without Cygwin installed
+          echo "Copying Cygwin DLLs..."
+          cp /usr/bin/cygwin1.dll valkey/bin/
+          cp /usr/bin/cygssl-3.dll valkey/bin/
+          cp /usr/bin/cygcrypto-3.dll valkey/bin/
+          cp /usr/bin/cygz.dll valkey/bin/
+          cp /usr/bin/cyggcc_s-seh-1.dll valkey/bin/
+
+          echo "Contents of valkey/bin:"
+          ls -la valkey/bin/
+
           # Create zip (Windows convention) - archive from install/ to include valkey/ prefix
           mkdir -p ../dist
           zip -r "../dist/valkey-${VERSION}-${PLATFORM}.zip" valkey


### PR DESCRIPTION
…logging

- Copy required Cygwin DLLs (cygwin1, cygssl-3, cygcrypto-3, cygz, cyggcc_s-seh-1) to valkey/bin
- Add comment explaining DLLs are needed for standalone Windows execution
- Log contents of valkey/bin directory after copying DLLs
- Add DLL detection and logging in Redis Windows repackaging
- Log warning if no DLLs found in Windows package
- Fix formatting for multi-line log message in buildFromSource fallback