### PR TITLE
Add FerretDB v1 support and Windows warning for v2

### DIFF
--- a/.github/workflows/release-ferretdb.yml
+++ b/.github/workflows/release-ferretdb.yml
@@ -200,6 +200,8 @@ jobs:
             - `darwin-arm64` - macOS Apple Silicon
             - `win32-x64` - Windows x64
 
+            > **Windows note:** FerretDB v2 requires PostgreSQL with the DocumentDB extension, which is not available on Windows. The Windows binary compiles and runs but cannot function without a DocumentDB-enabled backend. Use [FerretDB v1](https://github.com/robertjbass/hostdb/releases?q=ferretdb-v1) on Windows instead, which works with plain PostgreSQL.
+
             ### Usage
             ```bash
             # Download URL pattern

--- a/builds/ferretdb/download.ts
+++ b/builds/ferretdb/download.ts
@@ -573,7 +573,7 @@ async function repackage(
     }
 
     // 4. Add metadata file
-    const metadata = {
+    const metadata: Record<string, unknown> = {
       name: 'ferretdb',
       version,
       platform,
@@ -586,6 +586,20 @@ async function repackage(
       rehosted_by: 'hostdb',
       rehosted_at: new Date().toISOString(),
     }
+
+    if (platform === 'win32-x64') {
+      metadata.warnings = [
+        'FerretDB v2 requires PostgreSQL with the DocumentDB extension, which is not available on Windows. The postgresql-documentdb Windows package only includes plain PostgreSQL + pgvector. Use FerretDB v1 (ferretdb-v1) on Windows instead, which works with plain PostgreSQL.',
+      ]
+      logWarn(
+        'FerretDB v2 requires the DocumentDB extension, which is not available on Windows.',
+      )
+      logWarn(
+        'The win32-x64 package will compile but will NOT work without a DocumentDB-enabled PostgreSQL backend.',
+      )
+      logWarn('Use FerretDB v1 (ferretdb-v1) on Windows instead.')
+    }
+
     writeFileSync(
       join(bundleDir, '.hostdb-metadata.json'),
       JSON.stringify(metadata, null, 2),


### PR DESCRIPTION
## Summary
- Add FerretDB v1 (plain PostgreSQL backend) with support for all 5 platforms including Windows cross-compilation via Go
- Add Windows incompatibility warning for FerretDB v2 in metadata and release notes, directing users to v1
- Update releases.json with ferretdb-v1 1.24.2

## Test plan
- [ ] Verify FerretDB v1 workflow builds successfully for all platforms
- [ ] Verify FerretDB v2 Windows package includes `warnings` in `.hostdb-metadata.json`
- [ ] Verify GitHub Release notes for FerretDB v2 display the Windows caveat