### PR TITLE
chore: add -DOPENSSL_NO_ASYNC and -DOPENSSL_NO_POSIX_IO to OpenSSL Wi…

### DIFF
--- a/.github/workflows/release-clickhouse.yml
+++ b/.github/workflows/release-clickhouse.yml
@@ -385,7 +385,7 @@ jobs:
             echo "=== ARCH_AMD64 block (for debugging pattern match) ==="
             sed -n '/if(ARCH_AMD64)/,/elseif(ARCH_AARCH64)/p' "$OPENSSL_CMAKE" | head -40
             # Add a Windows branch under ARCH_AMD64 to avoid ASM defines.
-            python -c $'from pathlib import Path\nimport re\npath = Path("contrib/openssl-cmake/CMakeLists.txt")\ntext = path.read_text()\nmarker = "# OPENSSL_WINDOWS_NO_ASM"\nif marker not in text:\n    arch_start = text.find("if(ARCH_AMD64)")\n    arch_end = text.find("elseif(ARCH_AARCH64)", arch_start)\n    if arch_start != -1 and arch_end != -1:\n        block = text[arch_start:arch_end]\n        pattern = r"\\n\\s*else\\(\\)\\n\\s*set\\(PLATFORM_DIRECTORY linux_x86_64\\)\\n\\s*add_definitions\\("\n        replacement = (\"\\n    elseif(OS_WINDOWS)\\n        \" + marker + \"\\n        set(PLATFORM_DIRECTORY linux_x86_64)\\n        add_definitions(-DOPENSSL_NO_ASM -DOPENSSL_NO_BN_ASM -DNOCRYPT -DOPENSSL_NO_DSO -DL_ENDIAN)\\n    else()\\n        set(PLATFORM_DIRECTORY linux_x86_64)\\n        add_definitions(\")\n        new_block, count = re.subn(pattern, replacement, block, count=1)\n        if count:\n            text = text[:arch_start] + new_block + text[arch_end:]\n            path.write_text(text)\n'
+            python -c $'from pathlib import Path\nimport re\npath = Path("contrib/openssl-cmake/CMakeLists.txt")\ntext = path.read_text()\nmarker = "# OPENSSL_WINDOWS_NO_ASM"\nif marker not in text:\n    arch_start = text.find("if(ARCH_AMD64)")\n    arch_end = text.find("elseif(ARCH_AARCH64)", arch_start)\n    if arch_start != -1 and arch_end != -1:\n        block = text[arch_start:arch_end]\n        pattern = r"\\n\\s*else\\(\\)\\n\\s*set\\(PLATFORM_DIRECTORY linux_x86_64\\)\\n\\s*add_definitions\\("\n        replacement = (\"\\n    elseif(OS_WINDOWS)\\n        \" + marker + \"\\n        set(PLATFORM_DIRECTORY linux_x86_64)\\n        add_definitions(-DOPENSSL_NO_ASM -DOPENSSL_NO_BN_ASM -DNOCRYPT -DOPENSSL_NO_DSO -DOPENSSL_NO_ASYNC -DOPENSSL_NO_POSIX_IO -DL_ENDIAN)\\n    else()\\n        set(PLATFORM_DIRECTORY linux_x86_64)\\n        add_definitions(\")\n        new_block, count = re.subn(pattern, replacement, block, count=1)\n        if count:\n            text = text[:arch_start] + new_block + text[arch_end:]\n            # Windows: remove POSIX-only DSO sources\n            for posix_file in [\"crypto/dso/dso_dlfcn.c\", \"dso/dso_dlfcn.c\", \"crypto/dso/dso_dl.c\", \"dso/dso_dl.c\"]:\n                text = text.replace(posix_file, \"\")\n            path.write_text(text)\n'
             echo "Patched openssl-cmake (forced OPENSSL_TARGET=mingw64 on WIN32)"
             echo "openssl-cmake header (first 80 lines):"
             sed -n '1,80p' "$OPENSSL_CMAKE" || true
@@ -400,6 +400,13 @@ jobs:
               sed -i 's/-DOPENSSL_CPUID_OBJ//g' "$OPENSSL_CMAKE"
               sed -i 's/-DOPENSSL_IA32_SSE2//g' "$OPENSSL_CMAKE"
               echo "WARNING: OPENSSL_WINDOWS_NO_ASM patch missing"
+            fi
+            # Verify POSIX DSO files were removed
+            if grep -q "dso_dlfcn.c" "$OPENSSL_CMAKE"; then
+              echo "WARNING: dso_dlfcn.c still in sources, removing with sed"
+              sed -i 's/dso_dlfcn\.c//g' "$OPENSSL_CMAKE"
+            else
+              echo "Verified: dso_dlfcn.c removed from sources"
             fi
           else
             echo "WARNING: openssl-cmake CMakeLists.txt not found"


### PR DESCRIPTION
…ndows patch and remove POSIX DSO sources

- Add -DOPENSSL_NO_ASYNC -DOPENSSL_NO_POSIX_IO defines to Windows elseif branch in openssl-cmake patch
- Remove POSIX-only DSO source files (dso_dlfcn.c, dso_dl.c) from sources list after patching
- Add verification check to confirm dso_dlfcn.c was removed from sources
- Add fallback sed command to strip dso_dlfcn.c if verification fails
- Prevents POSIX I/O and async operation issues on Windows builds