### PR TITLE
chore: disable internal SSL library in ClickHouse Windows build

### DIFF
--- a/.github/workflows/release-clickhouse.yml
+++ b/.github/workflows/release-clickhouse.yml
@@ -465,6 +465,7 @@ jobs:
             -DENABLE_LIBURING=OFF \
             -DENABLE_PARQUET=OFF \
             -DENABLE_SSH=OFF \
+            -DUSE_INTERNAL_SSL_LIBRARY=OFF \
             -GNinja || {
               echo "::warning::CMake configuration failed. This is expected for experimental Windows builds."
               echo "::warning::ClickHouse does not officially support Windows."


### PR DESCRIPTION
- Add -DUSE_INTERNAL_SSL_LIBRARY=OFF to cmake configuration
- Forces use of system OpenSSL instead of ClickHouse's internal BoringSSL
- Prevents potential build conflicts with Windows SSL implementations