### PR TITLE
fix: resolve @loader_path references in macOS PostgreSQL dependency b…

### DIFF
--- a/.github/workflows/rebuild-macos-postgresql.yml
+++ b/.github/workflows/rebuild-macos-postgresql.yml
@@ -181,23 +181,39 @@ jobs:
           # Enable nullglob so unmatched patterns expand to nothing
           shopt -s nullglob
 
-          # Function to get all non-system dylib dependencies
-          get_external_deps() {
-            otool -L "$1" 2>/dev/null | tail -n +2 | awk '{print $1}' | \
-              grep -v '^/usr/lib/' | grep -v '^/System/' | grep -v '@executable_path' | grep -v '@rpath' | grep -v '@loader_path' || true
+          # Function to get all dylib dependencies, resolving @loader_path relative to file's directory
+          get_deps() {
+            local file="$1"
+            local filedir=$(dirname "$file")
+            otool -L "$file" 2>/dev/null | tail -n +2 | awk '{print $1}' | while read -r dep; do
+              # Skip system libraries
+              [[ "$dep" == /usr/lib/* ]] && continue
+              [[ "$dep" == /System/* ]] && continue
+              [[ "$dep" == @executable_path/* ]] && continue
+              [[ "$dep" == @rpath/* ]] && continue
+
+              # Resolve @loader_path relative to the file's directory
+              if [[ "$dep" == @loader_path/* ]]; then
+                local resolved="${filedir}/${dep#@loader_path/}"
+                [[ -f "$resolved" ]] && echo "$resolved"
+              else
+                echo "$dep"
+              fi
+            done
           }
 
           # Copy required Homebrew dylibs into our lib directory
           echo "Bundling external dependencies..."
+          declare -A PROCESSED_DEPS
+          declare -A ORIGINAL_PATHS  # Track where each lib came from
           DEPS_TO_PROCESS=()
-          PROCESSED_DEPS=()
 
           # Collect initial dependencies from all binaries and libraries
           for binary in postgresql/bin/*; do
             if [[ -f "$binary" && -x "$binary" ]]; then
               while IFS= read -r dep; do
                 [[ -n "$dep" ]] && DEPS_TO_PROCESS+=("$dep")
-              done < <(get_external_deps "$binary")
+              done < <(get_deps "$binary")
             fi
           done
 
@@ -205,7 +221,7 @@ jobs:
             if [[ -f "$lib" ]]; then
               while IFS= read -r dep; do
                 [[ -n "$dep" ]] && DEPS_TO_PROCESS+=("$dep")
-              done < <(get_external_deps "$lib")
+              done < <(get_deps "$lib")
             fi
           done
 
@@ -215,10 +231,8 @@ jobs:
             DEPS_TO_PROCESS=("${DEPS_TO_PROCESS[@]:1}")
 
             # Skip if already processed
-            for processed in "${PROCESSED_DEPS[@]:-}"; do
-              [[ "$dep" == "$processed" ]] && continue 2
-            done
-            PROCESSED_DEPS+=("$dep")
+            [[ -n "${PROCESSED_DEPS[$dep]:-}" ]] && continue
+            PROCESSED_DEPS[$dep]=1
 
             # Skip if not a file
             [[ ! -f "$dep" ]] && continue
@@ -229,14 +243,15 @@ jobs:
             # Skip if already exists
             [[ -f "$target" ]] && continue
 
-            echo "  Bundling: $libname"
+            echo "  Bundling: $libname (from $dep)"
             cp "$dep" "$target"
             chmod 755 "$target"
+            ORIGINAL_PATHS[$libname]="$dep"
 
-            # Check for transitive dependencies
+            # Check for transitive dependencies - scan ORIGINAL file to resolve @loader_path correctly
             while IFS= read -r transitive; do
               [[ -n "$transitive" ]] && DEPS_TO_PROCESS+=("$transitive")
-            done < <(get_external_deps "$target")
+            done < <(get_deps "$dep")
           done
 
           # Fix the bundled dylibs - set their install names and fix internal references
@@ -248,13 +263,15 @@ jobs:
               # Set the library's own install name to use @rpath
               install_name_tool -id "@rpath/$libname" "$dylib" 2>/dev/null || true
 
-              # Fix references to other libraries
-              while IFS= read -r dep; do
-                if [[ -n "$dep" ]]; then
-                  depname=$(basename "$dep")
-                  install_name_tool -change "$dep" "@rpath/$depname" "$dylib" 2>/dev/null || true
-                fi
-              done < <(get_external_deps "$dylib")
+              # Fix references to other libraries (both absolute paths and @loader_path)
+              otool -L "$dylib" 2>/dev/null | tail -n +2 | awk '{print $1}' | while read -r dep; do
+                [[ "$dep" == /usr/lib/* ]] && continue
+                [[ "$dep" == /System/* ]] && continue
+                [[ "$dep" == @rpath/* ]] && continue
+                [[ "$dep" == @executable_path/* ]] && continue
+                depname=$(basename "$dep")
+                install_name_tool -change "$dep" "@rpath/$depname" "$dylib" 2>/dev/null || true
+              done
             fi
           done
 
@@ -265,14 +282,15 @@ jobs:
               # Add rpath for finding libraries relative to executable
               install_name_tool -add_rpath "@executable_path/../lib" "$binary" 2>/dev/null || true
 
-              # Fix references to external libraries
-              while IFS= read -r dep; do
-                if [[ -n "$dep" ]]; then
-                  depname=$(basename "$dep")
-                  install_name_tool -change "$dep" "@executable_path/../lib/$depname" "$binary" 2>/dev/null || true
-                fi
-              done < <(otool -L "$binary" 2>/dev/null | tail -n +2 | awk '{print $1}' | \
-                grep -v '^/usr/lib/' | grep -v '^/System/' | grep -v '@executable_path' | grep -v '@rpath' || true)
+              # Fix references to external libraries (both absolute paths and @loader_path)
+              otool -L "$binary" 2>/dev/null | tail -n +2 | awk '{print $1}' | while read -r dep; do
+                [[ "$dep" == /usr/lib/* ]] && continue
+                [[ "$dep" == /System/* ]] && continue
+                [[ "$dep" == @rpath/* ]] && continue
+                [[ "$dep" == @executable_path/* ]] && continue
+                depname=$(basename "$dep")
+                install_name_tool -change "$dep" "@executable_path/../lib/$depname" "$binary" 2>/dev/null || true
+              done
             fi
           done
 
@@ -282,13 +300,14 @@ jobs:
             if [[ -f "$lib" ]]; then
               install_name_tool -add_rpath "@loader_path" "$lib" 2>/dev/null || true
 
-              while IFS= read -r dep; do
-                if [[ -n "$dep" ]]; then
-                  depname=$(basename "$dep")
-                  install_name_tool -change "$dep" "@rpath/$depname" "$lib" 2>/dev/null || true
-                fi
-              done < <(otool -L "$lib" 2>/dev/null | tail -n +2 | awk '{print $1}' | \
-                grep -v '^/usr/lib/' | grep -v '^/System/' | grep -v '@executable_path' | grep -v '@rpath' || true)
+              otool -L "$lib" 2>/dev/null | tail -n +2 | awk '{print $1}' | while read -r dep; do
+                [[ "$dep" == /usr/lib/* ]] && continue
+                [[ "$dep" == /System/* ]] && continue
+                [[ "$dep" == @rpath/* ]] && continue
+                [[ "$dep" == @executable_path/* ]] && continue
+                depname=$(basename "$dep")
+                install_name_tool -change "$dep" "@rpath/$depname" "$lib" 2>/dev/null || true
+              done
             fi
           done
 

--- a/.github/workflows/release-postgresql.yml
+++ b/.github/workflows/release-postgresql.yml
@@ -536,23 +536,39 @@ jobs:
           # Enable nullglob so unmatched patterns expand to nothing
           shopt -s nullglob
 
-          # Function to get all non-system dylib dependencies
-          get_external_deps() {
-            otool -L "$1" 2>/dev/null | tail -n +2 | awk '{print $1}' | \
-              grep -v '^/usr/lib/' | grep -v '^/System/' | grep -v '@executable_path' | grep -v '@rpath' | grep -v '@loader_path' || true
+          # Function to get all dylib dependencies, resolving @loader_path relative to file's directory
+          get_deps() {
+            local file="$1"
+            local filedir=$(dirname "$file")
+            otool -L "$file" 2>/dev/null | tail -n +2 | awk '{print $1}' | while read -r dep; do
+              # Skip system libraries
+              [[ "$dep" == /usr/lib/* ]] && continue
+              [[ "$dep" == /System/* ]] && continue
+              [[ "$dep" == @executable_path/* ]] && continue
+              [[ "$dep" == @rpath/* ]] && continue
+
+              # Resolve @loader_path relative to the file's directory
+              if [[ "$dep" == @loader_path/* ]]; then
+                local resolved="${filedir}/${dep#@loader_path/}"
+                [[ -f "$resolved" ]] && echo "$resolved"
+              else
+                echo "$dep"
+              fi
+            done
           }
 
           # Copy required Homebrew dylibs into our lib directory
           echo "Bundling external dependencies..."
+          declare -A PROCESSED_DEPS
+          declare -A ORIGINAL_PATHS  # Track where each lib came from
           DEPS_TO_PROCESS=()
-          PROCESSED_DEPS=()
 
           # Collect initial dependencies from all binaries and libraries
           for binary in postgresql/bin/*; do
             if [[ -f "$binary" && -x "$binary" ]]; then
               while IFS= read -r dep; do
                 [[ -n "$dep" ]] && DEPS_TO_PROCESS+=("$dep")
-              done < <(get_external_deps "$binary")
+              done < <(get_deps "$binary")
             fi
           done
 
@@ -560,7 +576,7 @@ jobs:
             if [[ -f "$lib" ]]; then
               while IFS= read -r dep; do
                 [[ -n "$dep" ]] && DEPS_TO_PROCESS+=("$dep")
-              done < <(get_external_deps "$lib")
+              done < <(get_deps "$lib")
             fi
           done
 
@@ -570,10 +586,8 @@ jobs:
             DEPS_TO_PROCESS=("${DEPS_TO_PROCESS[@]:1}")
 
             # Skip if already processed
-            for processed in "${PROCESSED_DEPS[@]:-}"; do
-              [[ "$dep" == "$processed" ]] && continue 2
-            done
-            PROCESSED_DEPS+=("$dep")
+            [[ -n "${PROCESSED_DEPS[$dep]:-}" ]] && continue
+            PROCESSED_DEPS[$dep]=1
 
             # Skip if not a file
             [[ ! -f "$dep" ]] && continue
@@ -584,14 +598,15 @@ jobs:
             # Skip if already exists
             [[ -f "$target" ]] && continue
 
-            echo "  Bundling: $libname"
+            echo "  Bundling: $libname (from $dep)"
             cp "$dep" "$target"
             chmod 755 "$target"
+            ORIGINAL_PATHS[$libname]="$dep"
 
-            # Check for transitive dependencies
+            # Check for transitive dependencies - scan ORIGINAL file to resolve @loader_path correctly
             while IFS= read -r transitive; do
               [[ -n "$transitive" ]] && DEPS_TO_PROCESS+=("$transitive")
-            done < <(get_external_deps "$target")
+            done < <(get_deps "$dep")
           done
 
           # Fix the bundled dylibs - set their install names and fix internal references
@@ -603,13 +618,15 @@ jobs:
               # Set the library's own install name to use @rpath
               install_name_tool -id "@rpath/$libname" "$dylib" 2>/dev/null || true
 
-              # Fix references to other libraries
-              while IFS= read -r dep; do
-                if [[ -n "$dep" ]]; then
-                  depname=$(basename "$dep")
-                  install_name_tool -change "$dep" "@rpath/$depname" "$dylib" 2>/dev/null || true
-                fi
-              done < <(get_external_deps "$dylib")
+              # Fix references to other libraries (both absolute paths and @loader_path)
+              otool -L "$dylib" 2>/dev/null | tail -n +2 | awk '{print $1}' | while read -r dep; do
+                [[ "$dep" == /usr/lib/* ]] && continue
+                [[ "$dep" == /System/* ]] && continue
+                [[ "$dep" == @rpath/* ]] && continue
+                [[ "$dep" == @executable_path/* ]] && continue
+                depname=$(basename "$dep")
+                install_name_tool -change "$dep" "@rpath/$depname" "$dylib" 2>/dev/null || true
+              done
             fi
           done
 
@@ -620,14 +637,15 @@ jobs:
               # Add rpath for finding libraries relative to executable
               install_name_tool -add_rpath "@executable_path/../lib" "$binary" 2>/dev/null || true
 
-              # Fix references to external libraries
-              while IFS= read -r dep; do
-                if [[ -n "$dep" ]]; then
-                  depname=$(basename "$dep")
-                  install_name_tool -change "$dep" "@executable_path/../lib/$depname" "$binary" 2>/dev/null || true
-                fi
-              done < <(otool -L "$binary" 2>/dev/null | tail -n +2 | awk '{print $1}' | \
-                grep -v '^/usr/lib/' | grep -v '^/System/' | grep -v '@executable_path' | grep -v '@rpath' || true)
+              # Fix references to external libraries (both absolute paths and @loader_path)
+              otool -L "$binary" 2>/dev/null | tail -n +2 | awk '{print $1}' | while read -r dep; do
+                [[ "$dep" == /usr/lib/* ]] && continue
+                [[ "$dep" == /System/* ]] && continue
+                [[ "$dep" == @rpath/* ]] && continue
+                [[ "$dep" == @executable_path/* ]] && continue
+                depname=$(basename "$dep")
+                install_name_tool -change "$dep" "@executable_path/../lib/$depname" "$binary" 2>/dev/null || true
+              done
             fi
           done
 
@@ -637,13 +655,14 @@ jobs:
             if [[ -f "$lib" ]]; then
               install_name_tool -add_rpath "@loader_path" "$lib" 2>/dev/null || true
 
-              while IFS= read -r dep; do
-                if [[ -n "$dep" ]]; then
-                  depname=$(basename "$dep")
-                  install_name_tool -change "$dep" "@rpath/$depname" "$lib" 2>/dev/null || true
-                fi
-              done < <(otool -L "$lib" 2>/dev/null | tail -n +2 | awk '{print $1}' | \
-                grep -v '^/usr/lib/' | grep -v '^/System/' | grep -v '@executable_path' | grep -v '@rpath' || true)
+              otool -L "$lib" 2>/dev/null | tail -n +2 | awk '{print $1}' | while read -r dep; do
+                [[ "$dep" == /usr/lib/* ]] && continue
+                [[ "$dep" == /System/* ]] && continue
+                [[ "$dep" == @rpath/* ]] && continue
+                [[ "$dep" == @executable_path/* ]] && continue
+                depname=$(basename "$dep")
+                install_name_tool -change "$dep" "@rpath/$depname" "$lib" 2>/dev/null || true
+              done
             fi
           done
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.12.3] - 2026-01-20
+
+### Fixed
+
+- **Missing ICU data library in macOS PostgreSQL builds**
+  - `libicudata.78.dylib` was not being bundled because ICU uses `@loader_path` references internally
+  - Updated dependency scanner to resolve `@loader_path` references relative to the source library's directory
+  - Updated path fixer to also rewrite `@loader_path` references to `@rpath`
+  - This caused `Killed: 9` errors when running PostgreSQL binaries
+
 ## [0.12.2] - 2026-01-20
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hostdb",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "Source and download pre-built database binaries for multiple platforms, distributed via GitHub Releases",
   "private": false,
   "type": "module",


### PR DESCRIPTION
…undling

- Update get_deps() function to resolve @loader_path references relative to the source file's directory
- Change PROCESSED_DEPS from array to associative array for O(1) lookup performance
- Add ORIGINAL_PATHS tracking to preserve source locations for debugging
- Scan original files (not copied targets) for transitive dependencies to correctly resolve @loader_path
- Update all otool filtering to use consistent while-rea

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request fixes critical issues with macOS PostgreSQL binary bundling by properly resolving `@loader_path` dynamic library references and improving dependency tracking during the build process.

### Key Changes

**Dependency Resolution (`get_deps()` function)**
- Introduced a new `get_deps()` function that resolves `@loader_path` references relative to each binary's source directory, fixing a core issue where library paths were not correctly resolved during bundling
- Replaced the previous `get_external_deps` approach with logic that properly handles both absolute paths and `@loader_path`/`@executable_path` references

**Improved Dependency Tracking**
- Converted `PROCESSED_DEPS` from an array to an associative array, enabling O(1) lookup performance when deduplicating dependencies during the bundling process
- Introduced `ORIGINAL_PATHS` tracking to preserve source locations of bundled libraries, aiding in debugging and relocation verification

**Transitive Dependency Resolution**
- Changed transitive dependency scanning to use original source files instead of copied targets, ensuring `@loader_path` references are correctly resolved throughout the dependency chain
- Updated all `otool` filtering to use consistent while-read implementation for robustness

**Path Rewriting for Relocatability**
- Enhanced install_name_tool logic to rewrite `@loader_path` and `@rpath`-based references appropriately for bundled dylibs and binaries
- Applied consistent path-fixing strategy across dylibs, binaries, and `.so` extension libraries

### Impact

**For PostgreSQL Builds**
- Resolves "Killed: 9" errors that occur when running PostgreSQL binaries on macOS with missing or incorrectly resolved ICU data and dynamic library dependencies
- Ensures bundled PostgreSQL is truly relocatable across different macOS systems

**For spindb and layerbase-desktop Users**
- PostgreSQL installations via spindb will now function correctly on macOS without runtime linking errors
- The desktop application's back-end database support for PostgreSQL will be more stable on macOS

### Version
- Package version bumped from 0.12.2 to 0.12.3
- Related changelog entry documents the ICU data bundling and @loader_path resolution fixes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->