### PR TITLE
feat: macOS dylib patching for relocatable binaries

### DIFF
--- a/.github/workflows/audit-dylibs.yml
+++ b/.github/workflows/audit-dylibs.yml
@@ -1,0 +1,139 @@
+name: Audit macOS dylibs
+
+on:
+  workflow_dispatch:
+    inputs:
+      database:
+        description: 'Database to audit'
+        required: true
+        type: choice
+        default: 'all'
+        options:
+          - 'all'
+          - 'mariadb'
+          - 'redis'
+          - 'valkey'
+          - 'postgresql'
+          - 'postgresql-documentdb'
+          - 'mysql'
+          - 'mongodb'
+          - 'sqlite'
+          - 'couchdb'
+
+jobs:
+  audit:
+    runs-on: macos-14
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Audit macOS releases for Homebrew dylib paths
+        run: |
+          set -euo pipefail
+
+          INPUT_DB="${{ github.event.inputs.database }}"
+
+          # Databases that use macOS source builds (may link against Homebrew).
+          # Statically-linked Go/Rust binaries (clickhouse, ferretdb, influxdb,
+          # meilisearch, qdrant, surrealdb, tigerbeetle, weaviate, cockroachdb,
+          # questdb, typedb, duckdb) are excluded — they have no dylib deps.
+          SOURCE_BUILD_DBS=("mariadb" "redis" "valkey" "postgresql" "postgresql-documentdb" "mysql" "mongodb" "sqlite" "couchdb")
+
+          if [[ "$INPUT_DB" != "all" ]]; then
+            DBS_TO_AUDIT=("$INPUT_DB")
+          else
+            DBS_TO_AUDIT=("${SOURCE_BUILD_DBS[@]}")
+          fi
+
+          echo "=== Audit macOS dylibs ==="
+          echo "Databases to audit: ${DBS_TO_AUDIT[*]}"
+          echo ""
+
+          chmod +x builds/common/check-macos-dylibs.sh
+
+          RESULTS=()
+          OVERALL_PASS=true
+
+          for db in "${DBS_TO_AUDIT[@]}"; do
+            echo "============================================"
+            echo "Auditing: $db"
+            echo "============================================"
+
+            # Get all versions for this database from releases.json
+            VERSIONS=$(jq -r ".databases[\"$db\"] // {} | keys[]" releases.json 2>/dev/null || true)
+
+            if [[ -z "$VERSIONS" ]]; then
+              echo "  No releases found for $db — skipping"
+              RESULTS+=("| $db | — | — | SKIP | No releases found |")
+              continue
+            fi
+
+            for version in $VERSIONS; do
+              for platform in darwin-arm64 darwin-x64; do
+                URL=$(jq -r ".databases[\"$db\"][\"$version\"].platforms[\"$platform\"].url // empty" releases.json)
+
+                if [[ -z "$URL" ]]; then
+                  RESULTS+=("| $db | $version | $platform | SKIP | No release URL |")
+                  continue
+                fi
+
+                TAG=$(jq -r ".databases[\"$db\"][\"$version\"].releaseTag" releases.json)
+                FILENAME=$(basename "$URL")
+                TMPDIR=$(mktemp -d)
+
+                echo ""
+                echo "--- $db $version ($platform) ---"
+                echo "  URL: $URL"
+
+                # Download
+                if ! curl -fsSL "$URL" -o "${TMPDIR}/${FILENAME}" 2>/dev/null; then
+                  echo "  WARN: Download failed"
+                  RESULTS+=("| $db | $version | $platform | WARN | Download failed |")
+                  rm -rf "$TMPDIR"
+                  continue
+                fi
+
+                # Extract
+                EXTRACT_DIR="${TMPDIR}/extract"
+                mkdir -p "$EXTRACT_DIR"
+
+                if [[ "$FILENAME" == *.tar.gz ]]; then
+                  tar -xzf "${TMPDIR}/${FILENAME}" -C "$EXTRACT_DIR" 2>/dev/null || true
+                elif [[ "$FILENAME" == *.zip ]]; then
+                  unzip -q "${TMPDIR}/${FILENAME}" -d "$EXTRACT_DIR" 2>/dev/null || true
+                fi
+
+                # Run check
+                if ./builds/common/check-macos-dylibs.sh "$EXTRACT_DIR" 2>&1; then
+                  RESULTS+=("| $db | $version | $platform | PASS | |")
+                else
+                  OVERALL_PASS=false
+                  ACTION="Run \`gh workflow run release-${db}.yml -f version=${version} -f platforms=${platform}\` to rebuild"
+                  RESULTS+=("| $db | $version | $platform | **FAIL** | ${ACTION} |")
+                fi
+
+                rm -rf "$TMPDIR"
+              done
+            done
+          done
+
+          # Print summary table
+          echo ""
+          echo "============================================"
+          echo "SUMMARY"
+          echo "============================================"
+          echo ""
+          echo "| Database | Version | Platform | Status | Action |"
+          echo "|----------|---------|----------|--------|--------|"
+          for row in "${RESULTS[@]}"; do
+            echo "$row"
+          done
+
+          echo ""
+          if [[ "$OVERALL_PASS" == "true" ]]; then
+            echo "Overall: PASS — all audited releases are clean"
+          else
+            echo "Overall: FAIL — some releases have non-relocatable Homebrew paths"
+            echo "Re-trigger the release workflow for each failing version/platform to rebuild with dylib patching."
+            exit 1
+          fi

