### PR TITLE
feat: add TypeDB support

### DIFF
--- a/.github/workflows/release-typedb.yml
+++ b/.github/workflows/release-typedb.yml
@@ -1,0 +1,265 @@
+name: Release TypeDB
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'TypeDB version'
+        required: true
+        type: choice
+        options:
+          - 3.8.0
+        default: 3.8.0
+      platforms:
+        description: 'Platforms'
+        required: true
+        default: 'all'
+        type: choice
+        options:
+          - 'all'
+          - 'linux-x64'
+          - 'linux-arm64'
+          - 'darwin-x64'
+          - 'darwin-arm64'
+          - 'win32-x64'
+
+# Prevent concurrent runs that could conflict when updating releases.json
+concurrency:
+  group: release-typedb
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ github.event.inputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate version against databases.json
+        run: |
+          DB="typedb"
+
+          echo "Validating TypeDB version: $VERSION"
+
+          # Check if version exists and is enabled in databases.json
+          ENABLED=$(jq -r ".databases.$DB.versions[\"$VERSION\"] // false" databases.json)
+          if [ "$ENABLED" != "true" ]; then
+            echo "::error::Version '$VERSION' is not enabled in databases.json"
+            echo ""
+            echo "Available versions:"
+            jq -r ".databases.$DB.versions | to_entries | map(select(.value == true)) | .[].key" databases.json
+            exit 1
+          fi
+
+          echo "✓ Version $VERSION is enabled in databases.json"
+
+      - name: Validate sources.json exists
+        run: |
+          DB="typedb"
+          if [ ! -f "builds/$DB/sources.json" ]; then
+            echo "::error::Missing builds/$DB/sources.json"
+            exit 1
+          fi
+          echo "✓ builds/$DB/sources.json exists"
+
+      - name: Validate version in sources.json
+        run: |
+          DB="typedb"
+
+          HAS_VERSION=$(jq -r ".versions[\"$VERSION\"] // empty" "builds/$DB/sources.json")
+          if [ -z "$HAS_VERSION" ]; then
+            echo "::error::Version '$VERSION' not found in builds/$DB/sources.json"
+            echo ""
+            echo "Available versions in sources.json:"
+            jq -r ".versions | keys[]" "builds/$DB/sources.json"
+            exit 1
+          fi
+
+          echo "✓ Version $VERSION found in sources.json"
+
+  build:
+    needs: validate
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ github.event.inputs.version }}
+      PLATFORMS: ${{ github.event.inputs.platforms }}
+    outputs:
+      artifact_names: ${{ steps.build.outputs.artifact_names }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download and repackage TypeDB
+        id: build
+        run: |
+          if [ "$PLATFORMS" = "all" ]; then
+            pnpm download:typedb -- --version "$VERSION" --all-platforms --output ./dist
+          else
+            for platform in $(echo "$PLATFORMS" | tr ',' ' '); do
+              pnpm download:typedb -- --version "$VERSION" --platform "$platform" --output ./dist
+            done
+          fi
+
+          # List created artifacts
+          ls -la ./dist/
+
+          # Create artifact names output
+          shopt -s nullglob
+          FILES=(./dist/*.tar.gz ./dist/*.zip)
+          if [ ${#FILES[@]} -eq 0 ]; then
+            echo "ERROR: No artifacts were created"
+            exit 1
+          fi
+          ARTIFACTS=$(printf '%s\n' "${FILES[@]}" | xargs -n1 basename | tr '\n' ',' | sed 's/,$//')
+          echo "artifact_names=$ARTIFACTS" >> $GITHUB_OUTPUT
+
+      - name: Generate checksums
+        run: |
+          cd dist
+          sha256sum *.tar.gz *.zip 2>/dev/null > checksums.txt || sha256sum *.tar.gz 2>/dev/null > checksums.txt || sha256sum *.zip > checksums.txt
+          cat checksums.txt
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: typedb-${{ github.event.inputs.version }}
+          path: |
+            dist/*.tar.gz
+            dist/*.zip
+            dist/checksums.txt
+          retention-days: 7
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: typedb-${{ github.event.inputs.version }}
+          path: ./release-assets
+
+      - name: List release assets
+        run: ls -la ./release-assets/
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: typedb-${{ github.event.inputs.version }}
+          name: TypeDB ${{ github.event.inputs.version }}
+          body: |
+            ## TypeDB ${{ github.event.inputs.version }}
+
+            TypeDB binaries repackaged for hostdb. Each archive contains the TypeDB server, console, launcher script, config, and LICENSE.
+
+            ### Platforms
+            - `linux-x64` - Linux x86_64
+            - `linux-arm64` - Linux ARM64
+            - `darwin-x64` - macOS x86_64
+            - `darwin-arm64` - macOS Apple Silicon
+            - `win32-x64` - Windows x64
+
+            ### Archive Contents
+            ```
+            typedb/
+              .hostdb-metadata.json
+              LICENSE
+              typedb (launcher script)
+              server/
+                typedb_server_bin
+                config.yml
+              console/
+                typedb_console_bin
+            ```
+
+            ### Usage
+            ```bash
+            # Download URL pattern
+            https://github.com/${{ github.repository }}/releases/download/typedb-${{ github.event.inputs.version }}/typedb-${{ github.event.inputs.version }}-<platform>.tar.gz
+            ```
+
+            ### Checksums
+            See `checksums.txt` for SHA256 checksums.
+          files: |
+            release-assets/*.tar.gz
+            release-assets/*.zip
+            release-assets/checksums.txt
+          fail_on_unmatched_files: false
+
+  update-manifest:
+    needs: release
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ github.event.inputs.version }}
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Update releases.json
+        run: |
+          pnpm tsx scripts/update-releases.ts \
+            --database typedb \
+            --version "$VERSION" \
+            --tag "typedb-$VERSION"
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add releases.json
+          git diff --staged --quiet && echo "No changes to commit" && exit 0
+
+          git commit -m "chore: update releases.json for typedb-$VERSION"
+
+          # Retry push with rebase if remote has changed
+          for i in 1 2 3; do
+            if git push; then
+              echo "Push succeeded"
+              exit 0
+            fi
+            echo "Push failed, attempting rebase (attempt $i/3)..."
+            git fetch origin main
+            if ! git rebase origin/main; then
+              echo "ERROR: Rebase failed due to conflicts. Manual intervention required."
+              git rebase --abort
+              exit 1
+            fi
+            sleep $((2**i))
+          done
+          echo "ERROR: Push failed after 3 attempts"
+          exit 1

--- a/BINARIES.md
+++ b/BINARIES.md
@@ -17,6 +17,7 @@ Archive structure for each database distributed by hostdb.
 | ClickHouse | `clickhouse/` | `bin/` `.hostdb-metadata.json` | `bin/clickhouse` | `bin/clickhouse` |
 | Qdrant | `qdrant/` | `qdrant` `.hostdb-metadata.json` | `qdrant` | — (HTTP) |
 | Meilisearch | `meilisearch/` | `meilisearch` `.hostdb-metadata.json` | `meilisearch` | — (HTTP) |
+| TypeDB | `typedb/` | `server/` `console/` `typedb` `LICENSE` `.hostdb-metadata.json` | `server/typedb_server_bin` | `console/typedb_console_bin` |
 
 ## Detailed Structure
 
@@ -92,6 +93,21 @@ clickhouse/
 └── .hostdb-metadata.json
 ```
 
+### Custom structure (server/ + console/ subdirectories)
+
+```
+typedb/
+├── typedb                   # launcher script (typedb.bat on Windows)
+├── server/
+│   ├── typedb_server_bin    # or .exe on Windows
+│   ├── config.yml
+│   └── data/
+├── console/
+│   └── typedb_console_bin   # or .exe on Windows
+├── LICENSE
+└── .hostdb-metadata.json
+```
+
 ### Single binary (no bin/ subdirectory)
 
 ```
@@ -150,3 +166,4 @@ Every archive includes `.hostdb-metadata.json`:
 | ClickHouse | Yes | 1 + symlinks | CLI (`clickhouse client`) |
 | Qdrant | No | 1 | HTTP API only |
 | Meilisearch | No | 1 | HTTP API only |
+| TypeDB | Custom (`server/`, `console/`) | 2 + launcher | CLI (`typedb_console_bin`) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.20.0] - 2026-02-07
+
+### Added
+
+- **TypeDB support** (new database engine)
+  - Strongly-typed graph database with TypeQL query language, built for knowledge representation and reasoning
+  - All 5 platforms supported: linux-x64, linux-arm64, darwin-x64, darwin-arm64, win32-x64
+  - Official binaries from Cloudsmith (repo.typedb.com)
+  - Version 3.8.0 (Rust rewrite, v3.x)
+  - Archive preserves TypeDB's multi-component structure: server, console, launcher script, config
+  - First graph database in hostdb
+  - License: MPL-2.0
+
 ## [0.19.5] - 2026-02-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Auto-generated manifest updated after each GitHub Release. Structure:
 | ClickHouse | Analytical | Completed | 25.12.3.21 | Official binaries (no Windows) |
 | Qdrant | Vector | Completed | 1.16.3 | Official binaries |
 | Meilisearch | Search | In Progress | 1.33.1 | Official binaries |
+| TypeDB | Graph | In Progress | 3.8.0 | Official binaries (Cloudsmith) |
 
 See `pnpm dbs` for the full list.
 

--- a/builds/typedb/README.md
+++ b/builds/typedb/README.md
@@ -1,0 +1,85 @@
+# TypeDB Builds
+
+Download and repackage TypeDB binaries for distribution via GitHub Releases.
+
+## Status
+
+**In Progress** - All platforms have official binaries available.
+
+## Supported Versions
+
+- 3.8.0
+
+## Supported Platforms
+
+- `linux-x64` - Linux x86_64
+- `linux-arm64` - Linux ARM64
+- `darwin-x64` - macOS Intel
+- `darwin-arm64` - macOS Apple Silicon
+- `win32-x64` - Windows x64
+
+## Binary Sources
+
+| Platform | Source | Format | Notes |
+|----------|--------|--------|-------|
+| linux-x64 | Official (Cloudsmith) | tar.gz | |
+| linux-arm64 | Official (Cloudsmith) | tar.gz | |
+| darwin-x64 | Official (Cloudsmith) | zip | |
+| darwin-arm64 | Official (Cloudsmith) | zip | |
+| win32-x64 | Official (Cloudsmith) | zip | |
+
+All binaries are downloaded from TypeDB's Cloudsmith repository at `repo.typedb.com`.
+
+## Usage
+
+```bash
+# Download for current platform
+pnpm download:typedb
+
+# Download specific version
+pnpm download:typedb -- --version 3.8.0
+
+# Download for specific platform
+pnpm download:typedb -- --version 3.8.0 --platform linux-x64
+
+# Download for all platforms
+pnpm download:typedb -- --all-platforms
+```
+
+## Archive Contents
+
+Each hostdb release preserves TypeDB's multi-component structure:
+
+```
+typedb/
+├── typedb                   # launcher script (typedb.bat on Windows)
+├── server/
+│   ├── typedb_server_bin    # server binary (.exe on Windows)
+│   ├── config.yml
+│   └── data/
+├── console/
+│   └── typedb_console_bin   # console binary (.exe on Windows)
+├── LICENSE
+└── .hostdb-metadata.json
+```
+
+## Running TypeDB
+
+```bash
+# Extract and run server
+tar -xzf typedb-3.8.0-darwin-arm64.tar.gz
+cd typedb
+./typedb server
+
+# TypeDB starts on port 1729
+
+# Connect with console (in another terminal)
+./console/typedb_console_bin
+```
+
+## Related Links
+
+- [TypeDB Official Site](https://typedb.com/)
+- [TypeDB Documentation](https://typedb.com/docs)
+- [TypeDB Downloads](https://cloudsmith.io/~typedb/repos/public-release/packages/)
+- [Source Repository](https://github.com/typedb/typedb)

--- a/builds/typedb/download.ts
+++ b/builds/typedb/download.ts
@@ -1,0 +1,572 @@
+#!/usr/bin/env tsx
+/**
+ * Download official TypeDB binaries for re-hosting
+ *
+ * Usage:
+ *   pnpm download:typedb
+ *   pnpm download:typedb -- --version 3.8.0
+ *   pnpm download:typedb -- --all-platforms
+ *
+ * TypeDB distributes "typedb-all" archives via Cloudsmith:
+ * - Linux: tar.gz containing typedb-all-linux-{arch}-{version}/
+ * - macOS: zip containing typedb-all-mac-{arch}-{version}/
+ * - Windows: zip containing typedb-all-windows-x86_64-{version}/
+ *
+ * Each archive contains:
+ *   typedb-all-{platform}-{version}/
+ *     LICENSE
+ *     typedb (or typedb.bat on Windows)
+ *     server/
+ *       typedb_server_bin (or .exe)
+ *       config.yml
+ *       data/
+ *     console/
+ *       typedb_console_bin (or .exe)
+ *
+ * The repackage step renames the top-level directory to "typedb" and
+ * injects .hostdb-metadata.json, preserving the original structure.
+ */
+
+import {
+  createWriteStream,
+  createReadStream,
+  mkdirSync,
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  readdirSync,
+  rmSync,
+  renameSync,
+  unlinkSync,
+} from 'node:fs'
+import { createHash } from 'node:crypto'
+import { resolve, dirname, basename } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { execFileSync } from 'node:child_process'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+type Platform =
+  | 'linux-x64'
+  | 'linux-arm64'
+  | 'darwin-x64'
+  | 'darwin-arm64'
+  | 'win32-x64'
+
+const VALID_PLATFORMS: Platform[] = [
+  'linux-x64',
+  'linux-arm64',
+  'darwin-x64',
+  'darwin-arm64',
+  'win32-x64',
+]
+
+function isValidPlatform(value: string): value is Platform {
+  return VALID_PLATFORMS.includes(value as Platform)
+}
+
+const VERSION_REGEX = /^\d+\.\d+\.\d+$/
+
+function isValidVersion(value: string): boolean {
+  return VERSION_REGEX.test(value)
+}
+
+type SourceEntry = {
+  url: string
+  format: 'tar.gz' | 'zip'
+  sha256: string | null
+  sourceType: 'official'
+}
+
+type Sources = {
+  database: string
+  versions: Record<string, Record<Platform, SourceEntry>>
+  notes: Record<string, string>
+}
+
+const colors = {
+  reset: '\x1b[0m',
+  red: '\x1b[31m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  blue: '\x1b[34m',
+  cyan: '\x1b[36m',
+}
+
+function log(color: keyof typeof colors, prefix: string, msg: string) {
+  console.log(`${colors[color]}[${prefix}]${colors.reset} ${msg}`)
+}
+
+function logInfo(msg: string) {
+  log('blue', 'INFO', msg)
+}
+function logSuccess(msg: string) {
+  log('green', 'OK', msg)
+}
+function logWarn(msg: string) {
+  log('yellow', 'WARN', msg)
+}
+function logError(msg: string) {
+  log('red', 'ERROR', msg)
+}
+
+function detectPlatform(): Platform {
+  const platform = process.platform
+  const arch = process.arch
+
+  if (platform === 'linux' && arch === 'x64') return 'linux-x64'
+  if (platform === 'linux' && arch === 'arm64') return 'linux-arm64'
+  if (platform === 'darwin' && arch === 'x64') return 'darwin-x64'
+  if (platform === 'darwin' && arch === 'arm64') return 'darwin-arm64'
+  if (platform === 'win32' && arch === 'x64') return 'win32-x64'
+
+  throw new Error(`Unsupported platform: ${platform}-${arch}`)
+}
+
+function loadSources(): Sources {
+  const sourcesPath = resolve(__dirname, 'sources.json')
+  const content = readFileSync(sourcesPath, 'utf-8')
+  try {
+    return JSON.parse(content) as Sources
+  } catch (error) {
+    throw new Error(`Failed to parse sources.json: invalid JSON`, {
+      cause: error,
+    })
+  }
+}
+
+async function downloadFile(url: string, destPath: string): Promise<void> {
+  logInfo(`Downloading: ${url}`)
+
+  const response = await fetch(url, { redirect: 'follow' })
+
+  if (!response.ok) {
+    throw new Error(
+      `Download failed: ${response.status} ${response.statusText}`,
+    )
+  }
+
+  const contentLength = response.headers.get('content-length')
+  const totalBytes = contentLength ? parseInt(contentLength, 10) : 0
+
+  mkdirSync(dirname(destPath), { recursive: true })
+
+  const tempPath = destPath + '.partial'
+  const fileStream = createWriteStream(tempPath)
+  const reader = response.body?.getReader()
+
+  if (!reader) {
+    throw new Error('No response body')
+  }
+
+  let downloadedBytes = 0
+  const startTime = Date.now()
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+
+      const canContinue = fileStream.write(value)
+      downloadedBytes += value.length
+
+      if (!canContinue) {
+        await new Promise<void>((resolve, reject) => {
+          const onDrain = () => {
+            fileStream.removeListener('error', onError)
+            resolve()
+          }
+          const onError = (err: Error) => {
+            fileStream.removeListener('drain', onDrain)
+            reject(err)
+          }
+          fileStream.once('drain', onDrain)
+          fileStream.once('error', onError)
+        })
+      }
+
+      if (totalBytes > 0) {
+        const percent = ((downloadedBytes / totalBytes) * 100).toFixed(1)
+        const mbDownloaded = (downloadedBytes / 1024 / 1024).toFixed(1)
+        const mbTotal = (totalBytes / 1024 / 1024).toFixed(1)
+        process.stdout.write(
+          `\r  ${mbDownloaded}MB / ${mbTotal}MB (${percent}%)    `,
+        )
+      } else {
+        const mbDownloaded = (downloadedBytes / 1024 / 1024).toFixed(1)
+        process.stdout.write(`\r  ${mbDownloaded}MB downloaded...    `)
+      }
+    }
+
+    await new Promise<void>((resolve, reject) => {
+      fileStream.end()
+      fileStream.on('finish', resolve)
+      fileStream.on('error', reject)
+    })
+
+    // Rename temp file to final destination
+    renameSync(tempPath, destPath)
+
+    console.log()
+
+    const duration = ((Date.now() - startTime) / 1000).toFixed(1)
+    logSuccess(
+      `Downloaded ${(downloadedBytes / 1024 / 1024).toFixed(1)}MB in ${duration}s`,
+    )
+  } catch (error) {
+    // Clean up partial file on error
+    fileStream.destroy()
+    try {
+      reader.cancel()
+    } catch {
+      // Ignore cancel errors
+    }
+    try {
+      if (existsSync(tempPath)) {
+        unlinkSync(tempPath)
+      }
+    } catch {
+      // Ignore cleanup errors
+    }
+    console.log()
+    throw error
+  }
+}
+
+async function calculateSha256(filePath: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const hash = createHash('sha256')
+    const stream = createReadStream(filePath)
+
+    stream.on('data', (chunk) => hash.update(chunk))
+    stream.on('end', () => resolve(hash.digest('hex')))
+    stream.on('error', reject)
+  })
+}
+
+function verifyCommand(command: string): void {
+  const whichCmd = process.platform === 'win32' ? 'where' : 'which'
+  try {
+    execFileSync(whichCmd, [command], { stdio: 'pipe' })
+  } catch {
+    throw new Error(`Required command not found: ${command}`)
+  }
+}
+
+function extractTarGz(sourcePath: string, destDir: string): void {
+  logInfo('Extracting tar.gz archive...')
+  mkdirSync(destDir, { recursive: true })
+  verifyCommand('tar')
+  execFileSync('tar', ['-xzf', sourcePath, '-C', destDir], {
+    stdio: 'inherit',
+  })
+}
+
+function extractZip(sourcePath: string, destDir: string): void {
+  logInfo('Extracting zip archive...')
+  mkdirSync(destDir, { recursive: true })
+
+  if (process.platform === 'win32') {
+    const psCommand = `Expand-Archive -Path '${sourcePath}' -DestinationPath '${destDir}' -Force`
+    execFileSync('powershell', ['-NoProfile', '-Command', psCommand], {
+      stdio: 'inherit',
+    })
+  } else {
+    verifyCommand('unzip')
+    execFileSync('unzip', ['-q', '-o', sourcePath, '-d', destDir], {
+      stdio: 'inherit',
+    })
+  }
+}
+
+function findTypedbDir(extractDir: string): string {
+  const entries = readdirSync(extractDir, { withFileTypes: true })
+  const dirs = entries.filter(
+    (e) => e.isDirectory() && e.name.startsWith('typedb-all-'),
+  )
+
+  if (dirs.length === 1) {
+    return resolve(extractDir, dirs[0].name)
+  }
+
+  // Fallback: look for any directory containing a "server" subdirectory
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      const serverDir = resolve(extractDir, entry.name, 'server')
+      if (existsSync(serverDir)) {
+        return resolve(extractDir, entry.name)
+      }
+    }
+  }
+
+  throw new Error(
+    `Could not find TypeDB directory in ${extractDir}. Contents: ${entries.map((e) => e.name).join(', ')}`,
+  )
+}
+
+function repackage(
+  extractDir: string,
+  outputPath: string,
+  version: string,
+  platform: Platform,
+): void {
+  if (platform.startsWith('win32')) {
+    verifyCommand('zip')
+  } else {
+    verifyCommand('tar')
+  }
+
+  // Find the extracted typedb-all-* directory
+  const typedbSrcDir = findTypedbDir(extractDir)
+  logInfo(`Found TypeDB directory: ${basename(typedbSrcDir)}`)
+
+  // Rename to "typedb"
+  const typedbDir = resolve(extractDir, 'typedb')
+  renameSync(typedbSrcDir, typedbDir)
+
+  // Inject metadata file
+  const metadata = {
+    name: 'typedb',
+    version,
+    platform,
+    source: 'official',
+    rehosted_by: 'hostdb',
+    rehosted_at: new Date().toISOString(),
+  }
+  writeFileSync(
+    resolve(typedbDir, '.hostdb-metadata.json'),
+    JSON.stringify(metadata, null, 2),
+  )
+
+  // Create output archive
+  mkdirSync(dirname(outputPath), { recursive: true })
+  logInfo(`Creating: ${basename(outputPath)}`)
+
+  if (platform.startsWith('win32')) {
+    execFileSync('zip', ['-rq', outputPath, 'typedb'], {
+      stdio: 'inherit',
+      cwd: extractDir,
+    })
+  } else {
+    execFileSync('tar', ['-czf', outputPath, '-C', extractDir, 'typedb'], {
+      stdio: 'inherit',
+    })
+  }
+
+  logSuccess(`Created: ${outputPath}`)
+}
+
+function parseArgs(): {
+  version: string
+  platforms: Platform[]
+  outputDir: string
+} {
+  const args = process.argv.slice(2)
+  let version = '3.8.0'
+  let platforms: Platform[] = []
+  let outputDir = './dist'
+  let allPlatforms = false
+
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case '--':
+        // Ignore -- (end of options delimiter from pnpm)
+        break
+      case '--version': {
+        if (i + 1 >= args.length || args[i + 1].startsWith('-')) {
+          logError('--version requires a value')
+          process.exit(1)
+          break
+        }
+        const versionValue = args[++i]
+        if (!isValidVersion(versionValue)) {
+          logError(`Invalid version format: ${versionValue}`)
+          logError('Version must be in format: X.Y.Z (e.g., 3.8.0)')
+          process.exit(1)
+          break
+        }
+        version = versionValue
+        break
+      }
+      case '--platform': {
+        if (i + 1 >= args.length || args[i + 1].startsWith('-')) {
+          logError('--platform requires a value')
+          process.exit(1)
+          break
+        }
+        const platformValue = args[++i]
+        if (!isValidPlatform(platformValue)) {
+          logError(`Invalid platform: ${platformValue}`)
+          logError(`Valid platforms: ${VALID_PLATFORMS.join(', ')}`)
+          process.exit(1)
+          break
+        }
+        platforms.push(platformValue)
+        break
+      }
+      case '--output':
+        if (i + 1 >= args.length || args[i + 1].startsWith('-')) {
+          logError('--output requires a value')
+          process.exit(1)
+          break
+        }
+        outputDir = args[++i]
+        break
+      case '--all-platforms':
+        allPlatforms = true
+        break
+      case '--help':
+      case '-h':
+        console.log(`
+Usage: pnpm download:typedb [options]
+
+Options:
+  --version VERSION    TypeDB version (default: 3.8.0)
+  --platform PLATFORM  Target platform (default: current)
+  --output DIR         Output directory (default: ./dist)
+  --all-platforms      Download for all platforms
+  --help               Show this help
+
+Platforms: linux-x64, linux-arm64, darwin-x64, darwin-arm64, win32-x64
+
+Examples:
+  pnpm download:typedb
+  pnpm download:typedb -- --version 3.8.0 --platform linux-x64
+  pnpm download:typedb -- --all-platforms
+`)
+        process.exit(0)
+        break
+    }
+  }
+
+  if (allPlatforms) {
+    platforms = [...VALID_PLATFORMS]
+  } else if (platforms.length === 0) {
+    platforms = [detectPlatform()]
+  }
+
+  return { version, platforms, outputDir }
+}
+
+async function main() {
+  const { version, platforms, outputDir } = parseArgs()
+  const sources = loadSources()
+
+  console.log()
+  logInfo(`TypeDB Download Script`)
+  logInfo(`Version: ${version}`)
+  logInfo(`Platforms: ${platforms.join(', ')}`)
+  logInfo(`Output: ${outputDir}`)
+  console.log()
+
+  const versionSources = sources.versions[version]
+  if (!versionSources) {
+    logError(`Version ${version} not found in sources.json`)
+    logInfo(`Available versions: ${Object.keys(sources.versions).join(', ')}`)
+    process.exit(1)
+  }
+
+  let successCount = 0
+
+  for (const platform of platforms) {
+    console.log()
+    logInfo(`=== ${platform} ===`)
+
+    const source = versionSources[platform]
+    if (!source) {
+      logWarn(`No source for ${platform}, skipping`)
+      continue
+    }
+
+    const ext = platform.startsWith('win32') ? 'zip' : 'tar.gz'
+    const downloadPath = resolve(
+      outputDir,
+      'downloads',
+      `typedb-${version}-${platform}-original.${source.format === 'tar.gz' ? 'tar.gz' : 'zip'}`,
+    )
+    const outputPath = resolve(outputDir, `typedb-${version}-${platform}.${ext}`)
+
+    // Download or use cache (with checksum verification)
+    let needsDownload = !existsSync(downloadPath)
+
+    if (!needsDownload) {
+      // Verify cached file integrity
+      const cachedSha256 = await calculateSha256(downloadPath)
+      if (source.sha256) {
+        if (cachedSha256 === source.sha256) {
+          logInfo(`Using cached download: ${downloadPath}`)
+          logSuccess('Cached file checksum verified')
+        } else {
+          logWarn(
+            `Cached file checksum mismatch (got ${cachedSha256.slice(0, 16)}..., expected ${source.sha256.slice(0, 16)}...)`,
+          )
+          logInfo('Re-downloading...')
+          rmSync(downloadPath, { force: true })
+          needsDownload = true
+        }
+      } else {
+        logWarn(
+          `No checksum in sources.json to verify cached file (SHA256: ${cachedSha256})`,
+        )
+        logInfo('Re-downloading to ensure integrity...')
+        rmSync(downloadPath, { force: true })
+        needsDownload = true
+      }
+    }
+
+    if (needsDownload) {
+      await downloadFile(source.url, downloadPath)
+    }
+
+    // Verify checksum after download
+    const actualSha256 = await calculateSha256(downloadPath)
+    if (needsDownload) {
+      logInfo(`SHA256: ${actualSha256}`)
+    }
+
+    if (source.sha256) {
+      if (actualSha256 === source.sha256) {
+        if (needsDownload) {
+          logSuccess('Checksum verified')
+        }
+      } else {
+        logError(`Checksum mismatch! Expected: ${source.sha256}`)
+        process.exit(1)
+      }
+    } else if (needsDownload) {
+      logWarn('No checksum in sources.json - update it with the SHA256 above')
+    }
+
+    // Extract archive
+    const extractDir = resolve(outputDir, 'extract', platform)
+    rmSync(extractDir, { recursive: true, force: true })
+    mkdirSync(extractDir, { recursive: true })
+
+    if (source.format === 'tar.gz') {
+      extractTarGz(downloadPath, extractDir)
+    } else {
+      extractZip(downloadPath, extractDir)
+    }
+
+    // Repackage with metadata (preserves directory structure)
+    repackage(extractDir, outputPath, version, platform)
+
+    // Cleanup extract directory
+    rmSync(extractDir, { recursive: true, force: true })
+
+    // Final checksum
+    const outputSha256 = await calculateSha256(outputPath)
+    logInfo(`Output SHA256: ${outputSha256}`)
+
+    successCount++
+  }
+
+  console.log()
+  logSuccess(`Done! ${successCount}/${platforms.length} platforms completed`)
+  logInfo(`Output files in: ${resolve(outputDir)}`)
+}
+
+main().catch((err) => {
+  logError(err.message)
+  process.exit(1)
+})

