### PR TITLE
chore: switch from DUSE_INTERNAL_SSL_LIBRARY to DENABLE_SSL in ClickH…

### DIFF
--- a/.github/workflows/release-clickhouse.yml
+++ b/.github/workflows/release-clickhouse.yml
@@ -465,7 +465,7 @@ jobs:
             -DENABLE_LIBURING=OFF \
             -DENABLE_PARQUET=OFF \
             -DENABLE_SSH=OFF \
-            -DUSE_INTERNAL_SSL_LIBRARY=OFF \
+            -DENABLE_SSL=OFF \
             -GNinja || {
               echo "::warning::CMake configuration failed. This is expected for experimental Windows builds."
               echo "::warning::ClickHouse does not officially support Windows."


### PR DESCRIPTION
…ouse Windows build

- Change -DUSE_INTERNAL_SSL_LIBRARY=OFF to -DENABLE_SSL=OFF in cmake configuration
- Disables SSL support entirely instead of forcing system OpenSSL
- Simplifies build by avoiding SSL library dependencies on Windows