--- a/.github/workflows/release-mariadb.yml
+++ b/.github/workflows/release-mariadb.yml
@@ -340,6 +340,10 @@ jobs:
           }
           EOF
 
+          # Fix macOS dylib paths for relocatable binaries
+          chmod +x "$GITHUB_WORKSPACE/builds/common/fix-macos-dylibs.sh"
+          "$GITHUB_WORKSPACE/builds/common/fix-macos-dylibs.sh" "$GITHUB_WORKSPACE/install/mariadb"
+
           # Create tarball
           mkdir -p "$GITHUB_WORKSPACE/dist"
           tar -czvf "$GITHUB_WORKSPACE/dist/mariadb-${VERSION}-${PLATFORM}.tar.gz" mariadb

--- a/.github/workflows/release-redis.yml
+++ b/.github/workflows/release-redis.yml
@@ -301,6 +301,10 @@ jobs:
             "  \"rehosted_at\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"" \
             '}' > redis/.hostdb-metadata.json
 
+          # Fix macOS dylib paths for relocatable binaries
+          chmod +x "$GITHUB_WORKSPACE/builds/common/fix-macos-dylibs.sh"
+          "$GITHUB_WORKSPACE/builds/common/fix-macos-dylibs.sh" "$GITHUB_WORKSPACE/install/redis"
+
           # Create tarball
           mkdir -p "$GITHUB_WORKSPACE/dist"
           tar -czvf "$GITHUB_WORKSPACE/dist/redis-${VERSION}-${PLATFORM}.tar.gz" redis

--- a/.github/workflows/release-valkey.yml
+++ b/.github/workflows/release-valkey.yml
@@ -256,6 +256,10 @@ jobs:
             "  \"rehosted_at\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"" \
             '}' > valkey/.hostdb-metadata.json
 
+          # Fix macOS dylib paths for relocatable binaries
+          chmod +x "$GITHUB_WORKSPACE/builds/common/fix-macos-dylibs.sh"
+          "$GITHUB_WORKSPACE/builds/common/fix-macos-dylibs.sh" "$GITHUB_WORKSPACE/install/valkey"
+
           # Create tarball
           mkdir -p "$GITHUB_WORKSPACE/dist"
           tar -czvf "$GITHUB_WORKSPACE/dist/valkey-${VERSION}-${PLATFORM}.tar.gz" valkey

--- a/BINARIES.md
+++ b/BINARIES.md
@@ -10,8 +10,8 @@ Archive structure for each database distributed by hostdb.
 | PostgreSQL | `postgresql/` | `bin/` `lib/` `share/` `.hostdb-metadata.json` | `bin/postgres` | `bin/psql` |
 | MariaDB | `mariadb/` | `bin/` `lib/` `share/` `man/` `.hostdb-metadata.json` | `bin/mariadbd` | `bin/mariadb` |
 | MongoDB | `mongodb/` | `bin/` `.hostdb-metadata.json` | `bin/mongod` | `bin/mongosh` |
-| Redis | `redis/` | `bin/` `.hostdb-metadata.json` | `bin/redis-server` | `bin/redis-cli` |
-| Valkey | `valkey/` | `bin/` `.hostdb-metadata.json` | `bin/valkey-server` | `bin/valkey-cli` |
+| Redis | `redis/` | `bin/` `lib/` (macOS) `.hostdb-metadata.json` | `bin/redis-server` | `bin/redis-cli` |
+| Valkey | `valkey/` | `bin/` `lib/` (macOS) `.hostdb-metadata.json` | `bin/valkey-server` | `bin/valkey-cli` |
 | SQLite | `sqlite/` | `bin/` `.hostdb-metadata.json` | — | `bin/sqlite3` |
 | DuckDB | `duckdb/` | `duckdb` `.hostdb-metadata.json` | — | `duckdb` |
 | ClickHouse | `clickhouse/` | `bin/` `.hostdb-metadata.json` | `bin/clickhouse` | `bin/clickhouse` |
