### PR TITLE
fix: generate version.txt before cross-compiling FerretDB v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.22.1] - 2026-02-14
+
+### Fixed
+
+- **FerretDB v1 binary panic on startup** — Cross-compiled binaries were missing `build/version/version.txt`, which FerretDB embeds via `//go:embed` at compile time. Without it, the `init()` function panics with "Invalid build/version/version.txt file content". Now generates the file with the correct version string before `go build`.
+
 ## [0.22.0] - 2026-02-13
 
 ### Added

--- a/builds/ferretdb-v1/download.ts
+++ b/builds/ferretdb-v1/download.ts
@@ -379,6 +379,14 @@ function crossCompileFerretDB(
     )
   }
 
+  // Generate version.txt required by FerretDB's go:embed
+  // Without this, the binary panics on startup with:
+  //   "Invalid build/version/version.txt file content"
+  const versionTxtPath = join(repoDir, 'build', 'version', 'version.txt')
+  mkdirSync(dirname(versionTxtPath), { recursive: true })
+  writeFileSync(versionTxtPath, `v${version}`)
+  logInfo(`Generated build/version/version.txt with v${version}`)
+
   // Build
   logInfo(`Cross-compiling for ${platform} (GOOS=${GOOS}, GOARCH=${GOARCH})...`)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hostdb",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "Source and download pre-built database binaries for multiple platforms, distributed via GitHub Releases",
   "private": false,
   "type": "module",

--- a/releases.json
+++ b/releases.json
@@ -71,6 +71,26 @@
         "releaseTag": "couchdb-3.5.1",
         "releasedAt": "2026-01-25T18:54:37Z",
         "platforms": {
+          "darwin-arm64": {
+            "url": "https://github.com/robertjbass/hostdb/releases/download/couchdb-3.5.1/couchdb-3.5.1-darwin-arm64.tar.gz",
+            "sha256": "e5b96ea40e6b92e441244c52add55192db0c9ffe74a3a296ebf1a87ac35c3ac0",
+            "size": 96849038
+          },
+          "darwin-x64": {
+            "url": "https://github.com/robertjbass/hostdb/releases/download/couchdb-3.5.1/couchdb-3.5.1-darwin-x64.tar.gz",
+            "sha256": "ce596086048fffb63b224612264cd219d4f229bbe2f40aa78154f56866e25391",
+            "size": 99325861
+          },
+          "linux-arm64": {
+            "url": "https://github.com/robertjbass/hostdb/releases/download/couchdb-3.5.1/couchdb-3.5.1-linux-arm64.tar.gz",
+            "sha256": "c74a5f5b37e518879a1f4c856d95594c0e7a0bab0000796693b94c1394a3f9c3",
+            "size": 75379710
+          },
+          "linux-x64": {
+            "url": "https://github.com/robertjbass/hostdb/releases/download/couchdb-3.5.1/couchdb-3.5.1-linux-x64.tar.gz",
+            "sha256": "1d769fb89c28c172bf5d48f44c19c60068411a2717ba72b4a544583d5f77d77e",
+            "size": 75806285
+          },
           "win32-x64": {
             "url": "https://github.com/robertjbass/hostdb/releases/download/couchdb-3.5.1/couchdb-3.5.1-win32-x64.zip",
             "sha256": "a64726782c4c321b3bf62ccc46e38aa97ad3c3ecbb78288c68a050722acf8a9a",
@@ -711,10 +731,30 @@
         "releaseTag": "postgresql-documentdb-17-0.107.0",
         "releasedAt": "2026-01-23T23:05:02Z",
         "platforms": {
+          "darwin-arm64": {
+            "url": "https://github.com/robertjbass/hostdb/releases/download/postgresql-documentdb-17-0.107.0/postgresql-documentdb-17-0.107.0-darwin-arm64.tar.gz",
+            "sha256": "09298146e0cbb9f668e2d2058280277dee661ce6ece922471c1cfe0b84a0fd1d",
+            "size": 37575761
+          },
           "darwin-x64": {
             "url": "https://github.com/robertjbass/hostdb/releases/download/postgresql-documentdb-17-0.107.0/postgresql-documentdb-17-0.107.0-darwin-x64.tar.gz",
             "sha256": "15a3e342adbf9007609bd2aa3a69c47264fd97e998f38403b9b461149c0b5a85",
             "size": 38520395
+          },
+          "linux-arm64": {
+            "url": "https://github.com/robertjbass/hostdb/releases/download/postgresql-documentdb-17-0.107.0/postgresql-documentdb-17-0.107.0-linux-arm64.tar.gz",
+            "sha256": "ab960ac1d5893264299e3ebb5267efe35585a49360da8d51b38d8c8a30893f6d",
+            "size": 78415221
+          },
+          "linux-x64": {
+            "url": "https://github.com/robertjbass/hostdb/releases/download/postgresql-documentdb-17-0.107.0/postgresql-documentdb-17-0.107.0-linux-x64.tar.gz",
+            "sha256": "7c5c3ba0b589dbc2b0dffb9f78fd1479b337ce15fec6b08bc05e0399a0fc7bd8",
+            "size": 83019446
+          },
+          "win32-x64": {
+            "url": "https://github.com/robertjbass/hostdb/releases/download/postgresql-documentdb-17-0.107.0/postgresql-documentdb-17-0.107.0-win32-x64.zip",
+            "sha256": "3305c27b01307c6b3cb43df376d463fd191f2bb12da134f17520a206804eb469",
+            "size": 334867318
           }
         }
       }


### PR DESCRIPTION
## Summary

- Fix FerretDB v1 binary panic on startup caused by missing `build/version/version.txt`
- FerretDB uses `//go:embed *.txt` to embed the version file at compile time; without it, `init()` panics
- Now generates the file with the correct version string before `go build`
- Also includes releases.json sync for ferretdb-v1 1.24.2 and checksum repairs for couchdb/postgresql-documentdb

## Test plan

- [ ] Re-trigger ferretdb-v1 release workflow and verify binary starts without panic
- [ ] Verify `ferretdb --version` outputs correct version