### PR TITLE
fix: replace Bash 4 associative arrays with Bash 3.2-compatible imple…

### DIFF
--- a/.github/workflows/rebuild-macos-postgresql.yml
+++ b/.github/workflows/rebuild-macos-postgresql.yml
@@ -204,9 +204,17 @@ jobs:
 
           # Copy required Homebrew dylibs into our lib directory
           echo "Bundling external dependencies..."
-          declare -A PROCESSED_DEPS
-          declare -A ORIGINAL_PATHS  # Track where each lib came from
+          PROCESSED_DEPS=()
           DEPS_TO_PROCESS=()
+
+          # Helper to check if dep was already processed
+          is_processed() {
+            local check="$1"
+            for p in "${PROCESSED_DEPS[@]}"; do
+              [[ "$p" == "$check" ]] && return 0
+            done
+            return 1
+          }
 
           # Collect initial dependencies from all binaries and libraries
           for binary in postgresql/bin/*; do
@@ -231,8 +239,8 @@ jobs:
             DEPS_TO_PROCESS=("${DEPS_TO_PROCESS[@]:1}")
 
             # Skip if already processed
-            [[ -n "${PROCESSED_DEPS[$dep]:-}" ]] && continue
-            PROCESSED_DEPS[$dep]=1
+            is_processed "$dep" && continue
+            PROCESSED_DEPS+=("$dep")
 
             # Skip if not a file
             [[ ! -f "$dep" ]] && continue
@@ -246,7 +254,6 @@ jobs:
             echo "  Bundling: $libname (from $dep)"
             cp "$dep" "$target"
             chmod 755 "$target"
-            ORIGINAL_PATHS[$libname]="$dep"
 
             # Check for transitive dependencies - scan ORIGINAL file to resolve @loader_path correctly
             while IFS= read -r transitive; do

--- a/.github/workflows/release-postgresql.yml
+++ b/.github/workflows/release-postgresql.yml
@@ -559,9 +559,17 @@ jobs:
 
           # Copy required Homebrew dylibs into our lib directory
           echo "Bundling external dependencies..."
-          declare -A PROCESSED_DEPS
-          declare -A ORIGINAL_PATHS  # Track where each lib came from
+          PROCESSED_DEPS=()
           DEPS_TO_PROCESS=()
+
+          # Helper to check if dep was already processed
+          is_processed() {
+            local check="$1"
+            for p in "${PROCESSED_DEPS[@]}"; do
+              [[ "$p" == "$check" ]] && return 0
+            done
+            return 1
+          }
 
           # Collect initial dependencies from all binaries and libraries
           for binary in postgresql/bin/*; do
@@ -586,8 +594,8 @@ jobs:
             DEPS_TO_PROCESS=("${DEPS_TO_PROCESS[@]:1}")
 
             # Skip if already processed
-            [[ -n "${PROCESSED_DEPS[$dep]:-}" ]] && continue
-            PROCESSED_DEPS[$dep]=1
+            is_processed "$dep" && continue
+            PROCESSED_DEPS+=("$dep")
 
             # Skip if not a file
             [[ ! -f "$dep" ]] && continue
@@ -601,7 +609,6 @@ jobs:
             echo "  Bundling: $libname (from $dep)"
             cp "$dep" "$target"
             chmod 755 "$target"
-            ORIGINAL_PATHS[$libname]="$dep"
 
             # Check for transitive dependencies - scan ORIGINAL file to resolve @loader_path correctly
             while IFS= read -r transitive; do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.12.4] - 2026-01-20
+
+### Fixed
+
+- **Bash 3.2 compatibility for macOS builds**
+  - Removed `declare -A` (associative arrays) which requires Bash 4+
+  - macOS ships with Bash 3.2; GitHub Actions macOS runners use system bash
+  - Replaced with regular arrays and helper function for linear search
+
 ## [0.12.3] - 2026-01-20
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hostdb",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "Source and download pre-built database binaries for multiple platforms, distributed via GitHub Releases",
   "private": false,
   "type": "module",


### PR DESCRIPTION
…mentation

- Remove `declare -A PROCESSED_DEPS` (requires Bash 4+, not available on macOS default Bash 3.2)
- Replace associative array with regular array and `is_processed()` helper function for O(n) lookup
- Remove unused `ORIGINAL_PATHS` tracking array
- Update both rebuild-macos-postgresql.yml and release-postgresql.yml workflows
- Update version to 0.12.4 and add CHANGELOG entry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Pull Request Summary: Bash 3.2 Compatibility Fix

## Overview
This PR replaces Bash 4+ associative arrays with Bash 3.2-compatible implementations across the hostdb project's PostgreSQL build and release workflows, addressing compatibility issues with macOS's default Bash version.

## Changes Made

**Workflow Files Updated:**
- `.github/workflows/rebuild-macos-postgresql.yml`
- `.github/workflows/release-postgresql.yml`

**Key Technical Changes:**
- Removed `declare -A PROCESSED_DEPS` associative array declarations that require Bash 4+
- Introduced a new `is_processed()` helper function that performs O(n) linear searches to check if a dependency has already been processed
- Replaced associative array lookups with simple array operations (`PROCESSED_DEPS+=()`)
- Removed the `ORIGINAL_PATHS` tracking associative array that was used to store library source locations
- Updated dependency processing loops to use the new linear search approach

**Version & Documentation:**
- Bumped version in `package.json` from 0.12.3 to 0.12.4
- Added changelog entry documenting the fix

## Motivation
macOS systems ship with Bash 3.2 by default, while GitHub Actions runners use the system bash. The previous implementation's use of associative arrays (a Bash 4+ feature) prevented the workflows from executing on macOS runners with default Bash.

## Impact Assessment
- **Scope**: Changes are limited to GitHub Actions workflow execution environments; no changes to npm package exports or public APIs
- **Performance Trade-off**: Replaces O(1) associative array lookups with O(n) linear searches in the helper function. This is acceptable given the workflows process a small, bounded set of dependencies
- **Compatibility**: Enables workflows to run on systems with Bash 3.2, including macOS runners
- **Related Projects**: These workflows compile and release PostgreSQL binaries used by the spindb package; changes ensure build reliability across supported platforms

## Testing Considerations
The workflows are integration-heavy (compiling PostgreSQL binaries), so changes should be validated by executing the workflows in a CI environment rather than local testing alone.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->