--- a/builds/typedb/sources.json
+++ b/builds/typedb/sources.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "../../schemas/sources.schema.json",
+  "database": "typedb",
+  "versions": {
+    "3.8.0": {
+      "linux-x64": {
+        "url": "https://repo.typedb.com/public/public-release/raw/names/typedb-all-linux-x86_64/versions/3.8.0/typedb-all-linux-x86_64-3.8.0.tar.gz",
+        "format": "tar.gz",
+        "sha256": "4e1dbb003b65e79ed772023c573489028af79433b82287e76b31fbdc10abbd64",
+        "sourceType": "official"
+      },
+      "linux-arm64": {
+        "url": "https://repo.typedb.com/public/public-release/raw/names/typedb-all-linux-arm64/versions/3.8.0/typedb-all-linux-arm64-3.8.0.tar.gz",
+        "format": "tar.gz",
+        "sha256": "cba5652fc2a2d20bfe7881aa86b77facde0ac423c271309a902440c63dc5ab71",
+        "sourceType": "official"
+      },
+      "darwin-x64": {
+        "url": "https://repo.typedb.com/public/public-release/raw/names/typedb-all-mac-x86_64/versions/3.8.0/typedb-all-mac-x86_64-3.8.0.zip",
+        "format": "zip",
+        "sha256": "1503e518bdde7db3ba324ad56dd32d8cbdeefa1929fe86f83d9903ebaa23c9f7",
+        "sourceType": "official"
+      },
+      "darwin-arm64": {
+        "url": "https://repo.typedb.com/public/public-release/raw/names/typedb-all-mac-arm64/versions/3.8.0/typedb-all-mac-arm64-3.8.0.zip",
+        "format": "zip",
+        "sha256": "640d3923e3b131b07024a054c42f3e7703e20551c49ff2a1b1b07d0a250164dc",
+        "sourceType": "official"
+      },
+      "win32-x64": {
+        "url": "https://repo.typedb.com/public/public-release/raw/names/typedb-all-windows-x86_64/versions/3.8.0/typedb-all-windows-x86_64-3.8.0.zip",
+        "format": "zip",
+        "sha256": "90ee30688eb28a576a940c1a527f18e6dddf8f763fdbd66802ca07c4bfe343d5",
+        "sourceType": "official"
+      }
+    }
+  },
+  "notes": {
+    "source": "Official Cloudsmith repository: https://repo.typedb.com/public/public-release/raw/names/",
+    "naming": "TypeDB uses platform naming: linux-x86_64, linux-arm64, mac-x86_64, mac-arm64, windows-x86_64",
+    "archive": "typedb-all archive includes server, console, launcher script, config, and LICENSE",
+    "format": "tar.gz for Linux, zip for macOS and Windows"
+  }
+}