@@ -71,6 +71,9 @@ redis/
 │   ├── redis-server
 │   ├── redis-cli
 │   └── redis-benchmark
+├── lib/                        # macOS only (bundled Homebrew dylibs)
+│   ├── libssl.3.dylib
+│   └── libcrypto.3.dylib
 └── .hostdb-metadata.json
 
 valkey/
@@ -78,6 +81,9 @@ valkey/
 │   ├── valkey-server
 │   ├── valkey-cli
 │   └── valkey-benchmark
+├── lib/                        # macOS only (bundled Homebrew dylibs)
+│   ├── libssl.3.dylib
+│   └── libcrypto.3.dylib
 └── .hostdb-metadata.json
 
 sqlite/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.27.0] - 2026-02-16
+
+### Added
+
+- **Generic macOS dylib patching for relocatable binaries** (`builds/common/fix-macos-dylibs.sh`)
+  - Standalone script that bundles Homebrew dylibs into a package's `lib/` directory and rewrites absolute paths to `@loader_path` relative references
+  - Adapted from the proven inline implementation in `builds/postgresql-documentdb/build-macos.sh`
+  - Handles recursive transitive dependencies, code signing, and verification (fails CI if Homebrew paths remain)
+  - Integrated into MariaDB, Redis, and Valkey release workflows (macOS build steps)
+  - Fixes OpenSSL (and pcre2, jemalloc, lz4, zstd, snappy for MariaDB) dylib-not-found crashes on Macs without Homebrew
+
+- **macOS dylib audit tooling**
+  - `builds/common/check-macos-dylibs.sh` — read-only diagnostic that scans packages for non-relocatable Homebrew paths (`pnpm check:dylibs`)
+  - `.github/workflows/audit-dylibs.yml` — manually triggered workflow that downloads macOS tarballs from R2 and audits them, producing a summary table with prescriptive rebuild actions
+
+### Changed
+
+- **Redis and Valkey macOS builds now include `lib/`** with bundled OpenSSL dylibs (`libssl.3.dylib`, `libcrypto.3.dylib`)
+- **BINARIES.md** updated to reflect `lib/` directory in Redis and Valkey macOS archives
+- **CHECKLIST.md** updated with Phase 5.1b for macOS dylib patching guidance
+
 ## [0.26.1] - 2026-02-16
 
 ### Fixed

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -218,6 +218,20 @@ Reference: `builds/mariadb/build-local.sh`
 
 Reference: `.github/workflows/release-mariadb.yml`, `.github/workflows/release-sqlite.yml`
 
+### 5.1b macOS dylib patching
+
+If the database links against Homebrew libraries (OpenSSL, pcre2, etc.) during macOS source builds:
+
+- [ ] Add `fix-macos-dylibs.sh` call in the macOS build step, between metadata creation and tarball creation:
+  ```bash
+  chmod +x "$GITHUB_WORKSPACE/builds/common/fix-macos-dylibs.sh"
+  "$GITHUB_WORKSPACE/builds/common/fix-macos-dylibs.sh" "$GITHUB_WORKSPACE/install/<database>"
+  ```
+- [ ] Update `BINARIES.md` to note the `lib/` directory for macOS builds
+- [ ] After first build, verify with `pnpm check:dylibs -- ./dist/<database>`
+
+Databases that **don't need this**: statically-linked Go/Rust binaries (ClickHouse, FerretDB, Meilisearch, Qdrant, SurrealDB, TigerBeetle, Weaviate, etc.)
+
 ### 5.2 Configure build matrix
 
 For each platform, ensure correct runner and build type:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,9 @@ hostdb/
 │   ├── sources.schema.json
 │   └── releases.schema.json
 ├── builds/                 # Per-database build configurations
+│   ├── common/
+│   │   ├── fix-macos-dylibs.sh   # Bundle Homebrew dylibs for relocatable binaries
+│   │   └── check-macos-dylibs.sh # Audit packages for non-relocatable paths
 │   ├── mysql/
 │   │   ├── download.ts     # Downloads/repackages binaries
 │   │   ├── sources.json    # Version → URL mappings
@@ -376,6 +379,10 @@ pnpm checksums:populate <database> # Populate missing SHA256 checksums
 pnpm edb:fileids                   # Show available file IDs from EDB
 pnpm edb:fileids -- --update       # Update sources.json with latest IDs
 
