### PR TITLE
docs: add BINARIES.md archive structure reference and bump version to…

### DIFF
--- a/BINARIES.md
+++ b/BINARIES.md
@@ -1,0 +1,152 @@
+# Binary Structure Reference
+
+Archive structure for each database distributed by hostdb.
+
+## Archive Contents
+
+| Database | Root Directory | Root Contents | Server | Client |
+|----------|----------------|---------------|--------|--------|
+| MySQL | `mysql/` | `bin/` `lib/` `share/` `LICENSE` `.hostdb-metadata.json` | `bin/mysqld` | `bin/mysql` |
+| PostgreSQL | `postgresql/` | `bin/` `lib/` `share/` `.hostdb-metadata.json` | `bin/postgres` | `bin/psql` |
+| MariaDB | `mariadb/` | `bin/` `lib/` `share/` `man/` `.hostdb-metadata.json` | `bin/mariadbd` | `bin/mariadb` |
+| MongoDB | `mongodb/` | `bin/` `.hostdb-metadata.json` | `bin/mongod` | `bin/mongosh` |
+| Redis | `redis/` | `bin/` `.hostdb-metadata.json` | `bin/redis-server` | `bin/redis-cli` |
+| Valkey | `valkey/` | `bin/` `.hostdb-metadata.json` | `bin/valkey-server` | `bin/valkey-cli` |
+| SQLite | `sqlite/` | `bin/` `.hostdb-metadata.json` | — | `bin/sqlite3` |
+| DuckDB | `duckdb/` | `duckdb` `.hostdb-metadata.json` | — | `duckdb` |
+| ClickHouse | `clickhouse/` | `bin/` `.hostdb-metadata.json` | `bin/clickhouse` | `bin/clickhouse` |
+| Qdrant | `qdrant/` | `qdrant` `.hostdb-metadata.json` | `qdrant` | — (HTTP) |
+| Meilisearch | `meilisearch/` | `meilisearch` `.hostdb-metadata.json` | `meilisearch` | — (HTTP) |
+
+## Detailed Structure
+
+### Multi-file (bin/ subdirectory)
+
+```
+mysql/
+├── bin/
+│   ├── mysqld
+│   ├── mysql
+│   ├── mysqldump
+│   └── ...
+├── lib/
+├── share/
+└── .hostdb-metadata.json
+
+postgresql/
+├── bin/
+│   ├── postgres
+│   ├── psql
+│   ├── pg_dump
+│   └── ...
+├── lib/
+├── share/
+└── .hostdb-metadata.json
+
+mariadb/
+├── bin/
+│   ├── mariadbd
+│   ├── mariadb
+│   ├── mariadb-dump
+│   └── ...
+├── lib/
+├── share/
+└── .hostdb-metadata.json
+
+mongodb/
+├── bin/
+│   ├── mongod
+│   ├── mongosh
+│   ├── mongodump
+│   ├── mongorestore
+│   └── ...
+└── .hostdb-metadata.json
+
+redis/
+├── bin/
+│   ├── redis-server
+│   ├── redis-cli
+│   └── redis-benchmark
+└── .hostdb-metadata.json
+
+valkey/
+├── bin/
+│   ├── valkey-server
+│   ├── valkey-cli
+│   └── valkey-benchmark
+└── .hostdb-metadata.json
+
+sqlite/
+├── bin/
+│   ├── sqlite3
+│   ├── sqldiff
+│   └── sqlite3_analyzer
+└── .hostdb-metadata.json
+
+clickhouse/
+├── bin/
+│   ├── clickhouse           # monolithic binary
+│   ├── clickhouse-server -> clickhouse
+│   ├── clickhouse-client -> clickhouse
+│   └── clickhouse-local -> clickhouse
+└── .hostdb-metadata.json
+```
+
+### Single binary (no bin/ subdirectory)
+
+```
+duckdb/
+├── duckdb                   # or duckdb.exe on Windows
+└── .hostdb-metadata.json
+
+qdrant/
+├── qdrant                   # or qdrant.exe on Windows
+└── .hostdb-metadata.json
+
+meilisearch/
+├── meilisearch              # or meilisearch.exe on Windows
+└── .hostdb-metadata.json
+```
+
+## Archive Formats
+
+| Platform | Format | Extension |
+|----------|--------|-----------|
+| linux-x64 | gzip tarball | `.tar.gz` |
+| linux-arm64 | gzip tarball | `.tar.gz` |
+| darwin-x64 | gzip tarball | `.tar.gz` |
+| darwin-arm64 | gzip tarball | `.tar.gz` |
+| win32-x64 | zip | `.zip` |
+
+**Exception:** ClickHouse has no Windows support (use WSL).
+
+## Metadata File
+
+Every archive includes `.hostdb-metadata.json`:
+
+```json
+{
+  "name": "mysql",
+  "version": "8.4.3",
+  "platform": "darwin-arm64",
+  "source": "official",
+  "rehosted_by": "hostdb",
+  "rehosted_at": "2024-01-15T10:30:00Z"
+}
+```
+
+## Quick Reference
+
+| Database | Has `bin/` subdir | Binary count | Client type |
+|----------|-------------------|--------------|-------------|
+| MySQL | Yes | Many | CLI (`mysql`) |
+| PostgreSQL | Yes | Many | CLI (`psql`) |
+| MariaDB | Yes | Many | CLI (`mariadb`) |
+| MongoDB | Yes | Many | CLI (`mongosh`) |
+| Redis | Yes | Few | CLI (`redis-cli`) |
+| Valkey | Yes | Few | CLI (`valkey-cli`) |
+| SQLite | Yes | Few | CLI (`sqlite3`) |
+| DuckDB | No | 1 | CLI (`duckdb`) |
+| ClickHouse | Yes | 1 + symlinks | CLI (`clickhouse client`) |
+| Qdrant | No | 1 | HTTP API only |
+| Meilisearch | No | 1 | HTTP API only |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,6 +229,8 @@ Then follow the printed instructions to implement the download logic.
 
 See [CHECKLIST.md](./CHECKLIST.md) for the complete checklist.
 
