### PR TITLE
fix: use direct file check for DocumentDB extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.14.18] - 2026-01-25
+
+### Fixed
+
+- **Linux build: fix DocumentDB extension check**
+  - Use direct file existence check instead of `ls | grep` for reliability
+
 ## [0.14.17] - 2026-01-24
 
 ### Fixed

--- a/builds/postgresql-documentdb/build-linux.sh
+++ b/builds/postgresql-documentdb/build-linux.sh
@@ -531,10 +531,13 @@ fi
 if [[ -d "${BUNDLE_DIR}/share/extension" ]]; then
     CTRL_FILES=$(ls "${BUNDLE_DIR}/share/extension" 2>/dev/null | grep '\.control$' | tr '\n' ' ' || true)
     echo "  extensions (*.control): ${CTRL_FILES}"
-    if ls "${BUNDLE_DIR}/share/extension" 2>/dev/null | grep -q 'documentdb'; then
+    # Check for DocumentDB files directly
+    if [[ -f "${BUNDLE_DIR}/share/extension/documentdb.control" ]] && \
+       [[ -f "${BUNDLE_DIR}/share/extension/documentdb_core.control" ]]; then
         echo "[OK] DocumentDB extension files present"
     else
         echo "[ERROR] DocumentDB extension files MISSING!"
+        ls -la "${BUNDLE_DIR}/share/extension/" 2>/dev/null | head -20 || true
         exit 1
     fi
 fi

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hostdb",
-  "version": "0.14.17",
+  "version": "0.14.18",
   "description": "Source and download pre-built database binaries for multiple platforms, distributed via GitHub Releases",
   "private": false,
   "type": "module",


### PR DESCRIPTION
Use -f to check for files directly instead of ls | grep which was failing on CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fix: Use Direct File Check for DocumentDB Extension

This PR resolves a CI build failure in the Linux DocumentDB extension build process by replacing an unreliable pipe-based approach with a direct file existence check.

**Problem:**
The build script for the PostgreSQL DocumentDB extension was using `ls | grep` to verify the presence of DocumentDB extension files. This approach was failing inconsistently during CI runs—a known fragility in shell scripting where pipes can fail unexpectedly in automated environments.

**Solution:**
- Replaced the `ls | grep` pattern with explicit `-f` file existence tests
- The updated script now directly checks for two specific required files:
  - `share/extension/documentdb.control`
  - `share/extension/documentdb_core.control`
- If both files are present, the build logs "OK" and continues
- If either file is missing, the script logs an error, displays the extension directory contents for debugging, and exits immediately

**Changes Made:**
- `builds/postgresql-documentdb/build-linux.sh`: Updated from a broad presence check to precise file-existence verification with better error diagnostics
- `package.json`: Version bump from 0.14.17 to 0.14.18
- `CHANGELOG.md`: Added entry documenting the Linux build fix under the Fixed section for v0.14.18

**Impact:**
This fix improves the reliability of hostdb binary builds on Linux CI systems, ensuring more stable and predictable binary releases for downstream consumers including spindb and layerbase-desktop. The explicit file check is more maintainable and easier to debug than pipe-based approaches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->