### PR TITLE
fix: set MACOSX_DEPLOYMENT_TARGET for PostgreSQL build on macOS 15.5 SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.19.4] - 2026-02-07
+
+### Fixed
+
+- **macOS build: fix PostgreSQL compilation on macOS 15.5 SDK**
+  - `strchrnul` declared available since macOS 15.4, but deployment target defaulted to 15.0
+  - PostgreSQL's `-Werror=unguarded-availability-new` turned this into a build error
+  - Set `MACOSX_DEPLOYMENT_TARGET` to current OS version dynamically
+  - Safe for arm64 (macOS 14 SDK doesn't declare `strchrnul` at all)
+
 ## [0.19.3] - 2026-02-07
 
 ### Fixed

--- a/builds/postgresql-documentdb/build-macos.sh
+++ b/builds/postgresql-documentdb/build-macos.sh
@@ -152,6 +152,13 @@ log_success "Extracted PostgreSQL source"
 # to the binary location at runtime - we just need a STANDARD directory structure
 log_info "Configuring PostgreSQL (standard --prefix layout)..."
 
+# Set deployment target to current OS version.
+# macOS 15.5 SDK declares strchrnul (available since 15.4), and PostgreSQL's
+# configure adds -Werror=unguarded-availability-new which errors if the
+# deployment target is lower than 15.4. Setting it to the running OS version
+# avoids this on x64 (macOS 15) and is a no-op on arm64 (macOS 14, no strchrnul).
+export MACOSX_DEPLOYMENT_TARGET="$(sw_vers -productVersion)"
+
 # Set up environment for configure
 export CPPFLAGS="-I${OPENSSL_PREFIX}/include -I${READLINE_PREFIX}/include -I${LIBXML2_PREFIX}/include -I${ICU_PREFIX}/include -I${ZLIB_PREFIX}/include -I${LZ4_PREFIX}/include -I${ZSTD_PREFIX}/include"
 export LDFLAGS="-L${OPENSSL_PREFIX}/lib -L${READLINE_PREFIX}/lib -L${LIBXML2_PREFIX}/lib -L${ICU_PREFIX}/lib -L${ZLIB_PREFIX}/lib -L${LZ4_PREFIX}/lib -L${ZSTD_PREFIX}/lib"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hostdb",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "Source and download pre-built database binaries for multiple platforms, distributed via GitHub Releases",
   "private": false,
   "type": "module",


### PR DESCRIPTION
strchrnul (available since macOS 15.4) causes -Werror=unguarded-availability-new to fail when targeting 15.0. Dynamically set deployment target to current OS version.