### PR TITLE
chore: bump version to 0.14.7 and fix PostgreSQL-DocumentDB macOS bui…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.14.7] - 2026-01-23
+
+### Fixed
+
+- **PostgreSQL-DocumentDB macOS build - missing headers**
+  - Added `icu4c` dependency for `unicode/ures.h`
+  - Set up include paths for libbson (`bson.h`) and ICU via CFLAGS/CPPFLAGS
+  - Export PKG_CONFIG_PATH for proper dependency discovery
+
 ## [0.14.6] - 2026-01-23
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hostdb",
-  "version": "0.14.6",
+  "version": "0.14.7",
   "description": "Source and download pre-built database binaries for multiple platforms, distributed via GitHub Releases",
   "private": false,
   "type": "module",


### PR DESCRIPTION
…ld missing headers

- Add version 0.14.7 entry to CHANGELOG.md documenting missing header fixes
- Add `icu4c` dependency for `unicode/ures.h` header
- Set up include paths for libbson (`bson.h`) and ICU via CFLAGS/CPPFLAGS
- Export PKG_CONFIG_PATH for proper dependency discovery
- Update package.json version from 0.14.6 to 0.14.7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## chore: bump version to 0.14.7 and fix PostgreSQL-DocumentDB macOS build missing headers

This PR addresses macOS build failures for PostgreSQL-DocumentDB binaries by resolving missing header dependencies and updating the version accordingly.

### Changes

**CHANGELOG.md** - Added version 0.14.7 entry documenting the fixes for PostgreSQL-DocumentDB macOS build issues.

**builds/postgresql-documentdb/build-macos.sh** - Enhanced the macOS build process:
- Added `icu4c` to the brew install dependencies to provide Unicode support headers
- Set `MONGO_C_PREFIX` and `ICU_PREFIX` from brew package paths
- Configured `PKG_CONFIG_PATH`, `CPPFLAGS`, `CFLAGS`, and `LDFLAGS` environment variables for proper dependency discovery
- Extended `EXTRA_CFLAGS` to include `-I` paths for libbson headers from mongo-c-driver and ICU headers
- Added logging of build configuration for transparency

**package.json** - Bumped version from 0.14.6 to 0.14.7.

### Impact

These changes ensure that PostgreSQL-DocumentDB binaries can be successfully compiled on macOS, resolving header resolution errors (notably `unicode/ures.h` and `bson.h`) that were preventing the build. This fix affects the binary distributions released through hostdb, which are consumed by downstream tools like spindb and layerbase-desktop.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->