### PR TITLE
chore: enable OpenSSL with no-asm mode instead of disabling SSL in Cl…

### DIFF
--- a/.github/workflows/release-clickhouse.yml
+++ b/.github/workflows/release-clickhouse.yml
@@ -465,7 +465,7 @@ jobs:
             -DENABLE_LIBURING=OFF \
             -DENABLE_PARQUET=OFF \
             -DENABLE_SSH=OFF \
-            -DENABLE_SSL=OFF \
+            -DOPENSSL_NO_ASM=ON \
             -GNinja || {
               echo "::warning::CMake configuration failed. This is expected for experimental Windows builds."
               echo "::warning::ClickHouse does not officially support Windows."


### PR DESCRIPTION
…ickHouse Windows build

- Change -DENABLE_SSL=OFF to -DOPENSSL_NO_ASM=ON in cmake configuration
- Enables SSL support but disables assembly optimizations for Windows compatibility
- Avoids SSL library build issues while maintaining SSL functionality