### PR TITLE
fix: resolve PostgreSQL-DocumentDB Docker extraction symlink failures…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.14.2] - 2026-01-23
+
+### Fixed
+
+- **PostgreSQL-DocumentDB Docker extraction failing on symlinks**
+  - `docker cp` fails with "invalid symlink" when copying files that contain symlinks pointing outside the copied directory
+  - Changed extraction to use `docker run` with a shell script that uses `cp -L` to dereference symlinks
+  - Creates proper bundle structure: bin/, lib/, share/extension/
+
 ## [0.14.1] - 2026-01-23
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hostdb",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Source and download pre-built database binaries for multiple platforms, distributed via GitHub Releases",
   "private": false,
   "type": "module",


### PR DESCRIPTION
… and bump version to 0.14.2

- Change Docker extraction from `docker cp` to `docker run` with shell script using `cp -L` to dereference symlinks
- Create proper bundle structure (bin/, lib/, share/extension/) by extracting via tarball
- Add intermediate tarball creation and cleanup to handle symlinks that point outside copied directories
- Update CHANGELOG.md with version 0.14.2 entry documenting symlink fix
- Update package.json version from 0.