### PR TITLE
fix: re-sign macOS PostgreSQL binaries after install_name_tool modifi…

### DIFF
--- a/.github/workflows/rebuild-macos-postgresql.yml
+++ b/.github/workflows/rebuild-macos-postgresql.yml
@@ -318,6 +318,21 @@ jobs:
             fi
           done
 
+          # Re-sign all modified binaries and libraries with ad-hoc signatures
+          # install_name_tool invalidates existing code signatures, causing macOS to kill the process
+          echo "Re-signing binaries and libraries..."
+          for dylib in postgresql/lib/*.dylib; do
+            if [[ -f "$dylib" ]]; then
+              codesign --force --sign - "$dylib" 2>/dev/null || true
+            fi
+          done
+          for binary in postgresql/bin/*; do
+            if [[ -f "$binary" && -x "$binary" ]]; then
+              codesign --force --sign - "$binary" 2>/dev/null || true
+            fi
+          done
+          echo "✓ Re-signed all binaries and libraries"
+
           # Verify no hardcoded paths remain
           echo "Verifying relocatable binaries..."
           FAILED=0

--- a/.github/workflows/release-postgresql.yml
+++ b/.github/workflows/release-postgresql.yml
@@ -673,6 +673,21 @@ jobs:
             fi
           done
 
+          # Re-sign all modified binaries and libraries with ad-hoc signatures
+          # install_name_tool invalidates existing code signatures, causing macOS to kill the process
+          echo "Re-signing binaries and libraries..."
+          for dylib in postgresql/lib/*.dylib; do
+            if [[ -f "$dylib" ]]; then
+              codesign --force --sign - "$dylib" 2>/dev/null || true
+            fi
+          done
+          for binary in postgresql/bin/*; do
+            if [[ -f "$binary" && -x "$binary" ]]; then
+              codesign --force --sign - "$binary" 2>/dev/null || true
+            fi
+          done
+          echo "✓ Re-signed all binaries and libraries"
+
           # Verify no hardcoded paths remain
           echo "Verifying relocatable binaries..."
           FAILED=0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.12.5] - 2026-01-20
+
+### Fixed
+
+- **Invalid code signatures on macOS PostgreSQL binaries**
+  - `install_name_tool` invalidates existing code signatures when modifying libraries
+  - macOS kills processes that load libraries with invalid signatures ("Killed: 9")
+  - Added `codesign --force --sign -` step to re-sign all modified dylibs and binaries with ad-hoc signatures
+
 ## [0.12.4] - 2026-01-20
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hostdb",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "Source and download pre-built database binaries for multiple platforms, distributed via GitHub Releases",
   "private": false,
   "type": "module",


### PR DESCRIPTION
…cations

- Add codesign step to re-sign all dylibs and binaries with ad-hoc signatures after install_name_tool modifications
- install_name_tool invalidates existing code signatures, causing macOS to kill processes with "Killed: 9"
- Apply to both rebuild-macos-postgresql.yml and release-postgresql.yml workflows
- Update version to 0.12.5 and add CHANGELOG entry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Re-sign macOS PostgreSQL Binaries After Code Signature Invalidation

### Problem
When GitHub Actions workflows modify macOS PostgreSQL binaries and libraries using `install_name_tool` to adjust hardcoded library paths, the operation invalidates existing code signatures. On macOS, processes attempting to load libraries with invalid signatures are terminated immediately by the system with exit code 9 ("Killed: 9"), preventing PostgreSQL from running correctly.

### Solution
This PR adds explicit code re-signing steps to restore code signature validity after path modifications. The fix applies `codesign --force --sign -` with ad-hoc signatures to all modified dylibs and executables:
- Re-signs all files in `postgresql/lib/*.dylib`
- Re-signs all executable files in `postgresql/bin/*`
- Gracefully handles files that may not require signing or fail during the process (using `2>/dev/null || true`)
- Runs after path modifications and before binary relocation verification

### Changes Made
1. **`.github/workflows/rebuild-macos-postgresql.yml`**: Adds 15-line codesign step in the PostgreSQL rebuild workflow
2. **`.github/workflows/release-postgresql.yml`**: Adds identical 15-line codesign step in the PostgreSQL release workflow
3. **`CHANGELOG.md`**: Documents the fix in version 0.12.5 entry with explanation of the root cause
4. **`package.json`**: Bumps hostdb version from 0.12.4 to 0.12.5

### Impact
This fix ensures that PostgreSQL binaries distributed by hostdb can be executed on macOS without process termination due to invalid signatures. Since spindb depends on hostdb to obtain precompiled database binaries, this resolves a critical issue where spindb's PostgreSQL installations on macOS would fail at runtime with "Killed: 9" errors. The fix applies consistently to both rebuild and release workflows, ensuring reliability across all distribution mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->