### PR TITLE
chore: expand Windows build documentation and improve OpenSSL patch f…

### DIFF
--- a/.github/workflows/release-clickhouse.yml
+++ b/.github/workflows/release-clickhouse.yml
@@ -375,12 +375,13 @@ jobs:
           # Patch OpenSSL bn_div.c to disable broken inline assembly on Windows
           # The issue is that the inline asm uses "divq %4" which generates "divq %r11d"
           # (64-bit instruction with 32-bit register) - this is broken on MSYS2/Windows.
-          # We undefine the ASM macros at the top of the file to use pure C fallback.
+          # The bn_div_words macro is enabled by SIXTY_FOUR_BIT or SIXTY_FOUR_BIT_LONG,
+          # so we need to undefine those to force the C fallback.
           echo ""
           echo "Patching OpenSSL bn_div.c to disable broken inline assembly..."
           OPENSSL_BN_DIV="contrib/openssl/crypto/bn/bn_div.c"
           if [ -f "$OPENSSL_BN_DIV" ]; then
-            sed -i '1i\/* Disable broken inline assembly on Windows */\n#undef OPENSSL_BN_ASM_MONT\n#undef OPENSSL_BN_ASM_MONT5\n#undef OPENSSL_BN_ASM_GF2m\n#undef BN_DIV3W\n' "$OPENSSL_BN_DIV"
+            sed -i '1i\/* Disable broken inline assembly on Windows */\n#undef SIXTY_FOUR_BIT_LONG\n#undef SIXTY_FOUR_BIT\n#undef OPENSSL_BN_ASM_MONT\n#undef OPENSSL_BN_ASM_MONT5\n#undef OPENSSL_BN_ASM_GF2m\n#undef BN_DIV3W\n' "$OPENSSL_BN_DIV"
             echo "Patched bn_div.c (disabled inline assembly)"
           fi
 

--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,6 @@ coverage/
 # Scratchpad for queuing prompts
 .prompts.md
 
-# Debugging
-clickhouse-windows-build-log.md
+# Debugging / Windows build iteration logs
+*-windows-build-log.md
+err.log

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -152,6 +152,8 @@ Reference implementations:
 
 Skip if all platforms have official binaries.
 
+**Windows builds:** If no official Windows binary exists, we attempt to build from source using cross-compilation or compatibility layers. See [WINDOWS_BUILD.md](./WINDOWS_BUILD.md) for detailed strategies (Cygwin, MSYS2 CLANG64, etc.).
+
 ### 4.1 Create Dockerfile
 
 - [ ] Create `builds/<database>/Dockerfile`
@@ -227,7 +229,7 @@ For each platform, ensure correct runner and build type:
 | linux-arm64 | ubuntu-latest | docker |
 | darwin-x64 | macos-13 | native |
 | darwin-arm64 | macos-14 | native |
-| win32-x64 | ubuntu-latest | download |
+| win32-x64 | windows-latest | download or source build (see [WINDOWS_BUILD.md](./WINDOWS_BUILD.md)) |
 
 ### 5.3 Version input
 
@@ -359,6 +361,7 @@ The sync script automatically updates the version dropdown in the workflow file.
 
 | Issue | Solution |
 |-------|----------|
+| No official Windows binary | See [WINDOWS_BUILD.md](./WINDOWS_BUILD.md) for Cygwin/MSYS2 strategies |
 | Download URL 403/404 | Check if URL requires authentication or has rate limits |
 | Docker build fails | Check build dependencies are installed |
 | macOS build fails | Verify Homebrew dependencies in workflow |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,7 +192,7 @@ Proceed with build (or fail with helpful error)
 | linux-arm64 | Docker build (QEMU emulation) |
 | darwin-x64 | Native build on macos-15-intel runner |
 | darwin-arm64 | Native build on macos-14 runner |
-| win32-x64 | Download official binary |
+| win32-x64 | Download official binary or source build (see [WINDOWS_BUILD.md](./WINDOWS_BUILD.md)) |
 
 ### macOS Native Build Considerations
 
@@ -228,6 +228,8 @@ This creates:
 Then follow the printed instructions to implement the download logic.
 
 See [CHECKLIST.md](./CHECKLIST.md) for the complete checklist.
+
+**Windows builds:** If no official Windows binary exists, see [WINDOWS_BUILD.md](./WINDOWS_BUILD.md) for strategies (Cygwin, MSYS2 CLANG64, cross-compilation, etc.).
 
 ### Download Script Requirements
 


### PR DESCRIPTION
…or ClickHouse

- Add WINDOWS_BUILD.md documenting Cygwin, MSYS2 CLANG64, and MINGW64 strategies
- Document when to use each approach (POSIX compatibility vs native binaries)
- Add common workarounds for POSIX stubs, macro conflicts, and architecture detection
- Include troubleshooting section and iteration workflow for build failures
- Document future strategies (cross-compilation, Wine, Zig, Docker images)
- Update CHECKLIST.md an