### PR TITLE
chore: extend OpenSSL Windows patch to remove RIO socket sources and …

### DIFF
--- a/.github/workflows/release-clickhouse.yml
+++ b/.github/workflows/release-clickhouse.yml
@@ -385,7 +385,7 @@ jobs:
             echo "=== ARCH_AMD64 block (for debugging pattern match) ==="
             sed -n '/if(ARCH_AMD64)/,/elseif(ARCH_AARCH64)/p' "$OPENSSL_CMAKE" | head -40
             # Add a Windows branch under ARCH_AMD64 to avoid ASM defines.
-            python -c $'from pathlib import Path\nimport re\npath = Path("contrib/openssl-cmake/CMakeLists.txt")\ntext = path.read_text()\nmarker = "# OPENSSL_WINDOWS_NO_ASM"\nif marker not in text:\n    arch_start = text.find("if(ARCH_AMD64)")\n    arch_end = text.find("elseif(ARCH_AARCH64)", arch_start)\n    if arch_start != -1 and arch_end != -1:\n        block = text[arch_start:arch_end]\n        pattern = r"\\n\\s*else\\(\\)\\n\\s*set\\(PLATFORM_DIRECTORY linux_x86_64\\)\\n\\s*add_definitions\\("\n        replacement = ("\\n    elseif(OS_WINDOWS)\\n        " + marker + "\\n        set(PLATFORM_DIRECTORY linux_x86_64)\\n        add_definitions(-DOPENSSL_NO_ASM -DOPENSSL_NO_BN_ASM -DNOCRYPT -DOPENSSL_NO_DSO -DOPENSSL_NO_ASYNC -DOPENSSL_NO_POSIX_IO -DL_ENDIAN)\\n    else()\\n        set(PLATFORM_DIRECTORY linux_x86_64)\\n        add_definitions(")\n        new_block, count = re.subn(pattern, replacement, block, count=1)\n        if count:\n            text = text[:arch_start] + new_block + text[arch_end:]\n            # Windows: remove POSIX-only DSO sources\n            for posix_file in ["crypto/dso/dso_dlfcn.c", "dso/dso_dlfcn.c", "crypto/dso/dso_dl.c", "dso/dso_dl.c"]:\n                text = text.replace(posix_file, "")\n            # Windows: remove ELF asm sources (pre-generated .s/.S under asm/)\n            text = re.sub(r"\\n\\s*asm/[^\\s]+\\.(s|S)\\s*", "\\n", text)\n            # Windows: remove all inline-asm C sources under asm/\n            text = re.sub(r"\\n\\s*[^\\s]*asm/[^\\s]+\\.c\\s*", "\\n", text)\n            path.write_text(text)\n'
+            python -c $'from pathlib import Path\nimport re\npath = Path("contrib/openssl-cmake/CMakeLists.txt")\ntext = path.read_text()\nmarker = "# OPENSSL_WINDOWS_NO_ASM"\nif marker not in text:\n    arch_start = text.find("if(ARCH_AMD64)")\n    arch_end = text.find("elseif(ARCH_AARCH64)", arch_start)\n    if arch_start != -1 and arch_end != -1:\n        block = text[arch_start:arch_end]\n        pattern = r"\\n\\s*else\\(\\)\\n\\s*set\\(PLATFORM_DIRECTORY linux_x86_64\\)\\n\\s*add_definitions\\("\n        replacement = ("\\n    elseif(OS_WINDOWS)\\n        " + marker + "\\n        set(PLATFORM_DIRECTORY linux_x86_64)\\n        add_definitions(-DOPENSSL_NO_ASM -DOPENSSL_NO_BN_ASM -DNOCRYPT -DOPENSSL_NO_DSO -DOPENSSL_NO_ASYNC -DOPENSSL_NO_POSIX_IO -DL_ENDIAN)\\n    else()\\n        set(PLATFORM_DIRECTORY linux_x86_64)\\n        add_definitions(")\n        new_block, count = re.subn(pattern, replacement, block, count=1)\n        if count:\n            text = text[:arch_start] + new_block + text[arch_end:]\n            # Windows: remove POSIX-only DSO sources\n            for posix_file in ["crypto/dso/dso_dlfcn.c", "dso/dso_dlfcn.c", "crypto/dso/dso_dl.c", "dso/dso_dl.c"]:\n                text = text.replace(posix_file, "")\n            # Windows: remove ELF asm sources (pre-generated .s/.S under asm/)\n            text = re.sub(r"\\n\\s*asm/[^\\s]+\\.(s|S)\\s*", "\\n", text)\n            # Windows: remove all inline-asm C sources under asm/\n            text = re.sub(r"\\n\\s*[^\\s]*asm/[^\\s]+\\.c\\s*", "\\n", text)\n            # Windows: remove RIO socket files (uses WSASocketA which needs winsock2.h)\n            text = re.sub(r"\\n\\s*ssl/rio/[^\\s]+\\.c\\s*", "\\n", text)\n            path.write_text(text)\n'
             echo "Patched openssl-cmake (forced OPENSSL_TARGET=mingw64 on WIN32)"
             echo "openssl-cmake header (first 80 lines):"
             sed -n '1,80p' "$OPENSSL_CMAKE" || true
@@ -414,6 +414,13 @@ jobs:
               sed -i -E 's/asm\/[^ ]+\.(s|S)//g' "$OPENSSL_CMAKE"
             else
               echo "Verified: asm sources removed"
+            fi
+            # Verify RIO files were removed
+            if grep -q "ssl/rio/" "$OPENSSL_CMAKE"; then
+              echo "WARNING: ssl/rio/ files still present, removing with sed"
+              sed -i 's|ssl/rio/[^ ]*\.c||g' "$OPENSSL_CMAKE"
+            else
+              echo "Verified: ssl/rio/ files removed"
             fi
           else
             echo "WARNING: openssl-cmake CMakeLists.txt not found"


### PR DESCRIPTION
…add verification

- Add regex pattern to strip ssl/rio/*.c source files from openssl-cmake sources list
- Remove RIO socket files that use WSASocketA requiring winsock2.h
- Add verification check to confirm ssl/rio/ files were removed from CMakeLists.txt
- Add fallback sed command to strip RIO sources if verification fails
- Prevents Windows socket API dependency issues on MINGW64 builds