### PR TITLE
Fix workflow validation and publish manifests to R2

### DIFF
--- a/.github/workflows/release-clickhouse.yml
+++ b/.github/workflows/release-clickhouse.yml
@@ -42,13 +42,23 @@ jobs:
 
           echo "Validating ClickHouse version: $VERSION"
 
-          # Check if version exists and is enabled in databases.json
-          ENABLED=$(jq -r ".databases.$DB.versions[\"$VERSION\"] // false" databases.json)
+          # A version is enabled if its value is `true` or an object without `"enabled": false`
+          ENABLED=$(jq -r "
+            .databases.$DB.versions[\"$VERSION\"] // null
+            | if . == null or . == false then \"false\"
+              elif type == \"object\" and .enabled == false then \"false\"
+              else \"true\"
+            end
+          " databases.json)
           if [ "$ENABLED" != "true" ]; then
             echo "::error::Version '$VERSION' is not enabled in databases.json"
             echo ""
             echo "Available versions:"
-            jq -r ".databases.$DB.versions | to_entries | map(select(.value == true)) | .[].key" databases.json
+            jq -r "
+              .databases.$DB.versions | to_entries
+              | map(select(.value == true or ((.value | type) == \"object\" and (.value.enabled // true) == true)))
+              | .[].key
+            " databases.json
             exit 1
           fi
 

--- a/.github/workflows/release-cockroachdb.yml
+++ b/.github/workflows/release-cockroachdb.yml
@@ -43,13 +43,23 @@ jobs:
 
           echo "Validating CockroachDB version: $VERSION"
 
-          # Check if version exists and is enabled in databases.json
-          ENABLED=$(jq -r ".databases.$DB.versions[\"$VERSION\"] // false" databases.json)
+          # A version is enabled if its value is `true` or an object without `"enabled": false`
+          ENABLED=$(jq -r "
+            .databases.$DB.versions[\"$VERSION\"] // null
+            | if . == null or . == false then \"false\"
+              elif type == \"object\" and .enabled == false then \"false\"
+              else \"true\"
+            end
+          " databases.json)
           if [ "$ENABLED" != "true" ]; then
             echo "::error::Version '$VERSION' is not enabled in databases.json"
             echo ""
             echo "Available versions:"
-            jq -r ".databases.$DB.versions | to_entries | map(select(.value == true)) | .[].key" databases.json
+            jq -r "
+              .databases.$DB.versions | to_entries
+              | map(select(.value == true or ((.value | type) == \"object\" and (.value.enabled // true) == true)))
+              | .[].key
+            " databases.json
             exit 1
           fi
 

--- a/.github/workflows/release-couchdb.yml
+++ b/.github/workflows/release-couchdb.yml
@@ -43,13 +43,23 @@ jobs:
 
           echo "Validating CouchDB version: $VERSION"
 
-          # Check if version exists and is enabled in databases.json
-          ENABLED=$(jq -r ".databases.$DB.versions[\"$VERSION\"] // false" databases.json)
+          # A version is enabled if its value is `true` or an object without `"enabled": false`
+          ENABLED=$(jq -r "
+            .databases.$DB.versions[\"$VERSION\"] // null
+            | if . == null or . == false then \"false\"
+              elif type == \"object\" and .enabled == false then \"false\"
+              else \"true\"
+            end
+          " databases.json)
           if [ "$ENABLED" != "true" ]; then
             echo "::error::Version '$VERSION' is not enabled in databases.json"
             echo ""
             echo "Available versions:"
-            jq -r ".databases.$DB.versions | to_entries | map(select(.value == true)) | .[].key" databases.json
+            jq -r "
+              .databases.$DB.versions | to_entries
+              | map(select(.value == true or ((.value | type) == \"object\" and (.value.enabled // true) == true)))
+              | .[].key
+            " databases.json
             exit 1
           fi
 

--- a/.github/workflows/release-duckdb.yml
+++ b/.github/workflows/release-duckdb.yml
@@ -43,13 +43,23 @@ jobs:
 
           echo "Validating DuckDB version: $VERSION"
 
-          # Check if version exists and is enabled in databases.json
-          ENABLED=$(jq -r ".databases.$DB.versions[\"$VERSION\"] // false" databases.json)
+          # A version is enabled if its value is `true` or an object without `"enabled": false`
+          ENABLED=$(jq -r "
+            .databases.$DB.versions[\"$VERSION\"] // null
+            | if . == null or . == false then \"false\"
+              elif type == \"object\" and .enabled == false then \"false\"
+              else \"true\"
+            end
+          " databases.json)
           if [ "$ENABLED" != "true" ]; then
             echo "::error::Version '$VERSION' is not enabled in databases.json"
             echo ""
             echo "Available versions:"
-            jq -r ".databases.$DB.versions | to_entries | map(select(.value == true)) | .[].key" databases.json
+            jq -r "
+              .databases.$DB.versions | to_entries
+              | map(select(.value == true or ((.value | type) == \"object\" and (.value.enabled // true) == true)))
+              | .[].key
+            " databases.json
             exit 1
           fi
 

--- a/.github/workflows/release-ferretdb-v1.yml
+++ b/.github/workflows/release-ferretdb-v1.yml
@@ -43,13 +43,23 @@ jobs:
 
           echo "Validating FerretDB v1 version: $VERSION"
 
-          # Check if version exists and is enabled in databases.json
-          ENABLED=$(jq -r ".databases[\"$DB\"].versions[\"$VERSION\"] // false" databases.json)
+          # A version is enabled if its value is `true` or an object without `"enabled": false`
+          ENABLED=$(jq -r "
+            .databases.$DB.versions[\"$VERSION\"] // null
+            | if . == null or . == false then \"false\"
+              elif type == \"object\" and .enabled == false then \"false\"
+              else \"true\"
+            end
+          " databases.json)
           if [ "$ENABLED" != "true" ]; then
             echo "::error::Version '$VERSION' is not enabled in databases.json"
             echo ""
             echo "Available versions:"
-            jq -r ".databases[\"$DB\"].versions | to_entries | map(select(.value == true)) | .[].key" databases.json
+            jq -r "
+              .databases.$DB.versions | to_entries
+              | map(select(.value == true or ((.value | type) == \"object\" and (.value.enabled // true) == true)))
+              | .[].key
+            " databases.json
             exit 1
           fi
 

--- a/.github/workflows/release-ferretdb.yml
+++ b/.github/workflows/release-ferretdb.yml
@@ -45,12 +45,23 @@ jobs:
           echo "Validating FerretDB version: $VERSION"
 
           # Check if version exists and is enabled in databases.json
-          ENABLED=$(jq -r ".databases.$DB.versions[\"$VERSION\"] // false" databases.json)
+          # A version is enabled if its value is `true` or an object without `"enabled": false`
+          ENABLED=$(jq -r "
+            .databases.$DB.versions[\"$VERSION\"] // null
+            | if . == null or . == false then \"false\"
+              elif type == \"object\" and .enabled == false then \"false\"
+              else \"true\"
+            end
+          " databases.json)
           if [ "$ENABLED" != "true" ]; then
             echo "::error::Version '$VERSION' is not enabled in databases.json"
             echo ""
             echo "Available versions:"
-            jq -r ".databases.$DB.versions | to_entries | map(select(.value == true)) | .[].key" databases.json
+            jq -r "
+              .databases.$DB.versions | to_entries
+              | map(select(.value == true or ((.value | type) == \"object\" and (.value.enabled // true) == true)))
+              | .[].key
+            " databases.json
             exit 1
           fi
 

--- a/.github/workflows/release-influxdb.yml
+++ b/.github/workflows/release-influxdb.yml
@@ -43,13 +43,23 @@ jobs:
 
           echo "Validating InfluxDB version: $VERSION"
 
-          # Check if version exists and is enabled in databases.json
-          ENABLED=$(jq -r ".databases.$DB.versions[\"$VERSION\"] // false" databases.json)
+          # A version is enabled if its value is `true` or an object without `"enabled": false`
+          ENABLED=$(jq -r "
+            .databases.$DB.versions[\"$VERSION\"] // null
+            | if . == null or . == false then \"false\"
+              elif type == \"object\" and .enabled == false then \"false\"
+              else \"true\"
+            end
+          " databases.json)
           if [ "$ENABLED" != "true" ]; then
             echo "::error::Version '$VERSION' is not enabled in databases.json"
             echo ""
             echo "Available versions:"
-            jq -r ".databases.$DB.versions | to_entries | map(select(.value == true)) | .[].key" databases.json
+            jq -r "
+              .databases.$DB.versions | to_entries
+              | map(select(.value == true or ((.value | type) == \"object\" and (.value.enabled // true) == true)))
+              | .[].key
+            " databases.json
             exit 1
           fi
 

--- a/.github/workflows/release-mariadb.yml
+++ b/.github/workflows/release-mariadb.yml
@@ -45,13 +45,23 @@ jobs:
 
           echo "Validating MariaDB version: $VERSION"
 
-          # Check if version exists and is enabled in databases.json
-          ENABLED=$(jq -r ".databases.$DB.versions[\"$VERSION\"] // false" databases.json)
+          # A version is enabled if its value is `true` or an object without `"enabled": false`
+          ENABLED=$(jq -r "
+            .databases.$DB.versions[\"$VERSION\"] // null
+            | if . == null or . == false then \"false\"
+              elif type == \"object\" and .enabled == false then \"false\"
+              else \"true\"
+            end
+          " databases.json)
           if [ "$ENABLED" != "true" ]; then
             echo "::error::Version '$VERSION' is not enabled in databases.json"
             echo ""
             echo "Available versions:"
-            jq -r ".databases.$DB.versions | to_entries | map(select(.value == true)) | .[].key" databases.json
+            jq -r "
+              .databases.$DB.versions | to_entries
+              | map(select(.value == true or ((.value | type) == \"object\" and (.value.enabled // true) == true)))
+              | .[].key
+            " databases.json
             exit 1
           fi
 

--- a/.github/workflows/release-meilisearch.yml
+++ b/.github/workflows/release-meilisearch.yml
@@ -43,13 +43,23 @@ jobs:
 
           echo "Validating Meilisearch version: $VERSION"
 
-          # Check if version exists and is enabled in databases.json
-          ENABLED=$(jq -r ".databases.$DB.versions[\"$VERSION\"] // false" databases.json)
+          # A version is enabled if its value is `true` or an object without `"enabled": false`
+          ENABLED=$(jq -r "
+            .databases.$DB.versions[\"$VERSION\"] // null
+            | if . == null or . == false then \"false\"
+              elif type == \"object\" and .enabled == false then \"false\"
+              else \"true\"
+            end
+          " databases.json)
           if [ "$ENABLED" != "true" ]; then
             echo "::error::Version '$VERSION' is not enabled in databases.json"
             echo ""
             echo "Available versions:"
-            jq -r ".databases.$DB.versions | to_entries | map(select(.value == true)) | .[].key" databases.json
+            jq -r "
+              .databases.$DB.versions | to_entries
+              | map(select(.value == true or ((.value | type) == \"object\" and (.value.enabled // true) == true)))
+              | .[].key
+            " databases.json
             exit 1
           fi
 

--- a/.github/workflows/release-mongodb.yml
+++ b/.github/workflows/release-mongodb.yml
@@ -45,13 +45,23 @@ jobs:
 
           echo "Validating MongoDB version: $VERSION"
 
-          # Check if version exists and is enabled in databases.json
-          ENABLED=$(jq -r ".databases.$DB.versions[\"$VERSION\"] // false" databases.json)
+          # A version is enabled if its value is `true` or an object without `"enabled": false`
+          ENABLED=$(jq -r "
+            .databases.$DB.versions[\"$VERSION\"] // null
+            | if . == null or . == false then \"false\"
+              elif type == \"object\" and .enabled == false then \"false\"
+              else \"true\"
+            end
+          " databases.json)
           if [ "$ENABLED" != "true" ]; then
             echo "::error::Version '$VERSION' is not enabled in databases.json"
             echo ""
             echo "Available versions:"
-            jq -r ".databases.$DB.versions | to_entries | map(select(.value == true)) | .[].key" databases.json
+            jq -r "
+              .databases.$DB.versions | to_entries
+              | map(select(.value == true or ((.value | type) == \"object\" and (.value.enabled // true) == true)))
+              | .[].key
+            " databases.json
             exit 1
           fi
 

--- a/.github/workflows/release-mysql.yml
+++ b/.github/workflows/release-mysql.yml
@@ -46,13 +46,23 @@ jobs:
 
           echo "Validating MySQL version: $VERSION"
 
-          # Check if version exists and is enabled in databases.json
-          ENABLED=$(jq -r ".databases.$DB.versions[\"$VERSION\"] // false" databases.json)
+          # A version is enabled if its value is `true` or an object without `"enabled": false`
+          ENABLED=$(jq -r "
+            .databases.$DB.versions[\"$VERSION\"] // null
+            | if . == null or . == false then \"false\"
+              elif type == \"object\" and .enabled == false then \"false\"
+              else \"true\"
+            end
+          " databases.json)
           if [ "$ENABLED" != "true" ]; then
             echo "::error::Version '$VERSION' is not enabled in databases.json"
             echo ""
             echo "Available versions:"
-            jq -r ".databases.$DB.versions | to_entries | map(select(.value == true)) | .[].key" databases.json
+            jq -r "
+              .databases.$DB.versions | to_entries
+              | map(select(.value == true or ((.value | type) == \"object\" and (.value.enabled // true) == true)))
+              | .[].key
+            " databases.json
             exit 1
           fi
 

--- a/.github/workflows/release-postgresql-documentdb.yml
+++ b/.github/workflows/release-postgresql-documentdb.yml
@@ -42,13 +42,23 @@ jobs:
 
           echo "Validating PostgreSQL + DocumentDB version: $VERSION"
 
-          # Check if version exists and is enabled in databases.json
-          ENABLED=$(jq -r ".databases.\"$DB\".versions[\"$VERSION\"] // false" databases.json)
+          # A version is enabled if its value is `true` or an object without `"enabled": false`
+          ENABLED=$(jq -r "
+            .databases.\"$DB\".versions[\"$VERSION\"] // null
+            | if . == null or . == false then \"false\"
+              elif type == \"object\" and .enabled == false then \"false\"
+              else \"true\"
+            end
+          " databases.json)
           if [ "$ENABLED" != "true" ]; then
             echo "::error::Version '$VERSION' is not enabled in databases.json"
             echo ""
             echo "Available versions:"
-            jq -r ".databases.\"$DB\".versions | to_entries | map(select(.value == true)) | .[].key" databases.json
+            jq -r "
+              .databases.\"$DB\".versions | to_entries
+              | map(select(.value == true or ((.value | type) == \"object\" and (.value.enabled // true) == true)))
+              | .[].key
+            " databases.json
             exit 1
           fi
 

--- a/.github/workflows/release-postgresql.yml
+++ b/.github/workflows/release-postgresql.yml
@@ -46,13 +46,23 @@ jobs:
 
           echo "Validating PostgreSQL version: $VERSION"
 
-          # Check if version exists and is enabled in databases.json
-          ENABLED=$(jq -r ".databases.$DB.versions[\"$VERSION\"] // false" databases.json)
+          # A version is enabled if its value is `true` or an object without `"enabled": false`
+          ENABLED=$(jq -r "
+            .databases.$DB.versions[\"$VERSION\"] // null
+            | if . == null or . == false then \"false\"
+              elif type == \"object\" and .enabled == false then \"false\"
+              else \"true\"
+            end
+          " databases.json)
           if [ "$ENABLED" != "true" ]; then
             echo "::error::Version '$VERSION' is not enabled in databases.json"
             echo ""
             echo "Available versions:"
-            jq -r ".databases.$DB.versions | to_entries | map(select(.value == true)) | .[].key" databases.json
+            jq -r "
+              .databases.$DB.versions | to_entries
+              | map(select(.value == true or ((.value | type) == \"object\" and (.value.enabled // true) == true)))
+              | .[].key
+            " databases.json
             exit 1
           fi
 

--- a/.github/workflows/release-qdrant.yml
+++ b/.github/workflows/release-qdrant.yml
@@ -43,13 +43,23 @@ jobs:
 
           echo "Validating Qdrant version: $VERSION"
 
-          # Check if version exists and is enabled in databases.json
-          ENABLED=$(jq -r ".databases.$DB.versions[\"$VERSION\"] // false" databases.json)
+          # A version is enabled if its value is `true` or an object without `"enabled": false`
+          ENABLED=$(jq -r "
+            .databases.$DB.versions[\"$VERSION\"] // null
+            | if . == null or . == false then \"false\"
+              elif type == \"object\" and .enabled == false then \"false\"
+              else \"true\"
+            end
+          " databases.json)
           if [ "$ENABLED" != "true" ]; then
             echo "::error::Version '$VERSION' is not enabled in databases.json"
             echo ""
             echo "Available versions:"
-            jq -r ".databases.$DB.versions | to_entries | map(select(.value == true)) | .[].key" databases.json
+            jq -r "
+              .databases.$DB.versions | to_entries
+              | map(select(.value == true or ((.value | type) == \"object\" and (.value.enabled // true) == true)))
+              | .[].key
+            " databases.json
             exit 1
           fi
 

--- a/.github/workflows/release-questdb.yml
+++ b/.github/workflows/release-questdb.yml
@@ -43,13 +43,23 @@ jobs:
 
           echo "Validating QuestDB version: $VERSION"
 
-          # Check if version exists and is enabled in databases.json
-          ENABLED=$(jq -r ".databases.$DB.versions[\"$VERSION\"] // false" databases.json)
+          # A version is enabled if its value is `true` or an object without `"enabled": false`
+          ENABLED=$(jq -r "
+            .databases.$DB.versions[\"$VERSION\"] // null
+            | if . == null or . == false then \"false\"
+              elif type == \"object\" and .enabled == false then \"false\"
+              else \"true\"
+            end
+          " databases.json)
           if [ "$ENABLED" != "true" ]; then
             echo "::error::Version '$VERSION' is not enabled in databases.json"
             echo ""
             echo "Available versions:"
-            jq -r ".databases.$DB.versions | to_entries | map(select(.value == true)) | .[].key" databases.json
+            jq -r "
+              .databases.$DB.versions | to_entries
+              | map(select(.value == true or ((.value | type) == \"object\" and (.value.enabled // true) == true)))
+              | .[].key
+            " databases.json
             exit 1
           fi
 

--- a/.github/workflows/release-redis.yml
+++ b/.github/workflows/release-redis.yml
@@ -44,13 +44,23 @@ jobs:
 
           echo "Validating Redis version: $VERSION"
 
-          # Check if version exists and is enabled in databases.json
-          ENABLED=$(jq -r ".databases.$DB.versions[\"$VERSION\"] // false" databases.json)
+          # A version is enabled if its value is `true` or an object without `"enabled": false`
+          ENABLED=$(jq -r "
+            .databases.$DB.versions[\"$VERSION\"] // null
+            | if . == null or . == false then \"false\"
+              elif type == \"object\" and .enabled == false then \"false\"
+              else \"true\"
+            end
+          " databases.json)
           if [ "$ENABLED" != "true" ]; then
             echo "::error::Version '$VERSION' is not enabled in databases.json"
             echo ""
             echo "Available versions:"
-            jq -r ".databases.$DB.versions | to_entries | map(select(.value == true)) | .[].key" databases.json
+            jq -r "
+              .databases.$DB.versions | to_entries
+              | map(select(.value == true or ((.value | type) == \"object\" and (.value.enabled // true) == true)))
+              | .[].key
+            " databases.json
             exit 1
           fi
 

--- a/.github/workflows/release-sqlite.yml
+++ b/.github/workflows/release-sqlite.yml
@@ -43,13 +43,23 @@ jobs:
 
           echo "Validating SQLite version: $VERSION"
 
-          # Check if version exists and is enabled in databases.json
-          ENABLED=$(jq -r ".databases.$DB.versions[\"$VERSION\"] // false" databases.json)
+          # A version is enabled if its value is `true` or an object without `"enabled": false`
+          ENABLED=$(jq -r "
+            .databases.$DB.versions[\"$VERSION\"] // null
+            | if . == null or . == false then \"false\"
+              elif type == \"object\" and .enabled == false then \"false\"
+              else \"true\"
+            end
+          " databases.json)
           if [ "$ENABLED" != "true" ]; then
             echo "::error::Version '$VERSION' is not enabled in databases.json"
             echo ""
             echo "Available versions:"
-            jq -r ".databases.$DB.versions | to_entries | map(select(.value == true)) | .[].key" databases.json
+            jq -r "
+              .databases.$DB.versions | to_entries
+              | map(select(.value == true or ((.value | type) == \"object\" and (.value.enabled // true) == true)))
+              | .[].key
+            " databases.json
             exit 1
           fi
 

--- a/.github/workflows/release-surrealdb.yml
+++ b/.github/workflows/release-surrealdb.yml
@@ -43,13 +43,23 @@ jobs:
 
           echo "Validating SurrealDB version: $VERSION"
 
-          # Check if version exists and is enabled in databases.json
-          ENABLED=$(jq -r ".databases.$DB.versions[\"$VERSION\"] // false" databases.json)
+          # A version is enabled if its value is `true` or an object without `"enabled": false`
+          ENABLED=$(jq -r "
+            .databases.$DB.versions[\"$VERSION\"] // null
+            | if . == null or . == false then \"false\"
+              elif type == \"object\" and .enabled == false then \"false\"
+              else \"true\"
+            end
+          " databases.json)
           if [ "$ENABLED" != "true" ]; then
             echo "::error::Version '$VERSION' is not enabled in databases.json"
             echo ""
             echo "Available versions:"
-            jq -r ".databases.$DB.versions | to_entries | map(select(.value == true)) | .[].key" databases.json
+            jq -r "
+              .databases.$DB.versions | to_entries
+              | map(select(.value == true or ((.value | type) == \"object\" and (.value.enabled // true) == true)))
+              | .[].key
+            " databases.json
             exit 1
           fi
 

--- a/.github/workflows/release-typedb.yml
+++ b/.github/workflows/release-typedb.yml
@@ -43,13 +43,23 @@ jobs:
 
           echo "Validating TypeDB version: $VERSION"
 
-          # Check if version exists and is enabled in databases.json
-          ENABLED=$(jq -r ".databases.$DB.versions[\"$VERSION\"] // false" databases.json)
+          # A version is enabled if its value is `true` or an object without `"enabled": false`
+          ENABLED=$(jq -r "
+            .databases.$DB.versions[\"$VERSION\"] // null
+            | if . == null or . == false then \"false\"
+              elif type == \"object\" and .enabled == false then \"false\"
+              else \"true\"
+            end
+          " databases.json)
           if [ "$ENABLED" != "true" ]; then
             echo "::error::Version '$VERSION' is not enabled in databases.json"
             echo ""
             echo "Available versions:"
-            jq -r ".databases.$DB.versions | to_entries | map(select(.value == true)) | .[].key" databases.json
+            jq -r "
+              .databases.$DB.versions | to_entries
+              | map(select(.value == true or ((.value | type) == \"object\" and (.value.enabled // true) == true)))
+              | .[].key
+            " databases.json
             exit 1
           fi
 

--- a/.github/workflows/release-valkey.yml
+++ b/.github/workflows/release-valkey.yml
@@ -44,13 +44,23 @@ jobs:
 
           echo "Validating Valkey version: $VERSION"
 
-          # Check if version exists and is enabled in databases.json
-          ENABLED=$(jq -r ".databases.$DB.versions[\"$VERSION\"] // false" databases.json)
+          # A version is enabled if its value is `true` or an object without `"enabled": false`
+          ENABLED=$(jq -r "
+            .databases.$DB.versions[\"$VERSION\"] // null
+            | if . == null or . == false then \"false\"
+              elif type == \"object\" and .enabled == false then \"false\"
+              else \"true\"
+            end
+          " databases.json)
           if [ "$ENABLED" != "true" ]; then
             echo "::error::Version '$VERSION' is not enabled in databases.json"
             echo ""
             echo "Available versions:"
-            jq -r ".databases.$DB.versions | to_entries | map(select(.value == true)) | .[].key" databases.json
+            jq -r "
+              .databases.$DB.versions | to_entries
+              | map(select(.value == true or ((.value | type) == \"object\" and (.value.enabled // true) == true)))
+              | .[].key
+            " databases.json
             exit 1
           fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.23.1] - 2026-02-15
+
+### Fixed
+
+- **Workflow validation rejects object-form versions** — The `validate` job in all release workflows only accepted `true` for version entries, rejecting versions with per-version config (platforms, dependencies, releasePrefix). Now treats both `true` and config objects (without explicit `"enabled": false`) as enabled.
+
+### Added
+
+- **Publish databases.json and downloads.json to R2** — The `--upload-r2` flag in `build-releases-json.ts` now uploads all three manifest files (`releases.json`, `databases.json`, `downloads.json`) to R2, ensuring the registry always has up-to-date metadata. `databases.json` is regenerated from `databases.yml` before upload.
+
 ## [0.23.0] - 2026-02-14
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hostdb",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "description": "Source and download pre-built database binaries for multiple platforms, distributed via GitHub Releases",
   "private": false,
   "type": "module",


### PR DESCRIPTION
## Summary

- **Fix version validation in all release workflows** — The `validate` job only accepted `true` for version entries, breaking any version using object-form config (per-version platforms, dependencies, releasePrefix). Now accepts both `true` and config objects without `"enabled": false`.
- **Publish databases.json and downloads.json to R2** — The `--upload-r2` flag now uploads all three manifest files to R2, with databases.json regenerated from databases.yml before upload.
- **Version bump** — 0.23.0 → 0.23.1

## Test plan

- [ ] Merge to main, then trigger Release FerretDB workflow with version 1.24.2 — validate job should pass
- [ ] Verify `databases.json` and `downloads.json` appear on `registry.layerbase.host` after next release build