### PR TITLE
fix: don't bundle C/C++ runtime libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.14.19] - 2026-01-25
+
+### Fixed
+
+- **Linux build: don't bundle C/C++ runtime libraries**
+  - Exclude libstdc++, libgfortran, libquadmath from bundling
+  - These are tightly coupled with glibc and should use the system version
+  - Fixes glibc version mismatch errors on older systems (Ubuntu 22.04)
+
 ## [0.14.18] - 2026-01-25
 
 ### Fixed

--- a/builds/postgresql-documentdb/build-linux.sh
+++ b/builds/postgresql-documentdb/build-linux.sh
@@ -366,11 +366,19 @@ BUNDLE_LIB="${BUNDLE_DIR}/lib"
 PROCESSED_LIBS="/tmp/processed_libs.txt"
 : > "${PROCESSED_LIBS}"
 
-# System libraries that should NOT be bundled (glibc, kernel interfaces)
+# System libraries that should NOT be bundled (glibc, kernel interfaces, C++ runtime)
+# These are tightly coupled with glibc and should use the system version
 is_system_lib() {
     local lib="$1"
     case "$lib" in
-        linux-vdso.so*|ld-linux*.so*|libc.so*|libm.so*|libdl.so*|libpthread.so*|librt.so*|libresolv.so*|libnss_*.so*|libgcc_s.so*)
+        # Core glibc
+        linux-vdso.so*|ld-linux*.so*|libc.so*|libm.so*|libdl.so*|libpthread.so*|librt.so*|libresolv.so*)
+            return 0 ;;
+        # NSS (name service switch) - always use system
+        libnss_*.so*)
+            return 0 ;;
+        # C/C++ runtime - tightly coupled with glibc
+        libgcc_s.so*|libstdc++.so*|libgfortran.so*|libquadmath.so*)
             return 0 ;;
         *)
             return 1 ;;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hostdb",
-  "version": "0.14.18",
+  "version": "0.14.19",
   "description": "Source and download pre-built database binaries for multiple platforms, distributed via GitHub Releases",
   "private": false,
   "type": "module",


### PR DESCRIPTION
Exclude libstdc++, libgfortran, libquadmath from bundling. These are tightly coupled with glibc and cause version mismatch on older systems like Ubuntu 22.04.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes a critical issue with Linux builds by preventing C/C++ runtime libraries from being bundled with the binary distribution. These libraries (libstdc++, libgfortran, libquadmath) are tightly coupled with glibc and bundling them causes version mismatches on systems with older glibc versions, particularly Ubuntu 22.04.

## Changes

### Build Script Enhancement (`builds/postgresql-documentdb/build-linux.sh`)
Updated the `is_system_lib()` function to exclude C/C++ runtime libraries from bundling:
- Added explicit recognition of libgcc_s.so*, libstdc++.so*, libgfortran.so*, and libquadmath.so* as system libraries
- Reorganized the function with clearer comments categorizing libraries into: core glibc, NSS (name service switch), and C/C++ runtime groups
- Maintains existing glibc library exclusions (linux-vdso, ld-linux, libc, libm, libdl, libpthread, librt, libresolv)

### Documentation (`CHANGELOG.md`)
Added version 0.14.19 entry documenting the fix with explanation that these libraries should use the system version to avoid glibc version mismatch errors on older systems.

### Version Bump
Updated package.json version from 0.14.18 to 0.14.19.

## Impact

- **Improves compatibility** with older Linux systems by ensuring system glibc versions are paired with system C/C++ runtime versions
- **Reduces binary size** by not redundantly bundling libraries already present on the system
- **Affects PostgreSQL-DocumentDB binaries** distributed for Linux platforms (linux-x64 and linux-arm64)
- **Upstream effects**: Since hostdb is used as a backend package by spindb and referenced by layerbase-desktop, this fix improves the compatibility of both projects on older Linux systems

## Technical Details

The fix addresses a fundamental incompatibility: glibc and the C/C++ runtime libraries are compiled together and interdependent. When newer versions are bundled with systems running older glibc, runtime errors occur due to symbol version mismatches. By excluding these from the bundle, the system's pre-installed versions (which match the installed glibc) are used instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->