--- a/databases.json
+++ b/databases.json
@@ -339,6 +339,42 @@
       },
       "status": "completed"
     },
+    "firebird": {
+      "displayName": "Firebird",
+      "description": "Relational database with embedded and client/server modes, full SQL support with stored procedures and triggers",
+      "type": "Relational",
+      "sourceRepo": "https://github.com/FirebirdSQL/firebird",
+      "license": "IDPL-1.0",
+      "commercialUse": true,
+      "protocol": null,
+      "note": "Single-file database. Supports both embedded (no server process, single-file like SQLite) and client/server modes. Official pre-built binaries available for all platforms.",
+      "latestLts": "5.0",
+      "versions": {
+        "5.0.3": true
+      },
+      "platforms": {
+        "linux-x64": true,
+        "linux-arm64": true,
+        "darwin-x64": true,
+        "darwin-arm64": true,
+        "win32-x64": true
+      },
+      "cliTools": {
+        "server": "firebird",
+        "client": "isql",
+        "utilities": ["gbak", "gfix", "gstat", "nbackup", "gsec"],
+        "enhanced": []
+      },
+      "connection": {
+        "runtime": "server",
+        "defaultPort": 3050,
+        "scheme": null,
+        "defaultDatabase": null,
+        "defaultUser": "SYSDBA",
+        "queryLanguage": "SQL"
+      },
+      "status": "pending"
+    },
     "gel": {
       "displayName": "Gel",
       "description": "Graph-relational database built on PostgreSQL, formerly EdgeDB, with strict typing and declarative schema",
@@ -841,7 +877,43 @@
       },
       "status": "completed"
     },
