### PR TITLE
chore: mark QuestDB as completed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.19.1] - 2026-01-26
+
+### Changed
+
+- **QuestDB marked as completed** - All platforms fully tested and integrated with SpinDB
+
 ## [0.19.0] - 2026-01-26
 
 ### Added

--- a/databases.json
+++ b/databases.json
@@ -755,7 +755,7 @@
         "defaultUser": "admin",
         "queryLanguage": "SQL"
       },
-      "status": "in-progress"
+      "status": "completed"
     },
     "redis": {
       "displayName": "Redis",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hostdb",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "Source and download pre-built database binaries for multiple platforms, distributed via GitHub Releases",
   "private": false,
   "type": "module",


### PR DESCRIPTION
## Summary

- Mark QuestDB status as `completed` in databases.json
- Bump version to 0.19.1
- Update CHANGELOG.md