+# macOS dylib auditing
+pnpm check:dylibs                              # Scan ./dist for Homebrew paths
+pnpm check:dylibs -- ./dist/redis              # Scan specific package
+
 # R2 binary hosting
 pnpm upload:r2 -- --tag mysql-8.4.3            # Upload single release to R2
 pnpm migrate:r2                                 # Migrate all releases to R2
@@ -531,3 +538,23 @@ concurrency:
 ```
 
 This means only one build runs at a time - subsequent triggers are queued, not cancelled.
+
+## macOS Dylib Patching (Shared Script)
+
+macOS source builds that link against Homebrew (OpenSSL, pcre2, etc.) produce binaries with absolute paths like `/opt/homebrew/opt/openssl@3/lib/libssl.3.dylib`. These break on any Mac without those exact Homebrew packages installed.
+
+**`builds/common/fix-macos-dylibs.sh <package-root>`** fixes this by:
+1. Bundling Homebrew dylibs into the package's `lib/` directory
+2. Rewriting all absolute paths to `@loader_path` relative references
+3. Re-signing modified binaries (required by macOS)
+4. Verifying no Homebrew paths remain (fails the build if any found)
+
+**When to use:** Add to any release workflow's macOS build step if the database links against Homebrew libraries at build time. Insert between metadata creation and tarball creation:
+```bash
+chmod +x "$GITHUB_WORKSPACE/builds/common/fix-macos-dylibs.sh"
+"$GITHUB_WORKSPACE/builds/common/fix-macos-dylibs.sh" "$GITHUB_WORKSPACE/install/<database>"
+```
+
+**Currently used by:** MariaDB, Redis, Valkey workflows. PostgreSQL-DocumentDB has its own inline implementation.
+
+**Diagnostic:** `pnpm check:dylibs [<path>]` scans packages for non-relocatable paths without modifying anything. The `audit-dylibs` workflow (`workflow_dispatch`) audits published releases on R2.

--- a/builds/common/check-macos-dylibs.sh
+++ b/builds/common/check-macos-dylibs.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# check-macos-dylibs.sh — Scan macOS packages for non-relocatable Homebrew dependencies
+#
+# Usage: ./builds/common/check-macos-dylibs.sh [<path>]
+#   <path>    Package dir or parent dir containing packages (default: ./dist)
+#
+# Examples:
+#   ./builds/common/check-macos-dylibs.sh ./dist/redis
+#   ./builds/common/check-macos-dylibs.sh ./dist          # scans all packages
+#   pnpm check:dylibs                                      # alias via package.json
+#   pnpm check:dylibs -- ./dist/mariadb
+#
+# Read-only — does NOT modify any files. Exit code 0 if clean, 1 if issues found.
+
+set -euo pipefail
+
+SCAN_PATH="${1:-./dist}"
+
+if [[ ! -e "$SCAN_PATH" ]]; then
+    echo "ERROR: Path does not exist: $SCAN_PATH"
+    echo "Usage: $0 [<path>]"
+    exit 1
+fi
+
+# Homebrew path pattern for grep
+BREW_PATTERN="(/opt/homebrew/|/usr/local/(Cellar|opt|lib)/)"
+
+TOTAL_FILES=0
+PROBLEM_FILES=0
+PROBLEM_DETAILS=()
+
+scan_file() {
+    local file="$1"
+    local label="$2"
+
+    file "$file" | grep -q "Mach-O" || return 0
+    ((TOTAL_FILES++)) || true
+
+    local bad_deps
+    bad_deps=$(otool -L "$file" 2>/dev/null | tail -n +2 | awk '{print $1}' | grep -E "$BREW_PATTERN" || true)
+
+    if [[ -n "$bad_deps" ]]; then
+        ((PROBLEM_FILES++)) || true
+        PROBLEM_DETAILS+=("$label")
+        echo "  FAIL: $label"
+        while IFS= read -r dep; do
+            echo "    -> $dep"
+            PROBLEM_DETAILS+=("    $dep")
+        done <<< "$bad_deps"
+    fi
+}
+
+scan_directory() {
+    local dir="$1"
+    local prefix="$2"
+
+    # Scan bin/
+    if [[ -d "${dir}/bin" ]]; then
+        for f in "${dir}/bin/"*; do
+            [[ -f "$f" ]] || continue
+            scan_file "$f" "${prefix}bin/$(basename "$f")"
+        done
+    fi
+
+    # Scan lib/ (including subdirectories)
+    if [[ -d "${dir}/lib" ]]; then
+        while IFS= read -r f; do
+            [[ -f "$f" ]] || continue
+            local rel="${f#${dir}/}"
+            scan_file "$f" "${prefix}${rel}"
+        done < <(find "${dir}/lib" -name '*.dylib' -type f 2>/dev/null)
+    fi
+
+    # Scan top-level Mach-O files (single-binary databases like duckdb, qdrant)
+    for f in "${dir}/"*; do
+        [[ -f "$f" ]] || continue
+        [[ "$(basename "$f")" == .* ]] && continue
+        [[ "$f" == *.json ]] && continue
+        [[ "$f" == *.conf ]] && continue
+        [[ "$f" == *.yml ]] && continue
+        file "$f" | grep -q "Mach-O" || continue
+        scan_file "$f" "${prefix}$(basename "$f")"
+    done
+}
+
+echo "=== check-macos-dylibs: Scanning $SCAN_PATH ==="
+echo ""
+
+# Determine if this is a single package or a directory of packages
+if [[ -d "${SCAN_PATH}/bin" ]] || ls "${SCAN_PATH}/"*.dylib &>/dev/null 2>&1; then
+    # Single package directory
+    scan_directory "$SCAN_PATH" "$(basename "$SCAN_PATH")/"
+else
+    # Parent directory — scan each subdirectory as a package
+    for pkg_dir in "${SCAN_PATH}/"*/; do
+        [[ -d "$pkg_dir" ]] || continue
+        pkg_name=$(basename "$pkg_dir")
+        echo "--- ${pkg_name} ---"
+        scan_directory "$pkg_dir" "${pkg_name}/"
+    done
+fi
+
+# Summary
+echo ""
+echo "=== Summary ==="
+echo "  Files scanned: ${TOTAL_FILES}"
+echo "  Files with issues: ${PROBLEM_FILES}"
+
+if [[ $PROBLEM_FILES -gt 0 ]]; then
+    echo ""
+    echo "RESULT: FAIL — ${PROBLEM_FILES} file(s) have non-relocatable Homebrew paths"
+    echo "Fix: Run builds/common/fix-macos-dylibs.sh <package-root> before creating the tarball"
+    exit 1
+else
+    echo ""
+    echo "RESULT: PASS — all binaries are relocatable"
+    exit 0
+fi

--- a/builds/common/fix-macos-dylibs.sh
+++ b/builds/common/fix-macos-dylibs.sh
@@ -1,0 +1,317 @@
+#!/usr/bin/env bash
+# fix-macos-dylibs.sh — Bundle Homebrew dylibs and rewrite paths for relocatable macOS binaries
+#
+# Usage: ./builds/common/fix-macos-dylibs.sh <package-root>
+#
+# Takes a package directory (e.g. install/redis, install/mariadb) and:
+#   1. Scans all Mach-O binaries for Homebrew dependencies
+#   2. Recursively copies those dylibs into the package's lib/ directory
+#   3. Rewrites all absolute paths to @loader_path relative references
+#   4. Re-signs all modified binaries (required by macOS)
+#   5. Verifies no Homebrew paths remain (fails CI if any found)
+#
+# Adapted from builds/postgresql-documentdb/build-macos.sh (steps 10-12).
+
+set -euo pipefail
+
+# ============================================================================
+# Argument validation
+# ============================================================================
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 <package-root>"
+    echo "Example: $0 \$GITHUB_WORKSPACE/install/redis"
+    exit 1
+fi
+
+PACKAGE_ROOT="$1"
+
+if [[ ! -d "$PACKAGE_ROOT" ]]; then
+    echo "ERROR: Package root does not exist: $PACKAGE_ROOT"
+    exit 1
+fi
+
+# Resolve to absolute path
+PACKAGE_ROOT="$(cd "$PACKAGE_ROOT" && pwd)"
+
+echo "=== fix-macos-dylibs: $PACKAGE_ROOT ==="
+
+# ============================================================================
+# Detect Homebrew prefixes
+# ============================================================================
+is_homebrew_path() {
+    local path="$1"
+    [[ "$path" == /opt/homebrew/* ]] || [[ "$path" == /usr/local/Cellar/* ]] || \
+    [[ "$path" == /usr/local/opt/* ]] || [[ "$path" == /usr/local/lib/* ]]
+}
+
+is_system_lib() {
+    local path="$1"
+    [[ "$path" == /usr/lib/* ]] || [[ "$path" == /System/* ]]
+}
+
+# ============================================================================
+# Phase 1: Bundle Homebrew dependencies
+# ============================================================================
+echo "Phase 1: Bundling Homebrew dependencies..."
+
+LIB_DIR="${PACKAGE_ROOT}/lib"
+mkdir -p "$LIB_DIR"
+
+# Track processed libraries to avoid infinite recursion
+PROCESSED_FILE=$(mktemp)
+trap 'rm -f "$PROCESSED_FILE"' EXIT
+
+is_processed() { grep -qxF "$1" "$PROCESSED_FILE" 2>/dev/null; }
+mark_processed() { echo "$1" >> "$PROCESSED_FILE"; }
+
+copy_lib_recursive() {
+    local lib_path="$1"
+    local lib_name
+    lib_name=$(basename "$lib_path")
+
+    if is_processed "$lib_name"; then return 0; fi
+    mark_processed "$lib_name"
+
+    # Skip system libraries and @-prefixed references we can't resolve
+    if is_system_lib "$lib_path" || [[ "$lib_path" == "@"* ]]; then
+        return 0
+    fi
+
+    if [[ ! -f "$lib_path" ]]; then return 0; fi
+
+    # Copy Homebrew libraries into the package lib/
+    if is_homebrew_path "$lib_path"; then
+        if [[ ! -f "${LIB_DIR}/${lib_name}" ]]; then
+            echo "  Bundling: ${lib_name}"
+            cp -L "$lib_path" "${LIB_DIR}/${lib_name}" 2>/dev/null || true
+        fi
+    fi
+
+    # Recursively process this library's dependencies
+    local deps lib_dir
+    lib_dir=$(dirname "$lib_path")
+    deps=$(otool -L "$lib_path" 2>/dev/null | tail -n +2 | awk '{print $1}') || return 0
+
+    for dep in $deps; do
+        if is_system_lib "$dep"; then continue; fi
+
+        if [[ "$dep" == @loader_path/* ]]; then
+            local resolved="${lib_dir}/${dep#@loader_path/}"
+            if [[ -f "$resolved" ]]; then copy_lib_recursive "$resolved"; fi
+            continue
+        fi
+
+        if [[ "$dep" == @rpath/* ]]; then
+            local rpath_lib="${dep#@rpath/}"
+            local found=""
+            for search_dir in "/opt/homebrew/lib" "/usr/local/lib" "$lib_dir" "$LIB_DIR"; do
+                if [[ -f "${search_dir}/${rpath_lib}" ]]; then
+                    found="${search_dir}/${rpath_lib}"
+                    break
+                fi
+            done
+            if [[ -n "$found" ]]; then copy_lib_recursive "$found"; fi
+            continue
+        fi
+
+        if [[ "$dep" == "@"* ]]; then continue; fi
+        if [[ -f "$dep" ]]; then copy_lib_recursive "$dep"; fi
+    done
+}
+
+# Scan binaries in bin/
+if [[ -d "${PACKAGE_ROOT}/bin" ]]; then
+    for binary in "${PACKAGE_ROOT}/bin/"*; do
+        [[ -f "$binary" ]] || continue
+        file "$binary" | grep -q "Mach-O" || continue
+        deps=$(otool -L "$binary" 2>/dev/null | tail -n +2 | awk '{print $1}') || continue
+        for dep in $deps; do copy_lib_recursive "$dep"; done
+    done
+fi
+
+# Scan dylibs in lib/ (and subdirectories) — loop until no new deps discovered
+prev_count=0
+curr_count=1
+while [[ $prev_count -ne $curr_count ]]; do
+    prev_count=$curr_count
+    while IFS= read -r dylib; do
+        [[ -f "$dylib" ]] || continue
+        deps=$(otool -L "$dylib" 2>/dev/null | tail -n +2 | awk '{print $1}') || continue
+        for dep in $deps; do copy_lib_recursive "$dep"; done
+    done < <(find "$LIB_DIR" -name '*.dylib' -type f 2>/dev/null)
+    curr_count=$(find "$LIB_DIR" -name '*.dylib' -type f 2>/dev/null | wc -l | tr -d ' ')
+done
+
+BUNDLED_COUNT=$(wc -l < "$PROCESSED_FILE" | tr -d ' ')
+echo "  Bundled ${BUNDLED_COUNT} libraries"
+
+# ============================================================================
+# Phase 2: Fix install names (set dylib IDs to @rpath/<name>)
+# ============================================================================
+echo "Phase 2: Fixing dylib install names..."
+
+while IFS= read -r dylib; do
+    [[ -f "$dylib" ]] || continue
+    lib_name=$(basename "$dylib")
+    current_id=$(otool -D "$dylib" 2>/dev/null | tail -1) || continue
+    if [[ "$current_id" == "@"* ]]; then continue; fi
+
+    # Preserve subdirectory structure in the ID (e.g. @rpath/plugin/foo.dylib)
+    local_path="${dylib#${LIB_DIR}/}"
+    install_name_tool -id "@rpath/${local_path}" "$dylib" 2>/dev/null || true
+done < <(find "$LIB_DIR" -name '*.dylib' -type f 2>/dev/null)
+
+# ============================================================================
+# Phase 3: Fix references (rewrite Homebrew paths to @loader_path)
+# ============================================================================
+echo "Phase 3: Fixing library references..."
+
+fix_references() {
+    local file="$1"
+    local file_type="$2"  # "dylib" or "binary"
+
+    file "$file" | grep -q "Mach-O" || return 0
+
+    local deps
+    deps=$(otool -L "$file" 2>/dev/null | tail -n +2 | awk '{print $1}') || return 0
+
+    # Compute how deep this file is relative to LIB_DIR (for subdirectory dylibs)
+    local file_dir rel_prefix=""
+    file_dir=$(dirname "$file")
+    if [[ "$file_type" == "dylib" && "$file_dir" != "$LIB_DIR" ]]; then
+        # e.g. lib/plugin/foo.dylib needs "../" to reach lib/
+        local depth
+        depth=$(echo "${file_dir#${LIB_DIR}/}" | tr '/' '\n' | wc -l | tr -d ' ')
+        for ((i=0; i<depth; i++)); do rel_prefix+="../"; done
+    fi
+
+    for dep in $deps; do
+        if is_system_lib "$dep" || [[ "$dep" == "@"* ]]; then continue; fi
+
+        local lib_name new_path=""
+        lib_name=$(basename "$dep")
+
+        # Check if the lib exists in LIB_DIR (top-level) or any subdirectory
+        if [[ -f "${LIB_DIR}/${lib_name}" ]]; then
+            if [[ "$file_type" == "dylib" ]]; then
+                new_path="@loader_path/${rel_prefix}${lib_name}"
+            else
+                new_path="@loader_path/../lib/${lib_name}"
+            fi
+        else
+            # Search subdirectories of LIB_DIR
+            local found_sub
+            found_sub=$(find "$LIB_DIR" -name "$lib_name" -type f 2>/dev/null | head -1)
+            if [[ -n "$found_sub" ]]; then
+                local sub_path="${found_sub#${LIB_DIR}/}"
+                if [[ "$file_type" == "dylib" ]]; then
+                    new_path="@loader_path/${rel_prefix}${sub_path}"
+                else
+                    new_path="@loader_path/../lib/${sub_path}"
+                fi
+            fi
+        fi
+
+        if [[ -n "$new_path" ]]; then
+            install_name_tool -change "$dep" "$new_path" "$file" 2>/dev/null || true
+        fi
+    done
+
+    # Add rpath for binaries so @rpath references resolve
+    if [[ "$file_type" == "binary" ]]; then
+        if ! otool -l "$file" 2>/dev/null | grep -A2 "LC_RPATH" | grep -q "@loader_path/../lib"; then
+            install_name_tool -add_rpath "@loader_path/../lib" "$file" 2>/dev/null || true
+        fi
+    fi
+}
+
+# Fix binaries in bin/
+if [[ -d "${PACKAGE_ROOT}/bin" ]]; then
+    for binary in "${PACKAGE_ROOT}/bin/"*; do
+        [[ -f "$binary" ]] && fix_references "$binary" "binary"
+    done
+fi
+
+# Fix all dylibs in lib/ (including subdirectories)
+while IFS= read -r dylib; do
+    [[ -f "$dylib" ]] && fix_references "$dylib" "dylib"
+done < <(find "$LIB_DIR" -name '*.dylib' -type f 2>/dev/null)
+
+# Fix rpaths on dylibs — remove Homebrew paths, add @loader_path
+echo "Phase 3b: Fixing rpaths on dylibs..."
+while IFS= read -r dylib; do
+    [[ -f "$dylib" ]] || continue
+    # Remove Homebrew rpaths
+    for rpath in $(otool -l "$dylib" 2>/dev/null | grep -A2 LC_RPATH | grep "path " | awk '{print $2}'); do
+        if [[ "$rpath" == *"/opt/homebrew/"* ]] || [[ "$rpath" == *"/usr/local/"* ]] || [[ "$rpath" == *"/Cellar/"* ]]; then
+            install_name_tool -delete_rpath "$rpath" "$dylib" 2>/dev/null || true
+        fi
+    done
+    # Add @loader_path if dylib references other dylibs via @rpath
+    if otool -L "$dylib" 2>/dev/null | grep -q "@rpath/"; then
+        if ! otool -l "$dylib" 2>/dev/null | grep -A2 "LC_RPATH" | grep -q "@loader_path"; then
+            install_name_tool -add_rpath "@loader_path" "$dylib" 2>/dev/null || true
+        fi
+    fi
+done < <(find "$LIB_DIR" -name '*.dylib' -type f 2>/dev/null)
+
+# ============================================================================
+# Phase 4: Code sign all modified Mach-O files
+# ============================================================================
+echo "Phase 4: Code signing..."
+
+SIGNED_COUNT=0
+if [[ -d "${PACKAGE_ROOT}/bin" ]]; then
+    for f in "${PACKAGE_ROOT}/bin/"*; do
+        if [[ -f "$f" ]] && file "$f" | grep -q "Mach-O"; then
+            codesign -s - --force "$f" 2>/dev/null && ((SIGNED_COUNT++)) || true
+        fi
+    done
+fi
+while IFS= read -r f; do
+    if [[ -f "$f" ]]; then
+        codesign -s - --force "$f" 2>/dev/null && ((SIGNED_COUNT++)) || true
+    fi
+done < <(find "$LIB_DIR" -name '*.dylib' -type f 2>/dev/null)
+
+echo "  Signed ${SIGNED_COUNT} files"
+
+# ============================================================================
+# Phase 5: Verify no Homebrew paths remain
+# ============================================================================
+echo "Phase 5: Verifying relocatable binaries..."
+
+VERIFY_FAILED=0
+
+check_file() {
+    local file="$1"
+    local label="$2"
+    local remaining
+    remaining=$(otool -L "$file" 2>/dev/null | grep -E "(Cellar|opt/homebrew|/usr/local/(opt|lib|Cellar))" | grep -v "^$" || true)
+    if [[ -n "$remaining" ]]; then
+        echo "  FAIL: Non-relocatable paths in ${label}:"
+        echo "$remaining" | while IFS= read -r line; do echo "    $line"; done
+        VERIFY_FAILED=1
+    fi
+}
+
+if [[ -d "${PACKAGE_ROOT}/bin" ]]; then
+    for binary in "${PACKAGE_ROOT}/bin/"*; do
+        [[ -f "$binary" ]] || continue
+        file "$binary" | grep -q "Mach-O" || continue
+        check_file "$binary" "bin/$(basename "$binary")"
+    done
+fi
+
+while IFS= read -r dylib; do
+    [[ -f "$dylib" ]] || continue
+    local_path="${dylib#${LIB_DIR}/}"
+    check_file "$dylib" "lib/${local_path}"
+done < <(find "$LIB_DIR" -name '*.dylib' -type f 2>/dev/null)
+
+if [[ $VERIFY_FAILED -eq 1 ]]; then
+    echo "ERROR: Some binaries still have non-relocatable Homebrew paths!"
+    exit 1
+fi
+
+echo "=== fix-macos-dylibs: All binaries are relocatable ==="

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hostdb",
-  "version": "0.26.1",
+  "version": "0.27.0",
   "description": "Source and download pre-built database binaries for multiple platforms, distributed via GitHub Releases",
   "private": false,
   "type": "module",
@@ -28,6 +28,7 @@
   "scripts": {
     "add:engine": "tsx scripts/add-engine.ts",
     "build:releases": "tsx scripts/build-releases-json.ts",
+    "check:dylibs": "builds/common/check-macos-dylibs.sh",
     "checksums:populate": "tsx scripts/populate-checksums.ts",
     "dbs": "tsx scripts/list-databases.ts",
     "delete:releases": "tsx scripts/delete-releases.ts",


### PR DESCRIPTION
## Summary

- Add shared `builds/common/fix-macos-dylibs.sh` that bundles Homebrew dylibs into `lib/` and rewrites absolute paths to `@loader_path` relative references, making macOS binaries fully relocatable
- Integrate into MariaDB, Redis, and Valkey release workflows (macOS build steps)
- Add `builds/common/check-macos-dylibs.sh` read-only diagnostic (`pnpm check:dylibs`)
- Add `audit-dylibs.yml` workflow to audit published R2 releases for non-relocatable paths
- Bump version to 0.27.0

## Test plan

- [ ] Trigger Redis release workflow for `darwin-arm64` and verify build log shows dylib patching step with library count
- [ ] Verify resulting tarball contains `redis/lib/` with OpenSSL dylibs
- [ ] Download and extract, run `pnpm check:dylibs -- ./dist/redis` — should pass clean
- [ ] Run `audit-dylibs` workflow against existing releases to confirm they correctly report FAIL (pre-patch)
- [ ] After rebuilding all 14 affected releases, re-run audit to confirm PASS