### PR TITLE
fix: correct bash glob syntax and GitHub Actions env context usage

### DIFF
--- a/.github/workflows/build-missing-releases.yml
+++ b/.github/workflows/build-missing-releases.yml
@@ -136,7 +136,7 @@ jobs:
   # Trigger release workflows for each missing release
   trigger-builds:
     needs: find-missing
-    if: env.ACTION == 'build-missing' && needs.find-missing.outputs.has-missing == 'true'
+    if: github.event.inputs.action == 'build-missing' && needs.find-missing.outputs.has-missing == 'true'
     runs-on: ubuntu-latest
     outputs:
       triggered: ${{ steps.trigger.outputs.triggered }}
@@ -177,7 +177,7 @@ jobs:
   # Wait for all triggered workflows to complete
   wait-for-builds:
     needs: [find-missing, trigger-builds]
-    if: env.ACTION == 'build-missing' && needs.find-missing.outputs.has-missing == 'true'
+    if: github.event.inputs.action == 'build-missing' && needs.find-missing.outputs.has-missing == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Wait for release workflows to complete
@@ -241,7 +241,7 @@ jobs:
   # Repair any missing checksums and update releases.json
   finalize:
     needs: [find-missing, trigger-builds, wait-for-builds]
-    if: always() && env.ACTION == 'build-missing' && needs.find-missing.outputs.has-missing == 'true' && needs.trigger-builds.result == 'success'
+    if: always() && github.event.inputs.action == 'build-missing' && needs.find-missing.outputs.has-missing == 'true' && needs.trigger-builds.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/rebuild-macos-postgresql.yml
+++ b/.github/workflows/rebuild-macos-postgresql.yml
@@ -178,6 +178,9 @@ jobs:
           # This ensures binaries work regardless of where they're installed
           echo "Making binaries relocatable..."
 
+          # Enable nullglob so unmatched patterns expand to nothing
+          shopt -s nullglob
+
           # Function to get all non-system dylib dependencies
           get_external_deps() {
             otool -L "$1" 2>/dev/null | tail -n +2 | awk '{print $1}' | \
@@ -198,7 +201,7 @@ jobs:
             fi
           done
 
-          for lib in postgresql/lib/*.dylib postgresql/lib/*.so 2>/dev/null; do
+          for lib in postgresql/lib/*.dylib postgresql/lib/*.so; do
             if [[ -f "$lib" ]]; then
               while IFS= read -r dep; do
                 [[ -n "$dep" ]] && DEPS_TO_PROCESS+=("$dep")

--- a/.github/workflows/release-postgresql.yml
+++ b/.github/workflows/release-postgresql.yml
@@ -533,6 +533,9 @@ jobs:
           # This ensures binaries work regardless of where they're installed
           echo "Making binaries relocatable..."
 
+          # Enable nullglob so unmatched patterns expand to nothing
+          shopt -s nullglob
+
           # Function to get all non-system dylib dependencies
           get_external_deps() {
             otool -L "$1" 2>/dev/null | tail -n +2 | awk '{print $1}' | \
@@ -553,7 +556,7 @@ jobs:
             fi
           done
 
-          for lib in postgresql/lib/*.dylib postgresql/lib/*.so 2>/dev/null; do
+          for lib in postgresql/lib/*.dylib postgresql/lib/*.so; do
             if [[ -f "$lib" ]]; then
               while IFS= read -r dep; do
                 [[ -n "$dep" ]] && DEPS_TO_PROCESS+=("$dep")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.12.2] - 2026-01-20
+
+### Fixed
+
+- **Bash syntax error in macOS PostgreSQL build**
+  - Fixed `syntax error near unexpected token '2'` caused by invalid `2>/dev/null` in for loop glob
+  - Added `shopt -s nullglob` to handle missing file patterns gracefully
+
+- **GitHub Actions `env` context error in build-missing-releases workflow**
+  - Fixed `Unrecognized named-value: 'env'` error in job-level `if` conditions
+  - Changed `env.ACTION` to `github.event.inputs.action` (env context not available at job level)
+
 ## [0.12.1] - 2026-01-20
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hostdb",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Source and download pre-built database binaries for multiple platforms, distributed via GitHub Releases",
   "private": false,
   "type": "module",


### PR DESCRIPTION
- Fix bash syntax error in macOS PostgreSQL builds by adding `shopt -s nullglob` and removing invalid `2>/dev/null` from for loop glob patterns
- Fix GitHub Actions workflow by replacing `env.ACTION` with `github.event.inputs.action` in job-level if conditions (env context not available at job level)
- Update version to 0.12.2 and add CHANGELOG entry