+See [BINARIES.md](./BINARIES.md) for archive structure reference (top-level dirs, binary locations, single vs multi-file).
+
 **Windows builds:** If no official Windows binary exists, see [WINDOWS_BUILD.md](./WINDOWS_BUILD.md) for strategies (Cygwin, MSYS2 CLANG64, cross-compilation, etc.).
 
 ### Download Script Requirements

--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ pnpm add:engine sqlite   # Then follow printed instructions
 ## Documentation
 
 - [ARCHITECTURE.md](./ARCHITECTURE.md) - Visual representation of how this repo works
+- [BINARIES.md](./BINARIES.md) - Archive structure reference for each database
 - [CHECKLIST.md](./CHECKLIST.md) - Checklist for adding a new database
 
 ## TODO

--- a/builds/meilisearch/download.ts
+++ b/builds/meilisearch/download.ts
@@ -22,6 +22,8 @@ import {
   copyFileSync,
   rmSync,
   chmodSync,
+  renameSync,
+  unlinkSync,
 } from 'node:fs'
 import { createHash } from 'node:crypto'
 import { resolve, dirname, basename } from 'node:path'
@@ -189,7 +191,6 @@ async function downloadFile(url: string, destPath: string): Promise<void> {
     })
 
     // Rename temp file to final destination
-    const { renameSync } = await import('node:fs')
     renameSync(tempPath, destPath)
 
     console.log()
@@ -207,7 +208,6 @@ async function downloadFile(url: string, destPath: string): Promise<void> {
       // Ignore cancel errors
     }
     try {
-      const { unlinkSync } = await import('node:fs')
       if (existsSync(tempPath)) {
         unlinkSync(tempPath)
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hostdb",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Source and download pre-built database binaries for multiple platforms, distributed via GitHub Releases",
   "private": false,
   "type": "module",


### PR DESCRIPTION
… 0.13.1

- Add BINARIES.md documenting archive structure for all databases (root directories, binary locations, single vs multi-file layouts)
- Include tables for archive contents, detailed structure examples, archive formats by platform, and metadata file format
- Reference BINARIES.md in CLAUDE.md and README.md documentation sections
- Move renameSync and unlinkSync imports to top of builds/meilisearch/download.ts (no functional

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR documents the binary archive structure for all databases distributed by hostdb and performs a minor code cleanup.

### Key Changes

**Documentation (BINARIES.md)**
- Creates a comprehensive reference documenting the archive structure for each of the 11 supported databases (MySQL, PostgreSQL, MariaDB, MongoDB, Redis, Valkey, SQLite, DuckDB, ClickHouse, Qdrant, Meilisearch)
- Includes a table with root directories, archive contents, and binary locations for each database
- Provides detailed directory tree examples showing:
  - Multi-file layouts with `bin/`, `lib/`, `share/` subdirectories (MySQL, PostgreSQL, MariaDB, MongoDB, Redis, Valkey, SQLite, ClickHouse)
  - Single-binary layouts without `bin/` subdirectories (DuckDB, Qdrant, Meilisearch)
- Documents the `.hostdb-metadata.json` file included in all archives
- References Windows/WSL considerations for certain binaries

**Documentation References**
- CLAUDE.md: Added reference to BINARIES.md for archive structure information
- README.md: Added link to BINARIES.md in the Documentation section

**Code Cleanup**
- `builds/meilisearch/download.ts`: Moved `renameSync` and `unlinkSync` from dynamic imports to top-level imports from `node:fs` (no functional change to logic or error handling)

**Version Bump**
- Updated package.json version from 0.13.0 to 0.13.1 (patch release)

### Impact on Related Projects

This documentation addition benefits spindb and layerbase-desktop users by providing clear guidance on the binary archive structure they will encounter when downloading and unpacking databases through hostdb. The code cleanup in the meilisearch download script has no functional impact. No breaking changes or new functionality affecting downstream consumers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->