### PR TITLE
Dev

### DIFF
--- a/.github/workflows/release-couchdb.yml
+++ b/.github/workflows/release-couchdb.yml
@@ -1,0 +1,496 @@
+name: Release CouchDB
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'CouchDB version'
+        required: true
+        type: choice
+        options:
+          - 3.5.1
+        default: 3.5.1
+      platforms:
+        description: 'Platforms to build'
+        required: true
+        default: 'all'
+        type: choice
+        options:
+          - 'all'
+          - 'linux-x64'
+          - 'linux-arm64'
+          - 'darwin-x64'
+          - 'darwin-arm64'
+          - 'win32-x64'
+
+# Prevent concurrent runs that could conflict when updating releases.json
+concurrency:
+  group: release-couchdb
+  cancel-in-progress: false
+
+jobs:
+  # Validate version against databases.json
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate version against databases.json
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          DB="couchdb"
+
+          echo "Validating CouchDB version: $VERSION"
+
+          # Check if version exists and is enabled in databases.json
+          ENABLED=$(jq -r ".databases.$DB.versions[\"$VERSION\"] // false" databases.json)
+          if [ "$ENABLED" != "true" ]; then
+            echo "::error::Version '$VERSION' is not enabled in databases.json"
+            echo ""
+            echo "Available versions:"
+            jq -r ".databases.$DB.versions | to_entries | map(select(.value == true)) | .[].key" databases.json
+            exit 1
+          fi
+
+          echo "✓ Version $VERSION is enabled in databases.json"
+
+      - name: Validate sources.json exists
+        run: |
+          DB="couchdb"
+          if [ ! -f "builds/$DB/sources.json" ]; then
+            echo "::error::Missing builds/$DB/sources.json"
+            exit 1
+          fi
+          echo "✓ builds/$DB/sources.json exists"
+
+      - name: Validate version in sources.json
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          DB="couchdb"
+
+          HAS_VERSION=$(jq -r ".versions[\"$VERSION\"] // empty" "builds/$DB/sources.json")
+          if [ -z "$HAS_VERSION" ]; then
+            echo "::error::Version '$VERSION' not found in builds/$DB/sources.json"
+            echo ""
+            echo "Available versions in sources.json:"
+            jq -r ".versions | keys[]" "builds/$DB/sources.json"
+            exit 1
+          fi
+
+          echo "✓ Version $VERSION found in sources.json"
+
+  # Determine which platforms to build based on input
+  prepare:
+    needs: validate
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Set build matrix
+        id: set-matrix
+        run: |
+          PLATFORMS="${{ github.event.inputs.platforms }}"
+          if [ "$PLATFORMS" = "all" ]; then
+            # All 5 platforms with their appropriate runners and build types
+            # - Linux: Docker extraction from official CouchDB image
+            # - macOS: Download from Neighbourhoodie
+            # - Windows: Download MSI and extract on Windows runner
+            MATRIX='[
+              {"platform": "linux-x64", "runner": "ubuntu-latest", "build_type": "docker"},
+              {"platform": "linux-arm64", "runner": "ubuntu-latest", "build_type": "docker"},
+              {"platform": "darwin-x64", "runner": "ubuntu-latest", "build_type": "download"},
+              {"platform": "darwin-arm64", "runner": "ubuntu-latest", "build_type": "download"},
+              {"platform": "win32-x64", "runner": "windows-latest", "build_type": "msi-extract"}
+            ]'
+          else
+            # Single platform - determine runner and build type
+            case "$PLATFORMS" in
+              linux-x64|linux-arm64)
+                MATRIX="[{\"platform\": \"$PLATFORMS\", \"runner\": \"ubuntu-latest\", \"build_type\": \"docker\"}]"
+                ;;
+              darwin-x64|darwin-arm64)
+                MATRIX="[{\"platform\": \"$PLATFORMS\", \"runner\": \"ubuntu-latest\", \"build_type\": \"download\"}]"
+                ;;
+              win32-x64)
+                MATRIX="[{\"platform\": \"$PLATFORMS\", \"runner\": \"windows-latest\", \"build_type\": \"msi-extract\"}]"
+                ;;
+            esac
+          fi
+          # Compact the JSON for output
+          MATRIX=$(echo "$MATRIX" | jq -c .)
+          echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
+          echo "Building platforms: $MATRIX"
+
+  # Build each platform in parallel
+  build:
+    needs: prepare
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.prepare.outputs.matrix) }}
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Set up QEMU for cross-platform Docker builds (required for linux-arm64 on x64 runners)
+      - name: Set up QEMU
+        if: matrix.build_type == 'docker'
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        if: matrix.build_type == 'docker'
+        uses: docker/setup-buildx-action@v3
+
+      # For Linux: extract from official Docker image
+      - name: Build for Linux (Docker extraction)
+        if: matrix.build_type == 'docker'
+        id: build-linux
+        timeout-minutes: 30
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          PLATFORM="${{ matrix.platform }}"
+
+          echo "Extracting CouchDB $VERSION for $PLATFORM from Docker image"
+
+          # Map hostdb platform to Docker platform
+          case "$PLATFORM" in
+            linux-x64) DOCKER_PLATFORM="linux/amd64" ;;
+            linux-arm64) DOCKER_PLATFORM="linux/arm64" ;;
+          esac
+
+          # Build with Docker and extract files
+          docker buildx build \
+            --platform "$DOCKER_PLATFORM" \
+            --build-arg VERSION="$VERSION" \
+            --output "type=local,dest=./temp-extract" \
+            --file builds/couchdb/Dockerfile \
+            .
+
+          # Verify extraction
+          if [ ! -d "./temp-extract/couchdb" ]; then
+            echo "::error::Extraction failed - couchdb directory not found"
+            ls -la ./temp-extract/
+            exit 1
+          fi
+
+          # Create tarball
+          mkdir -p ./dist
+          tar -czvf "./dist/couchdb-${VERSION}-${PLATFORM}.tar.gz" -C ./temp-extract couchdb
+
+          echo "Build complete:"
+          ls -la ./dist/
+
+      # For macOS: download from Neighbourhoodie and repackage
+      - name: Download for macOS
+        if: matrix.build_type == 'download'
+        id: build-macos
+        timeout-minutes: 30
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          PLATFORM="${{ matrix.platform }}"
+
+          echo "Downloading CouchDB $VERSION for $PLATFORM"
+
+          pnpm download:couchdb -- \
+            --version "$VERSION" \
+            --platform "$PLATFORM" \
+            --output ./dist
+
+          # Check if artifact was created
+          shopt -s nullglob
+          FILES=(./dist/couchdb-*.tar.gz ./dist/couchdb-*.zip)
+          if [ ${#FILES[@]} -eq 0 ]; then
+            echo "::error::No artifact created for $PLATFORM"
+            exit 1
+          fi
+          ls -la ./dist/
+
+      # For Windows: download MSI and extract
+      - name: Download and extract MSI for Windows
+        if: matrix.build_type == 'msi-extract'
+        id: build-windows
+        timeout-minutes: 30
+        shell: pwsh
+        run: |
+          $VERSION = "${{ github.event.inputs.version }}"
+          $PLATFORM = "${{ matrix.platform }}"
+
+          Write-Host "Downloading CouchDB $VERSION MSI for $PLATFORM"
+
+          # Download MSI
+          $msiUrl = "https://couchdb.neighbourhood.ie/downloads/$VERSION/win/apache-couchdb-$VERSION.msi"
+          $msiPath = ".\couchdb-$VERSION.msi"
+
+          Write-Host "Downloading: $msiUrl"
+          Invoke-WebRequest -Uri $msiUrl -OutFile $msiPath -UseBasicParsing
+
+          # Verify download
+          if (-not (Test-Path $msiPath)) {
+            Write-Error "Download failed"
+            exit 1
+          }
+
+          Write-Host "MSI downloaded: $(Get-Item $msiPath | Select-Object -ExpandProperty Length) bytes"
+
+          # Extract MSI using msiexec
+          $extractDir = ".\extract"
+          New-Item -ItemType Directory -Force -Path $extractDir
+
+          Write-Host "Extracting MSI..."
+          $msiFullPath = (Get-Item $msiPath).FullName
+          $extractFullPath = (Get-Item $extractDir).FullName
+
+          Start-Process msiexec.exe -ArgumentList "/a `"$msiFullPath`" /qn TARGETDIR=`"$extractFullPath`"" -Wait -NoNewWindow
+
+          # Find CouchDB installation
+          Write-Host "Looking for CouchDB installation..."
+          Get-ChildItem -Path $extractDir -Recurse -Directory | Select-Object -First 20 | ForEach-Object { Write-Host $_.FullName }
+
+          # CouchDB typically extracts to Apache CouchDB folder
+          $couchdbDir = Get-ChildItem -Path $extractDir -Recurse -Directory | Where-Object { $_.Name -like "*CouchDB*" } | Select-Object -First 1
+
+          if (-not $couchdbDir) {
+            # Try finding by bin/couchdb.cmd
+            $binDir = Get-ChildItem -Path $extractDir -Recurse -Directory | Where-Object { $_.Name -eq "bin" } | Select-Object -First 1
+            if ($binDir) {
+              $couchdbDir = $binDir.Parent
+            }
+          }
+
+          if (-not $couchdbDir) {
+            Write-Error "Could not find CouchDB installation"
+            Write-Host "Contents of extract directory:"
+            Get-ChildItem -Path $extractDir -Recurse | Select-Object -First 50 | ForEach-Object { Write-Host $_.FullName }
+            exit 1
+          }
+
+          Write-Host "Found CouchDB at: $($couchdbDir.FullName)"
+
+          # Create final directory structure
+          $finalDir = ".\final\couchdb"
+          New-Item -ItemType Directory -Force -Path $finalDir
+
+          # Copy CouchDB files
+          Copy-Item -Path "$($couchdbDir.FullName)\*" -Destination $finalDir -Recurse -Force
+
+          # Add metadata
+          $metadata = @{
+            name = "couchdb"
+            version = $VERSION
+            platform = $PLATFORM
+            source = "neighbourhoodie"
+            sourceUrl = "https://neighbourhood.ie/couchdb-support/download-binaries"
+            rehosted_by = "hostdb"
+            rehosted_at = (Get-Date -Format "o")
+          } | ConvertTo-Json
+          $metadata | Out-File -FilePath "$finalDir\.hostdb-metadata.json" -Encoding UTF8
+
+          # Verify key files
+          if (-not (Test-Path "$finalDir\bin")) {
+            Write-Host "Warning: bin directory not found"
+            Write-Host "Contents of final directory:"
+            Get-ChildItem -Path $finalDir -Recurse | Select-Object -First 30 | ForEach-Object { Write-Host $_.FullName }
+          }
+
+          # Create ZIP
+          New-Item -ItemType Directory -Force -Path ".\dist"
+          $zipPath = ".\dist\couchdb-$VERSION-$PLATFORM.zip"
+
+          Compress-Archive -Path ".\final\couchdb" -DestinationPath $zipPath -Force
+
+          Write-Host "Build complete:"
+          Get-ChildItem -Path ".\dist"
+
+      - name: Generate checksum
+        shell: bash
+        run: |
+          cd dist
+          shopt -s nullglob
+          for f in *.tar.gz *.zip; do
+            if [ -f "$f" ]; then
+              if command -v sha256sum &> /dev/null; then
+                sha256sum "$f" >> checksums.txt
+              else
+                # macOS/Windows use different tools
+                shasum -a 256 "$f" >> checksums.txt 2>/dev/null || \
+                  certutil -hashfile "$f" SHA256 | grep -v ":" >> checksums.txt
+              fi
+            fi
+          done
+          cat checksums.txt || true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: couchdb-${{ github.event.inputs.version }}-${{ matrix.platform }}
+          path: |
+            dist/*.tar.gz
+            dist/*.zip
+            dist/checksums.txt
+          retention-days: 1
+
+  # Collect all artifacts and create release
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: ./artifacts
+          pattern: couchdb-${{ github.event.inputs.version }}-*
+
+      - name: Prepare release assets
+        run: |
+          mkdir -p ./release-assets
+
+          # Move all artifacts to release-assets, flattening the directory structure
+          find ./artifacts -type f \( -name "*.tar.gz" -o -name "*.zip" \) -exec mv {} ./release-assets/ \;
+
+          # Combine all checksums
+          find ./artifacts -name "checksums.txt" -exec cat {} \; > ./release-assets/checksums.txt
+
+          echo "Release assets:"
+          ls -la ./release-assets/
+
+          # Verify we have at least one artifact
+          shopt -s nullglob
+          FILES=(./release-assets/*.tar.gz ./release-assets/*.zip)
+          if [ ${#FILES[@]} -eq 0 ]; then
+            echo "ERROR: No artifacts were created for any platform"
+            exit 1
+          fi
+
+          echo ""
+          echo "Checksums:"
+          cat ./release-assets/checksums.txt
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: couchdb-${{ github.event.inputs.version }}
+          name: CouchDB ${{ github.event.inputs.version }}
+          body: |
+            ## CouchDB ${{ github.event.inputs.version }}
+
+            Apache CouchDB binaries for hostdb - all 5 platforms.
+
+            ### Available Platforms
+            | Platform | Source |
+            |----------|--------|
+            | `linux-x64` | Extracted from official Docker image |
+            | `linux-arm64` | Extracted from official Docker image |
+            | `darwin-x64` | [Neighbourhoodie](https://neighbourhood.ie/couchdb-support/download-binaries) |
+            | `darwin-arm64` | [Neighbourhoodie](https://neighbourhood.ie/couchdb-support/download-binaries) |
+            | `win32-x64` | [Neighbourhoodie](https://neighbourhood.ie/couchdb-support/download-binaries) MSI |
+
+            ### Usage
+            ```bash
+            # Download URL pattern
+            https://github.com/${{ github.repository }}/releases/download/couchdb-${{ github.event.inputs.version }}/couchdb-${{ github.event.inputs.version }}-<platform>.tar.gz
+            ```
+
+            ### Checksums
+            See `checksums.txt` for SHA256 checksums.
+
+            ### License
+            Apache CouchDB is licensed under Apache-2.0.
+
+            ### Sources
+            - **Official Docker Image**: [hub.docker.com/_/couchdb](https://hub.docker.com/_/couchdb)
+            - **macOS/Windows Binaries**: [Neighbourhoodie](https://neighbourhood.ie/couchdb-support/download-binaries)
+            - **Official Website**: [couchdb.apache.org](https://couchdb.apache.org/)
+          files: |
+            release-assets/*.tar.gz
+            release-assets/*.zip
+            release-assets/checksums.txt
+          fail_on_unmatched_files: false
+
+  # Update the releases manifest
+  update-manifest:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Update releases.json
+        run: |
+          pnpm tsx scripts/update-releases.ts \
+            --database couchdb \
+            --version "${{ github.event.inputs.version }}" \
+            --tag "couchdb-${{ github.event.inputs.version }}"
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add releases.json
+          git diff --staged --quiet && echo "No changes to commit" && exit 0
+
+          git commit -m "chore: update releases.json for couchdb-${{ github.event.inputs.version }}"
+
+          # Retry push with rebase if remote has changed
+          for i in 1 2 3; do
+            if git push; then
+              echo "Push succeeded"
+              exit 0
+            fi
+            echo "Push failed, attempting rebase (attempt $i/3)..."
+            git fetch origin main
+            if ! git rebase origin/main; then
+              echo "ERROR: Rebase failed due to conflicts. Manual intervention required."
+              git rebase --abort
+              exit 1
+            fi
+            sleep $((2**i))
+          done
+          echo "ERROR: Push failed after 3 attempts"
+          exit 1
+
+  # Trigger sync to ensure releases.json is fully up to date
+  trigger-sync:
+    needs: update-manifest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger sync-releases workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run sync-releases.yml --repo ${{ github.repository }}
+          echo "Triggered sync-releases workflow"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.17.0] - 2026-01-25
+
+### Added
+
+- **CouchDB support** (new database engine)
+  - Apache CouchDB document database with HTTP API and offline-first sync
+  - All 5 platforms supported: linux-x64, linux-arm64, darwin-x64, darwin-arm64, win32-x64
+  - Linux: Extracted from official CouchDB Docker image
+  - macOS: Official binaries from Neighbourhoodie
+  - Windows: MSI installer from Neighbourhoodie, extracted for portable use
+  - License: Apache-2.0
+
 ## [0.14.20] - 2026-01-25
 
 ### Fixed

--- a/builds/couchdb/Dockerfile
+++ b/builds/couchdb/Dockerfile
@@ -1,0 +1,65 @@
+# CouchDB Extraction Dockerfile
+# Extracts CouchDB from official Docker image for Linux platforms
+#
+# The official CouchDB Docker image contains a complete, pre-built installation
+# with all dependencies (Erlang, ICU, OpenSSL, etc.) statically linked.
+# This Dockerfile extracts that installation for portable use.
+#
+# Usage:
+#   docker buildx build --platform linux/amd64 \
+#     --build-arg VERSION=3.5.1 \
+#     --output type=local,dest=./downloads \
+#     -f builds/couchdb/Dockerfile .
+#
+# Extraction time: ~1-2 minutes (pulling image + copying files)
+
+ARG VERSION=3.5.1
+
+# =============================================================================
+# Stage 1: Extract from official image
+# =============================================================================
+FROM couchdb:${VERSION} AS source
+
+# Nothing to do here - we just need the base image
+
+# =============================================================================
+# Stage 2: Package
+# =============================================================================
+FROM ubuntu:22.04 AS packager
+
+ARG VERSION
+ARG TARGETARCH
+
+# Install minimal tools for packaging
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy CouchDB installation from official image
+# CouchDB is installed at /opt/couchdb in the official image
+COPY --from=source /opt/couchdb /opt/couchdb
+
+WORKDIR /opt/couchdb
+
+# Map Docker TARGETARCH to hostdb platform naming
+RUN PLATFORM="linux-x64"; \
+    if [ "$TARGETARCH" = "arm64" ]; then PLATFORM="linux-arm64"; fi; \
+    printf '{\n  "name": "couchdb",\n  "version": "%s",\n  "platform": "%s",\n  "source": "docker-extract",\n  "sourceUrl": "https://hub.docker.com/_/couchdb",\n  "dockerImage": "couchdb:%s",\n  "rehosted_by": "hostdb",\n  "rehosted_at": "%s"\n}\n' \
+        "${VERSION}" "${PLATFORM}" "${VERSION}" "$(date -Iseconds)" \
+        > /opt/couchdb/.hostdb-metadata.json
+
+# Verify key files exist
+RUN test -f /opt/couchdb/bin/couchdb \
+    && test -d /opt/couchdb/etc \
+    && echo "Extraction verification passed"
+
+# List contents for debugging
+RUN echo "=== CouchDB bin directory ===" && ls -la /opt/couchdb/bin/ | head -20
+RUN echo "=== CouchDB structure ===" && find /opt/couchdb -maxdepth 2 -type d
+
+# =============================================================================
+# Stage 3: Export (scratch image for minimal output)
+# =============================================================================
+FROM scratch AS export
+
+COPY --from=packager /opt/couchdb /couchdb

--- a/builds/couchdb/README.md
+++ b/builds/couchdb/README.md
@@ -1,0 +1,149 @@
+# CouchDB Build
+
+Apache CouchDB binaries for all 5 platforms.
+
+## Platform Coverage
+
+| Platform | Source | Notes |
+|----------|--------|-------|
+| `linux-x64` | Docker extraction | Extracted from official `couchdb` Docker image |
+| `linux-arm64` | Docker extraction | Extracted from official `couchdb` Docker image (QEMU) |
+| `darwin-x64` | Neighbourhoodie | Official macOS x86_64 binary |
+| `darwin-arm64` | Neighbourhoodie | Official macOS Apple Silicon binary |
+| `win32-x64` | Neighbourhoodie | MSI installer, extracted for portable use |
+
+## Binary Sources
+
+### Linux (Docker Extraction)
+
+CouchDB does not provide standalone Linux binaries - only .deb/.rpm packages that require system installation. Instead, we extract the complete CouchDB installation from the official Docker image, which includes all dependencies (Erlang, ICU, OpenSSL, etc.) pre-configured.
+
+**Docker Image:** [`couchdb`](https://hub.docker.com/_/couchdb) (official)
+
+**Extraction Path:** `/opt/couchdb` in the Docker image
+
+### macOS & Windows (Neighbourhoodie)
+
+Official binaries are hosted by [Neighbourhoodie](https://neighbourhood.ie/couchdb-support/download-binaries), a CouchDB consulting company that sponsors binary distribution.
+
+**macOS:** ZIP containing `Apache CouchDB.app` bundle
+**Windows:** MSI installer
+
+## Usage
+
+### Download for current platform
+
+```bash
+pnpm download:couchdb
+```
+
+### Download for specific platform
+
+```bash
+pnpm download:couchdb -- --version 3.5.1 --platform darwin-arm64
+```
+
+### Download for all platforms (macOS/Windows only)
+
+```bash
+pnpm download:couchdb -- --all-platforms
+```
+
+### Build Linux binaries locally (requires Docker)
+
+```bash
+./builds/couchdb/build-local.sh --version 3.5.1 --platform linux-x64
+./builds/couchdb/build-local.sh --version 3.5.1 --platform linux-arm64
+```
+
+### Download with Docker fallback for Linux
+
+```bash
+pnpm download:couchdb -- --all-platforms --build-fallback
+```
+
+## Build Times
+
+| Platform | Method | Approximate Time |
+|----------|--------|------------------|
+| `darwin-x64` | Download + repackage | 1-2 minutes |
+| `darwin-arm64` | Download + repackage | 1-2 minutes |
+| `win32-x64` | MSI extract | 2-3 minutes |
+| `linux-x64` | Docker pull + extract | 2-3 minutes |
+| `linux-arm64` | Docker pull + extract (QEMU) | 5-10 minutes |
+
+## Archive Structure
+
+```
+couchdb/
+├── bin/
+│   ├── couchdb
+│   ├── couchjs
+│   └── ...
+├── etc/
+│   ├── default.ini
+│   ├── local.ini
+│   └── ...
+├── lib/
+│   └── couch-*/
+├── share/
+│   └── www/         # Fauxton web UI
+├── data/            # Default data directory
+└── .hostdb-metadata.json
+```
+
+## Configuration
+
+CouchDB uses `.ini` files in `etc/` for configuration:
+
+- `default.ini` - Default settings (do not modify)
+- `local.ini` - Local overrides (safe to modify)
+
+### Quick Start
+
+```bash
+# Extract
+tar -xzf couchdb-3.5.1-linux-x64.tar.gz
+
+# Set admin password (required for first run)
+echo "[admins]" >> couchdb/etc/local.ini
+echo "admin = mysecretpassword" >> couchdb/etc/local.ini
+
+# Start CouchDB
+./couchdb/bin/couchdb
+
+# Access Fauxton UI
+open http://127.0.0.1:5984/_utils/
+```
+
+## API Access
+
+CouchDB provides an HTTP API - no dedicated CLI client is needed:
+
+```bash
+# Check server status
+curl http://127.0.0.1:5984/
+
+# Create database
+curl -X PUT http://admin:password@127.0.0.1:5984/mydb
+
+# Create document
+curl -X POST http://admin:password@127.0.0.1:5984/mydb \
+  -H "Content-Type: application/json" \
+  -d '{"name": "test"}'
+
+# Query all documents
+curl http://admin:password@127.0.0.1:5984/mydb/_all_docs
+```
+
+## License
+
+Apache CouchDB is licensed under [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+## Links
+
+- [Official Website](https://couchdb.apache.org/)
+- [Documentation](https://docs.couchdb.org/)
+- [Docker Hub](https://hub.docker.com/_/couchdb)
+- [Neighbourhoodie Downloads](https://neighbourhood.ie/couchdb-support/download-binaries)
+- [GitHub](https://github.com/apache/couchdb)

--- a/builds/couchdb/build-local.sh
+++ b/builds/couchdb/build-local.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+# Local CouchDB build script using Docker
+#
+# Extracts CouchDB from official Docker image for Linux platforms
+#
+# Usage:
+#   ./builds/couchdb/build-local.sh --version 3.5.1 --platform linux-x64
+#   ./builds/couchdb/build-local.sh --version 3.5.1 --platform linux-arm64
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+log_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
+log_success() { echo -e "${GREEN}[OK]${NC} $1"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+
+# Default values
+VERSION="3.5.1"
+PLATFORM=""
+OUTPUT_DIR="./downloads"
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --version)
+            VERSION="$2"
+            shift 2
+            ;;
+        --platform)
+            PLATFORM="$2"
+            shift 2
+            ;;
+        --output)
+            OUTPUT_DIR="$2"
+            shift 2
+            ;;
+        --help|-h)
+            echo "Usage: $0 [options]"
+            echo ""
+            echo "Options:"
+            echo "  --version VERSION    CouchDB version (default: 3.5.1)"
+            echo "  --platform PLATFORM  Target platform: linux-x64 or linux-arm64"
+            echo "  --output DIR         Output directory (default: ./downloads)"
+            echo "  --help               Show this help"
+            exit 0
+            ;;
+        *)
+            log_error "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+# Validate platform
+if [[ -z "$PLATFORM" ]]; then
+    log_error "Platform is required (--platform linux-x64 or linux-arm64)"
+    exit 1
+fi
+
+if [[ "$PLATFORM" != "linux-x64" && "$PLATFORM" != "linux-arm64" ]]; then
+    log_error "Invalid platform: $PLATFORM"
+    log_error "Only linux-x64 and linux-arm64 are supported for Docker extraction"
+    exit 1
+fi
+
+# Map hostdb platform to Docker platform
+DOCKER_PLATFORM=""
+case $PLATFORM in
+    linux-x64)
+        DOCKER_PLATFORM="linux/amd64"
+        ;;
+    linux-arm64)
+        DOCKER_PLATFORM="linux/arm64"
+        ;;
+esac
+
+# Script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+DOCKERFILE="$SCRIPT_DIR/Dockerfile"
+
+# Output file
+OUTPUT_FILE="$OUTPUT_DIR/couchdb-${VERSION}-${PLATFORM}.tar.gz"
+
+log_info "CouchDB Docker Extraction"
+log_info "Version: $VERSION"
+log_info "Platform: $PLATFORM ($DOCKER_PLATFORM)"
+log_info "Output: $OUTPUT_FILE"
+echo ""
+
+# Check Docker is available
+if ! command -v docker &> /dev/null; then
+    log_error "Docker is not installed or not in PATH"
+    exit 1
+fi
+
+# Check buildx is available
+if ! docker buildx version &> /dev/null; then
+    log_error "Docker buildx is not available"
+    log_info "Install with: docker buildx install"
+    exit 1
+fi
+
+# Create temp directory for build output
+TEMP_DIR=$(mktemp -d)
+trap "rm -rf $TEMP_DIR" EXIT
+
+log_info "Building Docker image and extracting CouchDB..."
+
+# Build with buildx and export to local directory
+docker buildx build \
+    --platform "$DOCKER_PLATFORM" \
+    --build-arg VERSION="$VERSION" \
+    --output "type=local,dest=$TEMP_DIR" \
+    --file "$DOCKERFILE" \
+    "$PROJECT_ROOT"
+
+# Check extraction succeeded
+if [[ ! -d "$TEMP_DIR/couchdb" ]]; then
+    log_error "Extraction failed - couchdb directory not found"
+    log_info "Contents of temp dir:"
+    ls -la "$TEMP_DIR"
+    exit 1
+fi
+
+# Verify key files
+if [[ ! -f "$TEMP_DIR/couchdb/bin/couchdb" ]]; then
+    log_error "Extraction incomplete - couchdb binary not found"
+    exit 1
+fi
+
+log_success "Extraction complete"
+
+# Create output directory
+mkdir -p "$(dirname "$OUTPUT_FILE")"
+
+# Create tarball
+log_info "Creating tarball: $(basename "$OUTPUT_FILE")"
+tar -czf "$OUTPUT_FILE" -C "$TEMP_DIR" couchdb
+
+# Calculate checksum
+SHA256=$(sha256sum "$OUTPUT_FILE" | cut -d' ' -f1)
+log_info "SHA256: $SHA256"
+
+log_success "Created: $OUTPUT_FILE"

--- a/builds/couchdb/download.ts
+++ b/builds/couchdb/download.ts
@@ -1,0 +1,792 @@
+#!/usr/bin/env tsx
+/**
+ * Download CouchDB binaries from Neighbourhoodie for re-hosting
+ *
+ * Sources:
+ *   - Neighbourhoodie: Official macOS and Windows binaries
+ *   - Docker: Linux binaries extracted from official Docker image
+ *
+ * Usage:
+ *   ./builds/couchdb/download.ts [options]
+ *   pnpm tsx builds/couchdb/download.ts [options]
+ *
+ * Options:
+ *   --version VERSION    CouchDB version (default: 3.5.1)
+ *   --platform PLATFORM  Target platform (default: current platform)
+ *   --output DIR         Output directory (default: ./downloads)
+ *   --all-platforms      Download for all platforms (skips docker-extract unless --build-fallback)
+ *   --build-fallback     Build from Docker for platforms without binaries (linux only)
+ *   --help               Show help
+ */
+
+import {
+  createWriteStream,
+  createReadStream,
+  mkdirSync,
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  rmSync,
+  readdirSync,
+  cpSync,
+  statSync,
+} from 'node:fs'
+import { createHash } from 'node:crypto'
+import { resolve, dirname, basename } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { execFileSync, spawnSync } from 'node:child_process'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+type Platform =
+  | 'linux-x64'
+  | 'linux-arm64'
+  | 'darwin-x64'
+  | 'darwin-arm64'
+  | 'win32-x64'
+
+const VALID_PLATFORMS: Platform[] = [
+  'linux-x64',
+  'linux-arm64',
+  'darwin-x64',
+  'darwin-arm64',
+  'win32-x64',
+]
+
+function isValidPlatform(value: string): value is Platform {
+  return VALID_PLATFORMS.includes(value as Platform)
+}
+
+// Validate version format to prevent command injection (e.g., "3.5.1")
+const VERSION_REGEX = /^\d+\.\d+\.\d+$/
+
+function isValidVersion(value: string): boolean {
+  return VERSION_REGEX.test(value)
+}
+
+type DownloadableSource = {
+  url: string
+  format: 'zip' | 'msi'
+  sha256: string | null
+  sourceType: 'neighbourhoodie'
+}
+
+type DockerExtractSource = {
+  sourceType: 'docker-extract'
+}
+
+type SourceEntry = DownloadableSource | DockerExtractSource
+
+type Sources = {
+  database: string
+  versions: Record<string, Record<Platform, SourceEntry>>
+  notes: Record<string, string>
+}
+
+function isDownloadableSource(
+  source: SourceEntry,
+): source is DownloadableSource {
+  return 'url' in source
+}
+
+const colors = {
+  reset: '\x1b[0m',
+  red: '\x1b[31m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  blue: '\x1b[34m',
+  cyan: '\x1b[36m',
+}
+
+function log(color: keyof typeof colors, prefix: string, msg: string) {
+  console.log(`${colors[color]}[${prefix}]${colors.reset} ${msg}`)
+}
+
+function logInfo(msg: string) {
+  log('blue', 'INFO', msg)
+}
+function logSuccess(msg: string) {
+  log('green', 'OK', msg)
+}
+function logWarn(msg: string) {
+  log('yellow', 'WARN', msg)
+}
+function logError(msg: string) {
+  log('red', 'ERROR', msg)
+}
+
+function detectPlatform(): Platform {
+  const platform = process.platform
+  const arch = process.arch
+
+  if (platform === 'linux' && arch === 'x64') return 'linux-x64'
+  if (platform === 'linux' && arch === 'arm64') return 'linux-arm64'
+  if (platform === 'darwin' && arch === 'x64') return 'darwin-x64'
+  if (platform === 'darwin' && arch === 'arm64') return 'darwin-arm64'
+  if (platform === 'win32' && arch === 'x64') return 'win32-x64'
+
+  throw new Error(`Unsupported platform: ${platform}-${arch}`)
+}
+
+function loadSources(): Sources {
+  const sourcesPath = resolve(__dirname, 'sources.json')
+  const content = readFileSync(sourcesPath, 'utf-8')
+  try {
+    return JSON.parse(content) as Sources
+  } catch (error) {
+    throw new Error(`Failed to parse sources.json: invalid JSON`, {
+      cause: error,
+    })
+  }
+}
+
+async function downloadFile(url: string, destPath: string): Promise<void> {
+  logInfo(`Downloading: ${url}`)
+
+  const response = await fetch(url, { redirect: 'follow' })
+
+  if (!response.ok) {
+    throw new Error(
+      `Download failed: ${response.status} ${response.statusText}`,
+    )
+  }
+
+  const contentLength = response.headers.get('content-length')
+  const totalBytes = contentLength ? parseInt(contentLength, 10) : 0
+
+  mkdirSync(dirname(destPath), { recursive: true })
+
+  const fileStream = createWriteStream(destPath)
+  const reader = response.body?.getReader()
+
+  if (!reader) {
+    throw new Error('No response body')
+  }
+
+  let downloadedBytes = 0
+  const startTime = Date.now()
+
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+
+    fileStream.write(value)
+    downloadedBytes += value.length
+
+    // Progress update
+    if (totalBytes > 0) {
+      const percent = ((downloadedBytes / totalBytes) * 100).toFixed(1)
+      const mbDownloaded = (downloadedBytes / 1024 / 1024).toFixed(1)
+      const mbTotal = (totalBytes / 1024 / 1024).toFixed(1)
+      process.stdout.write(
+        `\r  ${mbDownloaded}MB / ${mbTotal}MB (${percent}%)    `,
+      )
+    } else {
+      const mbDownloaded = (downloadedBytes / 1024 / 1024).toFixed(1)
+      process.stdout.write(`\r  ${mbDownloaded}MB downloaded...    `)
+    }
+  }
+
+  // Wait for the file stream to fully close before proceeding
+  await new Promise<void>((resolve, reject) => {
+    fileStream.end()
+    fileStream.on('finish', resolve)
+    fileStream.on('error', reject)
+  })
+
+  console.log() // New line after progress
+
+  const duration = ((Date.now() - startTime) / 1000).toFixed(1)
+  logSuccess(
+    `Downloaded ${(downloadedBytes / 1024 / 1024).toFixed(1)}MB in ${duration}s`,
+  )
+}
+
+// Calculate SHA256 checksum using streaming to avoid loading large files into memory
+async function calculateSha256(filePath: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const hash = createHash('sha256')
+    const stream = createReadStream(filePath)
+
+    stream.on('data', (chunk) => hash.update(chunk))
+    stream.on('end', () => resolve(hash.digest('hex')))
+    stream.on('error', reject)
+  })
+}
+
+/**
+ * Repackage macOS ZIP (contains Apache CouchDB.app bundle)
+ * Structure: Apache CouchDB.app/Contents/Resources/couchdbx-core/
+ */
+function repackageMacOS(
+  zipPath: string,
+  outputPath: string,
+  version: string,
+  platform: Platform,
+): void {
+  const tempDir = resolve(dirname(zipPath), 'temp-extract')
+  mkdirSync(tempDir, { recursive: true })
+
+  logInfo('Extracting macOS ZIP...')
+  execFileSync('unzip', ['-q', zipPath, '-d', tempDir], { stdio: 'inherit' })
+
+  // Find the .app bundle
+  const appDir = readdirSync(tempDir).find((d) => d.endsWith('.app'))
+  if (!appDir) {
+    throw new Error('Could not find .app bundle in ZIP')
+  }
+
+  // CouchDB stores the actual installation in Contents/Resources/couchdbx-core/
+  const couchdbCorePath = resolve(
+    tempDir,
+    appDir,
+    'Contents',
+    'Resources',
+    'couchdbx-core',
+  )
+
+  if (!existsSync(couchdbCorePath)) {
+    // Fallback: check if it's directly in Contents/Resources
+    const resourcesPath = resolve(tempDir, appDir, 'Contents', 'Resources')
+    logWarn(`couchdbx-core not found, checking Resources directory structure`)
+
+    // List what we have
+    if (existsSync(resourcesPath)) {
+      const contents = readdirSync(resourcesPath)
+      logInfo(`Resources contents: ${contents.join(', ')}`)
+    }
+    throw new Error(
+      `Could not find CouchDB installation in app bundle at ${couchdbCorePath}`,
+    )
+  }
+
+  // Create output directory structure
+  const finalDir = resolve(tempDir, 'couchdb')
+  mkdirSync(finalDir, { recursive: true })
+
+  // Copy the couchdbx-core contents to couchdb/
+  logInfo('Copying CouchDB files...')
+  cpSync(couchdbCorePath, finalDir, { recursive: true })
+
+  // Add metadata file
+  const metadata = {
+    name: 'couchdb',
+    version,
+    platform,
+    source: 'neighbourhoodie',
+    sourceUrl: 'https://neighbourhood.ie/couchdb-support/download-binaries',
+    rehosted_by: 'hostdb',
+    rehosted_at: new Date().toISOString(),
+  }
+  writeFileSync(
+    resolve(finalDir, '.hostdb-metadata.json'),
+    JSON.stringify(metadata, null, 2),
+  )
+
+  // Verify key directories/files exist
+  const binDir = resolve(finalDir, 'bin')
+  if (!existsSync(binDir)) {
+    logWarn('bin directory not found, checking structure...')
+    const contents = readdirSync(finalDir)
+    logInfo(`CouchDB directory contents: ${contents.join(', ')}`)
+  }
+
+  // Create output directory
+  mkdirSync(dirname(outputPath), { recursive: true })
+
+  logInfo(`Creating: ${basename(outputPath)}`)
+
+  // Create tar.gz for Unix platforms
+  execFileSync('tar', ['-czf', outputPath, '-C', tempDir, 'couchdb'], {
+    stdio: 'inherit',
+  })
+
+  // Cleanup temp
+  rmSync(tempDir, { recursive: true, force: true })
+
+  logSuccess(`Created: ${outputPath}`)
+}
+
+/**
+ * Repackage Windows MSI installer
+ * On Windows: use msiexec to extract
+ * On other platforms: use 7z if available, otherwise leave as MSI for CI
+ */
+function repackageWindowsMSI(
+  msiPath: string,
+  outputPath: string,
+  version: string,
+  platform: Platform,
+): void {
+  const tempDir = resolve(dirname(msiPath), 'temp-extract-win')
+  mkdirSync(tempDir, { recursive: true })
+
+  logInfo('Extracting MSI installer...')
+
+  // Try different extraction methods
+  let extracted = false
+
+  if (process.platform === 'win32') {
+    // On Windows, use msiexec
+    try {
+      execFileSync(
+        'msiexec',
+        ['/a', msiPath, '/qn', `TARGETDIR=${tempDir}`],
+        { stdio: 'inherit' },
+      )
+      extracted = true
+    } catch {
+      logWarn('msiexec extraction failed')
+    }
+  }
+
+  if (!extracted) {
+    // Try 7z (works on all platforms if installed)
+    try {
+      execFileSync('7z', ['x', '-y', `-o${tempDir}`, msiPath], {
+        stdio: 'inherit',
+      })
+      extracted = true
+    } catch {
+      logWarn('7z not available for MSI extraction')
+    }
+  }
+
+  if (!extracted) {
+    // Try msitools on Linux/macOS
+    try {
+      execFileSync('msiextract', ['-C', tempDir, msiPath], { stdio: 'inherit' })
+      extracted = true
+    } catch {
+      logWarn('msiextract not available')
+    }
+  }
+
+  if (!extracted) {
+    // Fallback: just copy the MSI as-is and let the CI workflow handle extraction
+    logWarn('No MSI extraction tool available')
+    logInfo('Leaving MSI as-is - CI workflow will extract on Windows runner')
+
+    // Create a simple wrapper directory
+    const finalDir = resolve(tempDir, 'couchdb')
+    mkdirSync(finalDir, { recursive: true })
+
+    // Copy MSI into the directory
+    cpSync(msiPath, resolve(finalDir, basename(msiPath)))
+
+    // Add metadata
+    const metadata = {
+      name: 'couchdb',
+      version,
+      platform,
+      source: 'neighbourhoodie',
+      sourceUrl: 'https://neighbourhood.ie/couchdb-support/download-binaries',
+      rehosted_by: 'hostdb',
+      rehosted_at: new Date().toISOString(),
+      note: 'Contains MSI installer - extract with msiexec /a',
+    }
+    writeFileSync(
+      resolve(finalDir, '.hostdb-metadata.json'),
+      JSON.stringify(metadata, null, 2),
+    )
+
+    // Create ZIP for Windows
+    mkdirSync(dirname(outputPath), { recursive: true })
+    execFileSync('zip', ['-rq', outputPath, 'couchdb'], {
+      cwd: tempDir,
+      stdio: 'inherit',
+    })
+
+    rmSync(tempDir, { recursive: true, force: true })
+    logSuccess(`Created: ${outputPath} (contains MSI, needs extraction)`)
+    return
+  }
+
+  // Find CouchDB installation directory
+  logInfo('Looking for CouchDB installation in extracted MSI...')
+  const entries = readdirSync(tempDir)
+  logInfo(`Extracted contents: ${entries.join(', ')}`)
+
+  // MSI typically extracts to a ProgramFiles structure or directly
+  // Look for Apache CouchDB folder or couchdb binaries
+  let couchdbDir = ''
+
+  // Common patterns for CouchDB MSI
+  const searchDirs = [
+    resolve(tempDir, 'Apache CouchDB'),
+    resolve(tempDir, 'Apache', 'CouchDB'),
+    resolve(tempDir, 'CouchDB'),
+    resolve(tempDir, 'Program Files', 'Apache CouchDB'),
+    resolve(tempDir, 'PFiles', 'Apache CouchDB'),
+  ]
+
+  for (const dir of searchDirs) {
+    if (existsSync(dir)) {
+      couchdbDir = dir
+      break
+    }
+  }
+
+  // If not found, search recursively for bin/couchdb.cmd or similar
+  if (!couchdbDir) {
+    function findCouchDB(dir: string): string | null {
+      try {
+        const entries = readdirSync(dir)
+        for (const entry of entries) {
+          const fullPath = resolve(dir, entry)
+          const stat = statSync(fullPath)
+          if (stat.isDirectory()) {
+            // Check if this looks like a CouchDB installation
+            if (
+              existsSync(resolve(fullPath, 'bin')) &&
+              existsSync(resolve(fullPath, 'etc'))
+            ) {
+              return fullPath
+            }
+            const found = findCouchDB(fullPath)
+            if (found) return found
+          }
+        }
+      } catch {
+        // Ignore permission errors
+      }
+      return null
+    }
+    couchdbDir = findCouchDB(tempDir) || ''
+  }
+
+  if (!couchdbDir) {
+    logError('Could not find CouchDB installation in extracted MSI')
+    logInfo('Listing temp directory contents recursively...')
+    execFileSync('find', [tempDir, '-type', 'd', '-maxdepth', '3'], {
+      stdio: 'inherit',
+    })
+    throw new Error('Failed to locate CouchDB installation')
+  }
+
+  logInfo(`Found CouchDB at: ${couchdbDir}`)
+
+  // Create final directory structure
+  const finalDir = resolve(tempDir, 'couchdb-final', 'couchdb')
+  mkdirSync(finalDir, { recursive: true })
+
+  // Copy CouchDB files
+  cpSync(couchdbDir, finalDir, { recursive: true })
+
+  // Add metadata
+  const metadata = {
+    name: 'couchdb',
+    version,
+    platform,
+    source: 'neighbourhoodie',
+    sourceUrl: 'https://neighbourhood.ie/couchdb-support/download-binaries',
+    rehosted_by: 'hostdb',
+    rehosted_at: new Date().toISOString(),
+  }
+  writeFileSync(
+    resolve(finalDir, '.hostdb-metadata.json'),
+    JSON.stringify(metadata, null, 2),
+  )
+
+  // Create ZIP for Windows
+  mkdirSync(dirname(outputPath), { recursive: true })
+  logInfo(`Creating: ${basename(outputPath)}`)
+
+  execFileSync(
+    'zip',
+    ['-rq', outputPath, 'couchdb'],
+    {
+      cwd: resolve(tempDir, 'couchdb-final'),
+      stdio: 'inherit',
+    },
+  )
+
+  // Cleanup
+  rmSync(tempDir, { recursive: true, force: true })
+
+  logSuccess(`Created: ${outputPath}`)
+}
+
+/**
+ * Build from Docker image (Linux platforms only)
+ */
+function buildFromDocker(
+  version: string,
+  platform: Platform,
+  outputDir: string,
+): boolean {
+  if (platform !== 'linux-x64' && platform !== 'linux-arm64') {
+    logError('Docker extraction only supports linux-x64 and linux-arm64')
+    return false
+  }
+
+  const buildScript = resolve(__dirname, 'build-local.sh')
+
+  if (!existsSync(buildScript)) {
+    logError(`Build script not found: ${buildScript}`)
+    return false
+  }
+
+  logInfo(
+    `Extracting from Docker image for ${platform} (this may take a few minutes)...`,
+  )
+  logInfo(`Running: ${buildScript}`)
+
+  const result = spawnSync(
+    buildScript,
+    ['--version', version, '--platform', platform, '--output', outputDir],
+    {
+      stdio: 'inherit',
+      cwd: resolve(__dirname, '../..'),
+      env: { ...process.env, CI: 'true' },
+    },
+  )
+
+  if (result.status !== 0) {
+    logError(`Docker extraction failed with exit code: ${result.status}`)
+    return false
+  }
+
+  logSuccess(`Docker extraction completed for ${platform}`)
+  return true
+}
+
+function parseArgs(): {
+  version: string
+  platforms: Platform[]
+  outputDir: string
+  buildFallback: boolean
+} {
+  const args = process.argv.slice(2)
+  let version = '3.5.1'
+  let platforms: Platform[] = []
+  let outputDir = './downloads'
+  let allPlatforms = false
+  let buildFallback = false
+
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case '--':
+        // Ignore -- (end of options delimiter from pnpm)
+        break
+      case '--version': {
+        if (i + 1 >= args.length || args[i + 1].startsWith('-')) {
+          logError('--version requires a value')
+          process.exit(1)
+        }
+        const versionValue = args[++i]
+        if (!isValidVersion(versionValue)) {
+          logError(`Invalid version format: ${versionValue}`)
+          logError('Version must be in format: X.Y.Z (e.g., 3.5.1)')
+          process.exit(1)
+        }
+        version = versionValue
+        break
+      }
+      case '--platform': {
+        if (i + 1 >= args.length || args[i + 1].startsWith('-')) {
+          logError('--platform requires a value')
+          process.exit(1)
+        }
+        const platformValue = args[++i]
+        if (!isValidPlatform(platformValue)) {
+          logError(`Invalid platform: ${platformValue}`)
+          logError(`Valid platforms: ${VALID_PLATFORMS.join(', ')}`)
+          process.exit(1)
+        }
+        platforms.push(platformValue)
+        break
+      }
+      case '--output':
+        if (i + 1 >= args.length || args[i + 1].startsWith('-')) {
+          logError('--output requires a value')
+          process.exit(1)
+        }
+        outputDir = args[++i]
+        break
+      case '--all-platforms':
+        allPlatforms = true
+        break
+      case '--build-fallback':
+        buildFallback = true
+        break
+      case '--help':
+      case '-h':
+        console.log(`
+Usage: ./builds/couchdb/download.ts [options]
+
+Options:
+  --version VERSION    CouchDB version (default: 3.5.1)
+  --platform PLATFORM  Target platform (default: current)
+  --output DIR         Output directory (default: ./downloads)
+  --all-platforms      Download for all platforms (skips docker-extract unless --build-fallback)
+  --build-fallback     Extract from Docker for Linux platforms
+  --help               Show this help
+
+Platforms: linux-x64, linux-arm64, darwin-x64, darwin-arm64, win32-x64
+
+Sources:
+  - Neighbourhoodie (neighbourhood.ie): darwin-x64, darwin-arm64, win32-x64
+  - Docker extraction: linux-x64, linux-arm64 (with --build-fallback)
+
+Examples:
+  ./builds/couchdb/download.ts
+  ./builds/couchdb/download.ts --version 3.5.1 --platform darwin-arm64
+  ./builds/couchdb/download.ts --all-platforms
+  ./builds/couchdb/download.ts --all-platforms --build-fallback
+`)
+        process.exit(0)
+        break // unreachable, but required for no-fallthrough rule
+    }
+  }
+
+  if (allPlatforms) {
+    platforms = [...VALID_PLATFORMS]
+  } else if (platforms.length === 0) {
+    platforms = [detectPlatform()]
+  }
+
+  return { version, platforms, outputDir, buildFallback }
+}
+
+async function main() {
+  const { version, platforms, outputDir, buildFallback } = parseArgs()
+  const sources = loadSources()
+
+  console.log()
+  logInfo('CouchDB Download Script')
+  logInfo(`Version: ${version}`)
+  logInfo(`Platforms: ${platforms.join(', ')}`)
+  logInfo(`Output: ${outputDir}`)
+  if (buildFallback) {
+    logInfo(
+      'Build fallback: enabled (will extract from Docker for Linux platforms)',
+    )
+  }
+  console.log()
+
+  const versionSources = sources.versions[version]
+  if (!versionSources) {
+    logError(`Version ${version} not found in sources.json`)
+    logInfo(`Available versions: ${Object.keys(sources.versions).join(', ')}`)
+    process.exit(1)
+  }
+
+  let downloadedCount = 0
+  let builtCount = 0
+  let skippedCount = 0
+
+  for (const platform of platforms) {
+    console.log()
+    logInfo(`=== ${platform} ===`)
+
+    const source = versionSources[platform]
+    if (!source) {
+      logWarn(`No source entry for ${platform}, skipping`)
+      skippedCount++
+      continue
+    }
+
+    // Handle docker-extract sources
+    if (!isDownloadableSource(source)) {
+      if (buildFallback) {
+        const canBuild = platform === 'linux-x64' || platform === 'linux-arm64'
+        if (canBuild) {
+          logInfo(
+            `No binary available for ${platform}, extracting from Docker...`,
+          )
+          const success = buildFromDocker(version, platform, outputDir)
+          if (success) {
+            builtCount++
+          } else {
+            logError(`Failed to extract ${platform} from Docker`)
+            skippedCount++
+          }
+          continue
+        } else {
+          logWarn(
+            `${platform} requires Docker extraction but only Linux platforms are supported`,
+          )
+          skippedCount++
+          continue
+        }
+      } else {
+        logWarn(
+          `${platform} requires Docker extraction (no binary available)`,
+        )
+        logInfo(
+          'Use --build-fallback to extract from Docker, or use builds/couchdb/build-local.sh',
+        )
+        skippedCount++
+        continue
+      }
+    }
+
+    const ext = platform.startsWith('win32') ? 'zip' : 'tar.gz'
+    const originalExt = source.format === 'msi' ? 'msi' : source.format
+    const downloadPath = resolve(
+      outputDir,
+      'downloads',
+      `couchdb-${version}-${platform}-original.${originalExt}`,
+    )
+    const outputPath = resolve(
+      outputDir,
+      `couchdb-${version}-${platform}.${ext}`,
+    )
+
+    // Download
+    if (existsSync(downloadPath)) {
+      logInfo(`Using cached download: ${downloadPath}`)
+    } else {
+      await downloadFile(source.url, downloadPath)
+    }
+
+    // Verify checksum
+    const actualSha256 = await calculateSha256(downloadPath)
+    logInfo(`SHA256: ${actualSha256}`)
+
+    if (source.sha256) {
+      if (actualSha256 === source.sha256) {
+        logSuccess('Checksum verified')
+      } else {
+        logError(`Checksum mismatch! Expected: ${source.sha256}`)
+        process.exit(1)
+      }
+    } else {
+      logWarn('No checksum in sources.json - update it with the SHA256 above')
+    }
+
+    // Repackage based on platform and format
+    if (platform.startsWith('darwin')) {
+      repackageMacOS(downloadPath, outputPath, version, platform)
+    } else if (platform === 'win32-x64') {
+      repackageWindowsMSI(downloadPath, outputPath, version, platform)
+    } else {
+      logError(`Unexpected platform for download: ${platform}`)
+      skippedCount++
+      continue
+    }
+
+    // Final checksum
+    const outputSha256 = await calculateSha256(outputPath)
+    logInfo(`Output SHA256: ${outputSha256}`)
+
+    downloadedCount++
+  }
+
+  console.log()
+  logSuccess('Done!')
+  logInfo(`Downloaded: ${downloadedCount} platform(s)`)
+  if (builtCount > 0) {
+    logInfo(`Extracted from Docker: ${builtCount} platform(s)`)
+  }
+  if (skippedCount > 0) {
+    logInfo(`Skipped: ${skippedCount} platform(s)`)
+  }
+  logInfo(`Output files in: ${resolve(outputDir)}`)
+}
+
+main().catch((err) => {
+  logError(err.message)
+  process.exit(1)
+})

--- a/builds/couchdb/sources.json
+++ b/builds/couchdb/sources.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "../../schemas/sources.schema.json",
+  "database": "couchdb",
+  "versions": {
+    "3.5.1": {
+      "linux-x64": {
+        "sourceType": "docker-extract"
+      },
+      "linux-arm64": {
+        "sourceType": "docker-extract"
+      },
+      "darwin-x64": {
+        "url": "https://couchdb.neighbourhood.ie/downloads/3.5.1/mac/x86_64/Apache-CouchDB.zip",
+        "format": "zip",
+        "sourceType": "neighbourhoodie",
+        "sha256": "528f6e2b6cf4352d4012ed5db29ab64861c187e0154c5a62649a1d7a41ad3ad7"
+      },
+      "darwin-arm64": {
+        "url": "https://couchdb.neighbourhood.ie/downloads/3.5.1/mac/arm64/Apache-CouchDB.zip",
+        "format": "zip",
+        "sourceType": "neighbourhoodie",
+        "sha256": "0adddf00aabc686f6f471546345712c86f9eb573fd364eff87e0768d0a96f11e"
+      },
+      "win32-x64": {
+        "url": "https://couchdb.neighbourhood.ie/downloads/3.5.1/win/apache-couchdb-3.5.1.msi",
+        "format": "msi",
+        "sourceType": "neighbourhoodie",
+        "sha256": "7062a90ef24f2603dc7bc75357b2418c62b5ba3d1599ce96bddd22d1fe6ac467"
+      }
+    }
+  },
+  "notes": {
+    "neighbourhoodie": "Official binaries hosted by Neighbourhoodie (https://neighbourhood.ie/couchdb-support/download-binaries)",
+    "docker-extract": "Extracted from official Apache CouchDB Docker image (couchdb:VERSION)",
+    "linux-x64": "Extracted from official Docker image couchdb:VERSION on linux/amd64",
+    "linux-arm64": "Extracted from official Docker image couchdb:VERSION on linux/arm64",
+    "darwin-x64": "Downloaded from Neighbourhoodie (macOS x86_64)",
+    "darwin-arm64": "Downloaded from Neighbourhoodie (macOS Apple Silicon)",
+    "win32-x64": "MSI installer downloaded from Neighbourhoodie, extracted for portable use"
+  }
+}

--- a/databases.json
+++ b/databases.json
@@ -160,7 +160,7 @@
       "license": "Apache-2.0",
       "commercialUse": true,
       "protocol": null,
-      "note": "Less popular document DB; FerretDB provides MongoDB compatibility with permissive license",
+      "note": "",
       "latestLts": "3.5",
       "versions": {
         "3.5.1": true
@@ -187,7 +187,7 @@
         "defaultUser": "admin",
         "queryLanguage": "HTTP"
       },
-      "status": "unsupported"
+      "status": "in-progress"
     },
     "duckdb": {
       "displayName": "DuckDB",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hostdb",
-  "version": "0.15.0",
+  "version": "0.17.0",
   "description": "Source and download pre-built database binaries for multiple platforms, distributed via GitHub Releases",
   "private": false,
   "type": "module",
@@ -30,6 +30,7 @@
     "checksums:populate": "tsx scripts/populate-checksums.ts",
     "dbs": "tsx scripts/list-databases.ts",
     "download:clickhouse": "tsx builds/clickhouse/download.ts",
+    "download:couchdb": "tsx builds/couchdb/download.ts",
     "download:duckdb": "tsx builds/duckdb/download.ts",
     "download:ferretdb": "tsx builds/ferretdb/download.ts",
     "download:mariadb": "tsx builds/mariadb/download.ts",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## CouchDB Support Addition

This PR adds comprehensive Apache CouchDB support to hostdb, enabling the database to be available across all five supported platforms (linux-x64, linux-arm64, darwin-x64, darwin-arm64, win32-x64). CouchDB becomes available for use in spindb and layerbase-desktop via the hostdb binary aggregation infrastructure.

### Core Changes

**Build Infrastructure & Scripts:**
- Multi-stage Dockerfile (`builds/couchdb/Dockerfile`) that extracts CouchDB from the official Docker image for Linux platforms (x64 and ARM64), validates installation integrity, and packages it with metadata
- Shell script (`builds/couchdb/build-local.sh`) for local Docker-based extraction with validation and checksum generation
- TypeScript download script (`builds/couchdb/download.ts`) that handles multi-platform binary acquisition: downloads prebuilt binaries from Neighbourhoodie for macOS and Windows, repackages them with standardized structure and metadata, and provides Docker-based fallback for Linux builds

**Configuration & Manifest:**
- `builds/couchdb/sources.json` defines version 3.5.1 with platform-specific source details: Docker extraction for Linux, direct download URLs for macOS/Windows from Neighbourhoodie with SHA256 checksums
- `builds/couchdb/README.md` documents platform coverage, build methods, usage, and quickstart instructions
- `databases.json` updated: CouchDB status changed from "unsupported" to "in-progress" with full metadata (display name, description, connection details, CLI tools, Apache-2.0 license)
- Package version bumped from 0.15.0 to 0.17.0; new npm script added: `download:couchdb`

**Release Automation:**
- Comprehensive GitHub Actions workflow (`.github/workflows/release-couchdb.yml`) orchestrating the complete release pipeline:
  - Validation stage checks version existence in databases.json and sources.json
  - Prepare stage derives platform matrix with appropriate runners (ubuntu-latest for Linux/macOS downloads, windows-latest for MSI extraction)
  - Parallel build stage executes platform-specific logic: Docker extraction for Linux, direct download and repackaging for macOS, MSI download and extraction for Windows
  - Checksum generation and artifact upload per platform
  - Release creation consolidates all artifacts and publishes GitHub release with checksums
  - Manifest update runs TypeScript script to update releases.json with retry logic for concurrent conflicts
  - Sync trigger ensures downstream systems are notified

**Documentation:**
- CHANGELOG entry (version 0.17.0) documents CouchDB as new database engine with platform availability and source information

### Architecture Details

CouchDB follows hostdb's established multi-source strategy: Linux platforms extract from official Docker images ensuring supply chain security, while macOS and Windows obtain prebuilt binaries from Neighbourhoodie (a CouchDB official support provider). All artifacts are repackaged with standardized directory structures and `.hostdb-metadata.json` containing version, platform, source, and provenance information, enabling spindb to abstract away platform differences and present a unified database interface to end users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->