### PR TITLE
fix: disable NLS in PostgreSQL configure to fix PostGIS build on x64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.19.5] - 2026-02-07
+
+### Fixed
+
+- **macOS build: disable NLS to fix PostGIS compilation on x64 runner**
+  - PostgreSQL's configure detected gettext on the x64 runner, enabling NLS
+  - This baked `#include <libintl.h>` into server headers (`c.h`)
+  - PostGIS build failed with `'libintl.h' file not found` since gettext include path wasn't propagated
+  - Fix: `--disable-nls` in PostgreSQL configure (translated error messages not needed)
+
 ## [0.19.4] - 2026-02-07
 
 ### Fixed

--- a/builds/postgresql-documentdb/build-macos.sh
+++ b/builds/postgresql-documentdb/build-macos.sh
@@ -171,7 +171,8 @@ export PKG_CONFIG_PATH="${OPENSSL_PREFIX}/lib/pkgconfig:${READLINE_PREFIX}/lib/p
     --with-icu \
     --with-lz4 \
     --with-zstd \
-    --with-readline
+    --with-readline \
+    --disable-nls
 
 log_success "PostgreSQL configured"
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hostdb",
-  "version": "0.19.4",
+  "version": "0.19.5",
   "description": "Source and download pre-built database binaries for multiple platforms, distributed via GitHub Releases",
   "private": false,
   "type": "module",


### PR DESCRIPTION
gettext on the x64 runner causes PostgreSQL to enable NLS, baking libintl.h into server headers. PostGIS then fails because it doesn't have gettext's include path.