-"sqlite": {
+    "rocksdb": {
+      "displayName": "RocksDB",
+      "description": "High-performance embedded key-value store based on LSM trees, developed by Meta",
+      "type": "Embedded KV",
+      "sourceRepo": "https://github.com/facebook/rocksdb",
+      "license": "GPL-2.0 OR Apache-2.0",
+      "commercialUse": true,
+      "protocol": null,
+      "note": "Single-file database. Library-first with ldb and sst_dump CLI tools. No official pre-built binaries - build from source required for all platforms. Widely used as storage engine by CockroachDB, TiKV, MySQL/MyRocks.",
+      "latestLts": "10.10",
+      "versions": {
+        "10.10.1": true
+      },
+      "platforms": {
+        "linux-x64": true,
+        "linux-arm64": true,
+        "darwin-x64": true,
+        "darwin-arm64": true,
+        "win32-x64": true
+      },
+      "cliTools": {
+        "server": null,
+        "client": "ldb",
+        "utilities": ["sst_dump"],
+        "enhanced": []
+      },
+      "connection": {
+        "runtime": "embedded",
+        "defaultPort": null,
+        "scheme": null,
+        "defaultDatabase": null,
+        "defaultUser": null,
+        "queryLanguage": "API"
+      },
+      "status": "pending"
+    },
+    "sqlite": {
       "displayName": "SQLite",
       "description": "Self-contained, serverless, zero-configuration SQL database engine",
       "type": "Embedded SQL",
@@ -986,7 +1058,7 @@
         "defaultUser": null,
         "queryLanguage": "TypeQL"
       },
-      "status": "pending"
+      "status": "in-progress"
     },
     "timescaledb": {
       "displayName": "TimescaleDB",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hostdb",
-  "version": "0.19.5",
+  "version": "0.20.0",
   "description": "Source and download pre-built database binaries for multiple platforms, distributed via GitHub Releases",
   "private": false,
   "type": "module",
@@ -45,6 +45,7 @@
     "download:redis": "tsx builds/redis/download.ts",
     "download:sqlite": "tsx builds/sqlite/download.ts",
     "download:surrealdb": "tsx builds/surrealdb/download.ts",
+    "download:typedb": "tsx builds/typedb/download.ts",
     "download:valkey": "tsx builds/valkey/download.ts",
     "edb:fileids": "tsx scripts/fetch-edb-fileids.ts",
     "format": "prettier --write .",


### PR DESCRIPTION
Rust-based graph database v3.8.0 with official Cloudsmith binaries for all 5 platforms. Preserves multi-component archive structure (server, console, launcher, config).