### PR TITLE
fix: build mongo-c-driver from source for Linux postgresql-documentdb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.14.17] - 2026-01-24
+
+### Fixed
+
+- **Linux postgresql-documentdb builds: build mongo-c-driver from source**
+  - Debian bookworm's libbson-dev is too old for DocumentDB v0.107.0 (missing `BSON_SUBTYPE_SENSITIVE`)
+  - Build mongo-c-driver 1.29.0 from source to get a compatible libbson
+  - Add error visibility for pg_documentdb build failures
+
+- **Linux build script: fix RPATH loop with pipefail**
+  - Use process substitution instead of pipe to avoid `set -eo pipefail` issues
+
 ## [0.14.16] - 2026-01-24
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hostdb",
-  "version": "0.14.16",
+  "version": "0.14.17",
   "description": "Source and download pre-built database binaries for multiple platforms, distributed via GitHub Releases",
   "private": false,
   "type": "module",


### PR DESCRIPTION
## Summary

- Build mongo-c-driver 1.29.0 from source instead of using Debian's old libbson-dev
- Debian bookworm's libbson is too old for DocumentDB v0.107.0 (missing `BSON_SUBTYPE_SENSITIVE`)
- Fix RPATH loops to use process substitution for `set -eo pipefail` compatibility

## Test plan

- [x] Local Docker build verified with smoke test
- [x] Postgres binary runs and shows correct version
- [x] ldd shows no missing dependencies
- [ ] GitHub Actions linux-x64 build
- [ ] SpinDB Docker E2E test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR fixes Linux PostgreSQL DocumentDB builds by compiling mongo-c-driver 1.29.0 from source instead of relying on Debian Bookworm's outdated libbson-dev package. It also resolves RPATH handling issues with shell pipefail mode.

## Technical Problem
Debian Bookworm's libbson-dev package lacks the BSON_SUBTYPE_SENSITIVE constant required by DocumentDB v0.107.0, causing build failures on Linux. Additionally, the existing build script's RPATH loop logic was incompatible with `set -eo pipefail`.

## Changes

### Build Configuration (builds/postgresql-documentdb/build-linux.sh)
- Replaces libbson-dev with cmake in host build dependencies
- Adds mongo-c-driver 1.29.0 source build step with configure, make, and install
- Extends compiler flags to reference the newly built libbson:
  - CPPFLAGS: adds `-I/build/mongo-c-driver/include/libbson-1.0`
  - LDFLAGS: adds `-L/build/mongo-c-driver/lib`
  - ICU_LINK: adds `-lbson-1.0`
- Uses process substitution to fix RPATH patching logic for pipefail compatibility
- Enhances error handling with targeted error messages and fast-fail semantics
- Adds verbose progress messages for build steps and library bundling

### Version Updates
- Bumps package.json from 0.14.16 to 0.14.17
- Adds changelog entry documenting the libbson source build fix and RPATH pipefail resolution

## Testing Status
- ✅ Local Docker build with smoke test: passed
- ✅ Postgres binary version verification: passed
- ✅ ldd dependency check: passed
- ⏳ GitHub Actions linux-x64 build: pending
- ⏳ SpinDB Docker E2E test: pending

## Impact Assessment
This change is specific to Linux PostgreSQL DocumentDB binaries and should not affect other database compilations. However, users of spindb and layerbase-desktop depend on hostdb for binary distribution, so successful E2E testing is critical to ensure no regressions in those applications.

## Risk Mitigation
The source build approach trades build time for compatibility certainty, ensuring consistent BSON support across distributions. Error handling improvements provide better diagnostics for future troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->