### PR TITLE
chore: extend OpenSSL Windows patch to remove ELF asm sources and add…

### DIFF
--- a/.github/workflows/release-clickhouse.yml
+++ b/.github/workflows/release-clickhouse.yml
@@ -385,7 +385,7 @@ jobs:
             echo "=== ARCH_AMD64 block (for debugging pattern match) ==="
             sed -n '/if(ARCH_AMD64)/,/elseif(ARCH_AARCH64)/p' "$OPENSSL_CMAKE" | head -40
             # Add a Windows branch under ARCH_AMD64 to avoid ASM defines.
-            python -c $'from pathlib import Path\nimport re\npath = Path("contrib/openssl-cmake/CMakeLists.txt")\ntext = path.read_text()\nmarker = "# OPENSSL_WINDOWS_NO_ASM"\nif marker not in text:\n    arch_start = text.find("if(ARCH_AMD64)")\n    arch_end = text.find("elseif(ARCH_AARCH64)", arch_start)\n    if arch_start != -1 and arch_end != -1:\n        block = text[arch_start:arch_end]\n        pattern = r"\\n\\s*else\\(\\)\\n\\s*set\\(PLATFORM_DIRECTORY linux_x86_64\\)\\n\\s*add_definitions\\("\n        replacement = (\"\\n    elseif(OS_WINDOWS)\\n        \" + marker + \"\\n        set(PLATFORM_DIRECTORY linux_x86_64)\\n        add_definitions(-DOPENSSL_NO_ASM -DOPENSSL_NO_BN_ASM -DNOCRYPT -DOPENSSL_NO_DSO -DOPENSSL_NO_ASYNC -DOPENSSL_NO_POSIX_IO -DL_ENDIAN)\\n    else()\\n        set(PLATFORM_DIRECTORY linux_x86_64)\\n        add_definitions(\")\n        new_block, count = re.subn(pattern, replacement, block, count=1)\n        if count:\n            text = text[:arch_start] + new_block + text[arch_end:]\n            # Windows: remove POSIX-only DSO sources\n            for posix_file in [\"crypto/dso/dso_dlfcn.c\", \"dso/dso_dlfcn.c\", \"crypto/dso/dso_dl.c\", \"dso/dso_dl.c\"]:\n                text = text.replace(posix_file, \"\")\n            path.write_text(text)\n'
+            python -c $'from pathlib import Path\nimport re\npath = Path("contrib/openssl-cmake/CMakeLists.txt")\ntext = path.read_text()\nmarker = "# OPENSSL_WINDOWS_NO_ASM"\nif marker not in text:\n    arch_start = text.find("if(ARCH_AMD64)")\n    arch_end = text.find("elseif(ARCH_AARCH64)", arch_start)\n    if arch_start != -1 and arch_end != -1:\n        block = text[arch_start:arch_end]\n        pattern = r"\\n\\s*else\\(\\)\\n\\s*set\\(PLATFORM_DIRECTORY linux_x86_64\\)\\n\\s*add_definitions\\("\n        replacement = (\"\\n    elseif(OS_WINDOWS)\\n        \" + marker + \"\\n        set(PLATFORM_DIRECTORY linux_x86_64)\\n        add_definitions(-DOPENSSL_NO_ASM -DOPENSSL_NO_BN_ASM -DNOCRYPT -DOPENSSL_NO_DSO -DOPENSSL_NO_ASYNC -DOPENSSL_NO_POSIX_IO -DL_ENDIAN)\\n    else()\\n        set(PLATFORM_DIRECTORY linux_x86_64)\\n        add_definitions(\")\n        new_block, count = re.subn(pattern, replacement, block, count=1)\n        if count:\n            text = text[:arch_start] + new_block + text[arch_end:]\n            # Windows: remove POSIX-only DSO sources\n            for posix_file in [\"crypto/dso/dso_dlfcn.c\", \"dso/dso_dlfcn.c\", \"crypto/dso/dso_dl.c\", \"dso/dso_dl.c\"]:\n                text = text.replace(posix_file, \"\")\n            # Windows: remove ELF asm sources (pre-generated .s/.S under asm/)\n            text = re.sub(r\"\\n\\s*asm/[^\\s]+\\.(s|S)\\s*\", \"\\n\", text)\n            path.write_text(text)\n'
             echo "Patched openssl-cmake (forced OPENSSL_TARGET=mingw64 on WIN32)"
             echo "openssl-cmake header (first 80 lines):"
             sed -n '1,80p' "$OPENSSL_CMAKE" || true
@@ -407,6 +407,13 @@ jobs:
               sed -i 's/dso_dlfcn\.c//g' "$OPENSSL_CMAKE"
             else
               echo "Verified: dso_dlfcn.c removed from sources"
+            fi
+            # Verify asm sources were removed
+            if grep -qE 'asm/.*\.(s|S)' "$OPENSSL_CMAKE"; then
+              echo "WARNING: asm sources still present, removing with sed"
+              sed -i -E 's/asm\/[^ ]+\.(s|S)//g' "$OPENSSL_CMAKE"
+            else
+              echo "Verified: asm sources removed"
             fi
           else
             echo "WARNING: openssl-cmake CMakeLists.txt not found"


### PR DESCRIPTION
… verification

- Add regex pattern to strip asm/*.s and asm/*.S source files from openssl-cmake sources list
- Remove pre-generated ELF assembly files that cause build failures on Windows
- Add verification check to confirm asm sources were removed from CMakeLists.txt
- Add fallback sed command to strip asm sources if verification fails
- Prevents ELF assembly format issues on Windows MINGW64 builds