### PR TITLE
chore: improve OpenSSL bn_div.c patch placement and clarify Wine stra…

### DIFF
--- a/.github/workflows/release-clickhouse.yml
+++ b/.github/workflows/release-clickhouse.yml
@@ -375,14 +375,15 @@ jobs:
           # Patch OpenSSL bn_div.c to disable broken inline assembly on Windows
           # The issue is that the inline asm uses "divq %4" which generates "divq %r11d"
           # (64-bit instruction with 32-bit register) - this is broken on MSYS2/Windows.
-          # The bn_div_words macro is enabled by SIXTY_FOUR_BIT or SIXTY_FOUR_BIT_LONG,
-          # so we need to undefine those to force the C fallback.
+          # The bn_div_words macro is controlled by SIXTY_FOUR_BIT / SIXTY_FOUR_BIT_LONG.
+          # We insert undefs RIGHT BEFORE the macro definition (after includes).
           echo ""
           echo "Patching OpenSSL bn_div.c to disable broken inline assembly..."
           OPENSSL_BN_DIV="contrib/openssl/crypto/bn/bn_div.c"
           if [ -f "$OPENSSL_BN_DIV" ]; then
-            sed -i '1i\/* Disable broken inline assembly on Windows */\n#undef SIXTY_FOUR_BIT_LONG\n#undef SIXTY_FOUR_BIT\n#undef OPENSSL_BN_ASM_MONT\n#undef OPENSSL_BN_ASM_MONT5\n#undef OPENSSL_BN_ASM_GF2m\n#undef BN_DIV3W\n' "$OPENSSL_BN_DIV"
-            echo "Patched bn_div.c (disabled inline assembly)"
+            # Insert undefs right before the bn_div_words macro definition
+            sed -i '/^#if defined(SIXTY_FOUR_BIT_LONG)/i\/* Disable broken inline asm on Windows - must be after includes */\n#undef SIXTY_FOUR_BIT_LONG\n#undef SIXTY_FOUR_BIT\n' "$OPENSSL_BN_DIV"
+            echo "Patched bn_div.c (disabled inline assembly before macro def)"
           fi
 
           # Create Windows compatibility header with POSIX stubs

--- a/WINDOWS_BUILD.md
+++ b/WINDOWS_BUILD.md
@@ -257,13 +257,22 @@ RUN apt-get update && apt-get install -y \
 RUN cmake -DCMAKE_TOOLCHAIN_FILE=mingw-w64.cmake ...
 ```
 
-### Wine + Native Compiler
+### Wine + MSVC Compiler
 
-**Concept:** Run Windows compiler (MSVC) under Wine on Linux.
+**Concept:** Run Microsoft Visual C++ (MSVC) compiler under Wine on Linux to produce native Windows binaries.
+
+**Important clarification:** Wine runs *Windows programs on Linux* — it doesn't help Windows users run Linux binaries. This strategy is for **building** Windows binaries from a Linux CI runner, not for end-user runtime.
 
 **When to consider:**
-- Project requires MSVC-specific features
+- Project requires MSVC-specific features (Windows SDK, ATL, MFC)
 - Need to match official Windows builds exactly
+- MinGW/Clang produce incompatible binaries
+
+**Challenges:**
+- Complex setup (Wine + MSVC installation)
+- Licensing concerns with redistributing MSVC
+- Slower than native Windows runner
+- May not work for all projects
 
 ### WSL Build + Copy
 


### PR DESCRIPTION
…tegy in Windows build docs

- Move sed patch to insert undefs right before bn_div_words macro definition instead of at top of file
- Remove unnecessary macro undefs (OPENSSL_BN_ASM_MONT, OPENSSL_BN_ASM_MONT5, OPENSSL_BN_ASM_GF2m, BN_DIV3W)
- Only undefine SIXTY_FOUR_BIT_LONG and SIXTY_FOUR_BIT to disable inline assembly
- Update comment explaining undefs must be after includes but before macro
- Clarify Wine strategy is for building Windows binaries on