### PR TITLE
fix: create fake libbson-static-1.0.pc for PostgreSQL-DocumentDB macO…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.14.8] - 2026-01-23
+
+### Fixed
+
+- **PostgreSQL-DocumentDB macOS build - libbson-static-1.0 not found**
+  - DocumentDB Makefile uses `pkg-config --cflags libbson-static-1.0`
+  - Homebrew only provides dynamic libbson-1.0, not static
+  - Create fake `libbson-static-1.0.pc` pkgconfig file pointing to Homebrew paths
+
 ## [0.14.7] - 2026-01-23
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hostdb",
-  "version": "0.14.7",
+  "version": "0.14.9",
   "description": "Source and download pre-built database binaries for multiple platforms, distributed via GitHub Releases",
   "private": false,
   "type": "module",


### PR DESCRIPTION
…S build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR resolves a PostgreSQL-DocumentDB macOS build issue where the DocumentDB Makefile cannot locate the static libbson library (`libbson-static-1.0`) via pkg-config, even though Homebrew only provides the dynamic variant.

## Changes Made

**builds/postgresql-documentdb/build-macos.sh**
- Created a fake `libbson-static-1.0.pc` pkgconfig file that points to Homebrew's mongo-c-driver library paths
- Established a dedicated `pkgconfig` directory in the build path to host the fake pkgconfig file
- Extended `PKG_CONFIG_PATH` to prioritize the newly created pkgconfig directory, followed by Homebrew paths for mongo-c-driver and icu4c
- Updated logging to report the creation of the fake pkgconfig file

**CHANGELOG.md**
- Added entry for version 0.14.8 documenting the fix for the libbson discovery issue on macOS

**package.json**
- Bumped version from 0.14.7 to 0.14.9

## Technical Details

The fix addresses a platform-specific incompatibility: DocumentDB's PostgreSQL extension Makefile uses `pkg-config --cflags libbson-static-1.0` to locate build dependencies, but Homebrew's mongo-c-driver only provides the dynamic `libbson-1.0` library. By creating a synthetic pkgconfig entry, the build system can successfully discover and link against the available library. The fake .pc file provides appropriate include and library directories from the Homebrew installation.

## Impact

This change is localized to the hostdb macOS PostgreSQL-DocumentDB build pipeline and should not affect spindb or layerbase-desktop directly. However, as hostdb provides the compiled binaries for spindb consumption, successful builds in hostdb are essential for spindb's functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->