### PR TITLE
chore: add OpenSSL ASM disable patch for Windows and replace ripgrep …

### DIFF
--- a/.github/workflows/release-clickhouse.yml
+++ b/.github/workflows/release-clickhouse.yml
@@ -379,18 +379,19 @@ jobs:
           OPENSSL_CMAKE="contrib/openssl-cmake/CMakeLists.txt"
           if [ -f "$OPENSSL_CMAKE" ]; then
             # Insert once, right after project() to keep it near the top.
-            if ! rg -q "OPENSSL_TARGET_FORCE_WINDOWS" "$OPENSSL_CMAKE"; then
+            if ! grep -q "OPENSSL_TARGET_FORCE_WINDOWS" "$OPENSSL_CMAKE"; then
               sed -i '/project(/a\\n# OPENSSL_TARGET_FORCE_WINDOWS\nif (WIN32)\n  if (NOT OPENSSL_TARGET)\n    set(OPENSSL_TARGET "mingw64")\n  endif()\nendif()\n' "$OPENSSL_CMAKE"
             fi
+            # Add a Windows branch under ARCH_AMD64 to avoid ASM defines.
+            python -c $'from pathlib import Path\npath = Path("contrib/openssl-cmake/CMakeLists.txt")\ntext = path.read_text()\nmarker = "# OPENSSL_WINDOWS_NO_ASM"\nif marker not in text:\n    arch_start = text.find("if(ARCH_AMD64)")\n    arch_end = text.find("elseif(ARCH_AARCH64)", arch_start)\n    if arch_start != -1 and arch_end != -1:\n        block = text[arch_start:arch_end]\n        needle = "    else()\\\\n        set(PLATFORM_DIRECTORY linux_x86_64)\\\\n        add_definitions("\n        if needle in block:\n            replacement = (\n                "    elseif(OS_WINDOWS)\\\\n"\n                f"        {marker}\\\\n"\n                "        set(PLATFORM_DIRECTORY linux_x86_64)\\\\n"\n                "        add_definitions(-DOPENSSL_NO_ASM -DOPENSSL_NO_BN_ASM -DL_ENDIAN)\\\\n"\n                "    else()\\\\n"\n                "        set(PLATFORM_DIRECTORY linux_x86_64)\\\\n"\n                "        add_definitions("\n            )\n            block = block.replace(needle, replacement, 1)\n            text = text[:arch_start] + block + text[arch_end:]\n            path.write_text(text)\n'
             echo "Patched openssl-cmake (forced OPENSSL_TARGET=mingw64 on WIN32)"
             echo "openssl-cmake header (first 80 lines):"
             sed -n '1,80p' "$OPENSSL_CMAKE" || true
             echo "openssl-cmake target/platform hints:"
-            rg -n "OPENSSL_TARGET|OPENSSL_PLATFORM|OPENSSL_CONFIG|mingw|win64|linux_x86_64|CMAKE_SYSTEM_NAME|CMAKE_SYSTEM_PROCESSOR" "$OPENSSL_CMAKE" || true
+            grep -nE "OPENSSL_TARGET|OPENSSL_PLATFORM|OPENSSL_CONFIG|mingw|win64|linux_x86_64|CMAKE_SYSTEM_NAME|CMAKE_SYSTEM_PROCESSOR|OPENSSL_WINDOWS_NO_ASM" "$OPENSSL_CMAKE" || true
           else
             echo "WARNING: openssl-cmake CMakeLists.txt not found"
           fi
-
           # Patch OpenSSL bn_div.c to disable broken inline assembly on Windows
           # The issue is that the inline asm uses "divq %4" which generates "divq %r11d"
           # (64-bit instruction with 32-bit register) - this is broken on MSYS2/Windows.


### PR DESCRIPTION
…with grep in build workflow

- Add Python script to patch openssl-cmake CMakeLists.txt with Windows-specific ASM disables
- Insert elseif(OS_WINDOWS) branch under ARCH_AMD64 to set -DOPENSSL_NO_ASM -DOPENSSL_NO_BN_ASM -DL_ENDIAN
- Use OPENSSL_WINDOWS_NO_ASM marker to prevent duplicate patches
- Replace rg (ripgrep) with grep for portability in patch verification and debug output
- Add OPENSSL_WINDOWS_NO_ASM to grep pattern for target