### PR TITLE
Release v0.28.0

### DIFF
--- a/.github/workflows/release-clickhouse.yml
+++ b/.github/workflows/release-clickhouse.yml
@@ -264,6 +264,12 @@ jobs:
           echo "Checksums:"
           cat ./release-assets/checksums.txt || echo "No checksums"
 
+      - name: Validate required binaries
+        if: steps.prepare.outputs.has-artifacts == 'true'
+        run: |
+          chmod +x builds/common/validate-binaries.sh
+          ./builds/common/validate-binaries.sh clickhouse ./release-assets
+
       - name: Create Release
         if: steps.prepare.outputs.has-artifacts == 'true'
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release-cockroachdb.yml
+++ b/.github/workflows/release-cockroachdb.yml
@@ -171,6 +171,11 @@ jobs:
       - name: List release assets
         run: ls -la ./release-assets/
 
+      - name: Validate required binaries
+        run: |
+          chmod +x builds/common/validate-binaries.sh
+          ./builds/common/validate-binaries.sh cockroachdb ./release-assets
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release-couchdb.yml
+++ b/.github/workflows/release-couchdb.yml
@@ -495,6 +495,11 @@ jobs:
           echo "Checksums:"
           cat ./release-assets/checksums.txt
 
+      - name: Validate required binaries
+        run: |
+          chmod +x builds/common/validate-binaries.sh
+          ./builds/common/validate-binaries.sh couchdb ./release-assets
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release-duckdb.yml
+++ b/.github/workflows/release-duckdb.yml
@@ -179,6 +179,11 @@ jobs:
       - name: List release assets
         run: ls -la ./release-assets/
 
+      - name: Validate required binaries
+        run: |
+          chmod +x builds/common/validate-binaries.sh
+          ./builds/common/validate-binaries.sh duckdb ./release-assets
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release-ferretdb.yml
+++ b/.github/workflows/release-ferretdb.yml
@@ -184,6 +184,11 @@ jobs:
       - name: List release assets
         run: ls -la ./release-assets/
 
+      - name: Validate required binaries
+        run: |
+          chmod +x builds/common/validate-binaries.sh
+          ./builds/common/validate-binaries.sh ferretdb ./release-assets
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release-influxdb.yml
+++ b/.github/workflows/release-influxdb.yml
@@ -205,6 +205,11 @@ jobs:
       - name: List release assets
         run: ls -la ./release-assets/
 
+      - name: Validate required binaries
+        run: |
+          chmod +x builds/common/validate-binaries.sh
+          ./builds/common/validate-binaries.sh influxdb ./release-assets
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release-mariadb.yml
+++ b/.github/workflows/release-mariadb.yml
@@ -418,6 +418,11 @@ jobs:
           echo "Checksums:"
           cat ./release-assets/checksums.txt
 
+      - name: Validate required binaries
+        run: |
+          chmod +x builds/common/validate-binaries.sh
+          ./builds/common/validate-binaries.sh mariadb ./release-assets
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release-meilisearch.yml
+++ b/.github/workflows/release-meilisearch.yml
@@ -171,6 +171,11 @@ jobs:
       - name: List release assets
         run: ls -la ./release-assets/
 
+      - name: Validate required binaries
+        run: |
+          chmod +x builds/common/validate-binaries.sh
+          ./builds/common/validate-binaries.sh meilisearch ./release-assets
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release-mongodb.yml
+++ b/.github/workflows/release-mongodb.yml
@@ -176,6 +176,11 @@ jobs:
       - name: List release assets
         run: ls -la ./release-assets/
 
+      - name: Validate required binaries
+        run: |
+          chmod +x builds/common/validate-binaries.sh
+          ./builds/common/validate-binaries.sh mongodb ./release-assets
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release-mysql.yml
+++ b/.github/workflows/release-mysql.yml
@@ -177,6 +177,11 @@ jobs:
       - name: List release assets
         run: ls -la ./release-assets/
 
+      - name: Validate required binaries
+        run: |
+          chmod +x builds/common/validate-binaries.sh
+          ./builds/common/validate-binaries.sh mysql ./release-assets
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release-postgresql-documentdb.yml
+++ b/.github/workflows/release-postgresql-documentdb.yml
@@ -401,6 +401,11 @@ jobs:
           echo "Checksums:"
           cat ./release-assets/checksums.txt
 
+      - name: Validate required binaries
+        run: |
+          chmod +x builds/common/validate-binaries.sh
+          ./builds/common/validate-binaries.sh postgresql-documentdb ./release-assets
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release-postgresql.yml
+++ b/.github/workflows/release-postgresql.yml
@@ -790,6 +790,11 @@ jobs:
           echo "Checksums:"
           cat ./release-assets/checksums.txt
 
+      - name: Validate required binaries
+        run: |
+          chmod +x builds/common/validate-binaries.sh
+          ./builds/common/validate-binaries.sh postgresql ./release-assets
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release-qdrant.yml
+++ b/.github/workflows/release-qdrant.yml
@@ -171,6 +171,11 @@ jobs:
       - name: List release assets
         run: ls -la ./release-assets/
 
+      - name: Validate required binaries
+        run: |
+          chmod +x builds/common/validate-binaries.sh
+          ./builds/common/validate-binaries.sh qdrant ./release-assets
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release-questdb.yml
+++ b/.github/workflows/release-questdb.yml
@@ -171,6 +171,11 @@ jobs:
       - name: List release assets
         run: ls -la ./release-assets/
 
+      - name: Validate required binaries
+        run: |
+          chmod +x builds/common/validate-binaries.sh
+          ./builds/common/validate-binaries.sh questdb ./release-assets
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release-redis.yml
+++ b/.github/workflows/release-redis.yml
@@ -379,6 +379,11 @@ jobs:
           echo "Checksums:"
           cat ./release-assets/checksums.txt
 
+      - name: Validate required binaries
+        run: |
+          chmod +x builds/common/validate-binaries.sh
+          ./builds/common/validate-binaries.sh redis ./release-assets
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release-sqlite.yml
+++ b/.github/workflows/release-sqlite.yml
@@ -252,6 +252,11 @@ jobs:
       - name: List release assets
         run: ls -la ./release-assets/
 
+      - name: Validate required binaries
+        run: |
+          chmod +x builds/common/validate-binaries.sh
+          ./builds/common/validate-binaries.sh sqlite ./release-assets
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release-surrealdb.yml
+++ b/.github/workflows/release-surrealdb.yml
@@ -171,6 +171,11 @@ jobs:
       - name: List release assets
         run: ls -la ./release-assets/
 
+      - name: Validate required binaries
+        run: |
+          chmod +x builds/common/validate-binaries.sh
+          ./builds/common/validate-binaries.sh surrealdb ./release-assets
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release-tigerbeetle.yml
+++ b/.github/workflows/release-tigerbeetle.yml
@@ -177,6 +177,11 @@ jobs:
       - name: List release assets
         run: ls -la ./release-assets/
 
+      - name: Validate required binaries
+        run: |
+          chmod +x builds/common/validate-binaries.sh
+          ./builds/common/validate-binaries.sh tigerbeetle ./release-assets
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release-typedb.yml
+++ b/.github/workflows/release-typedb.yml
@@ -171,6 +171,11 @@ jobs:
       - name: List release assets
         run: ls -la ./release-assets/
 
+      - name: Validate required binaries
+        run: |
+          chmod +x builds/common/validate-binaries.sh
+          ./builds/common/validate-binaries.sh typedb ./release-assets
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release-valkey.yml
+++ b/.github/workflows/release-valkey.yml
@@ -440,6 +440,11 @@ jobs:
           echo "Checksums:"
           cat ./release-assets/checksums.txt
 
+      - name: Validate required binaries
+        run: |
+          chmod +x builds/common/validate-binaries.sh
+          ./builds/common/validate-binaries.sh valkey ./release-assets
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release-weaviate.yml
+++ b/.github/workflows/release-weaviate.yml
@@ -176,6 +176,11 @@ jobs:
       - name: List release assets
         run: ls -la ./release-assets/
 
+      - name: Validate required binaries
+        run: |
+          chmod +x builds/common/validate-binaries.sh
+          ./builds/common/validate-binaries.sh weaviate ./release-assets
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.28.0] - 2026-02-20
+
+### Added
+
+- **Binary validation in all release workflows** (`builds/common/validate-binaries.sh`)
+  - Shared script that extracts archives and verifies all required `cli_tools` binaries exist before creating GitHub Releases
+  - Reads `databases.json` to determine required binaries per engine (server, client, utilities)
+  - Handles dependency-aware validation — skips binaries provided by dependency databases (e.g., QuestDB depends on PostgreSQL for `psql`)
+  - Handles naming variants across platforms (Windows `.exe`/`.cmd`/`.bat` extensions, hyphen-to-underscore)
+  - Added as a "Validate required binaries" step in all 21 release workflows
+  - Prevents shipping incomplete releases (e.g., PostgreSQL without `psql` and `pg_dump`)
+
 ## [0.27.0] - 2026-02-16
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,7 @@ hostdb/
 │   └── releases.schema.json
 ├── builds/                 # Per-database build configurations
 │   ├── common/
+│   │   ├── validate-binaries.sh  # Validate archives contain all required cli_tools binaries
 │   │   ├── fix-macos-dylibs.sh   # Bundle Homebrew dylibs for relocatable binaries
 │   │   └── check-macos-dylibs.sh # Audit packages for non-relocatable paths
 │   ├── mysql/
@@ -214,8 +215,10 @@ Each database has a release workflow that **validates against databases.json**:
 3. **Validate job** checks version is enabled in `databases.json` and exists in `sources.json`
 4. Matrix builds all platforms in parallel
 5. Downloads official binaries OR builds from source
-6. Creates GitHub Release with artifacts
-7. `update-releases` job rebuilds `releases.json` from all GitHub releases and publishes to R2
+6. **Validate binaries** - extracts archives and verifies all `cli_tools` binaries exist
+7. Creates GitHub Release with artifacts
+8. `upload-to-r2` job mirrors release assets to Cloudflare R2
+9. `update-releases` job rebuilds `releases.json` from all GitHub releases and publishes to R2
 
 **Validation flow:**
 ```
@@ -333,6 +336,14 @@ When implementing `.github/workflows/release-<database>.yml`:
    - name: Download source build artifacts
      if: needs.build-source.result == 'success'
      uses: actions/download-artifact@v4
+   ```
+
+3. **Binary validation step**: Every release workflow must validate archives before creating the GitHub Release. Add this step in the `release` job, after preparing release assets and before the "Create Release" step:
+   ```yaml
+   - name: Validate required binaries
+     run: |
+       chmod +x builds/common/validate-binaries.sh
+       ./builds/common/validate-binaries.sh <database-id> ./release-assets
    ```
 
 ## Adding New Versions
@@ -574,3 +585,22 @@ chmod +x "$GITHUB_WORKSPACE/builds/common/fix-macos-dylibs.sh"
 **Currently used by:** MariaDB, Redis, Valkey, CouchDB workflows. PostgreSQL-DocumentDB has its own inline implementation.
 
 **Diagnostic:** `pnpm check:dylibs [<path>]` scans packages for non-relocatable paths without modifying anything. The `audit-dylibs` workflow (`workflow_dispatch`) audits published releases on R2.
+
+## Binary Validation (Shared Script)
+
+Every release workflow validates that archives contain all required binaries before creating the GitHub Release. This prevents shipping incomplete releases (e.g., PostgreSQL 17.7.0 once shipped without `psql`, `pg_dump`, and other client tools, breaking SpinDB's backup/restore).
+
+**`builds/common/validate-binaries.sh <database> <release-assets-dir>`** does the following:
+1. Reads `databases.json` to get the database's `cliTools` (server, client, utilities)
+2. Collects all non-null binary names from those fields (skips `enhanced` tools)
+3. For each archive (`.tar.gz` / `.zip`) in the release assets directory, extracts and searches for each required binary
+4. Fails the build with clear error messages if any binary is missing
+
+**Dependency-aware:** Some databases depend on others for client tools. For example, QuestDB lists `psql` as its client but depends on PostgreSQL — `psql` comes from the PostgreSQL install, not the QuestDB tarball. The script reads `dependencies` from `databases.json` (both top-level and per-version) and skips binaries provided by dependency databases.
+
+**Name variant handling:** The script handles naming differences between `cli_tools` and actual binaries:
+- Windows extensions: `.exe`, `.cmd`, `.bat`
+- Hyphen-to-underscore: `typedb-console` → `typedb_console`, `typedb_console_bin`
+- Searches recursively through the entire extracted archive (handles `bin/`, root, and custom paths like TypeDB's `server/` and `console/`)
+
+**Currently used by:** All 21 release workflows. Added as a "Validate required binaries" step in each workflow's `release` job, positioned after artifact preparation and before "Create Release".

--- a/builds/common/validate-binaries.sh
+++ b/builds/common/validate-binaries.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# validate-binaries.sh - Validate release archives contain all required cli_tools binaries
+#
+# Usage: validate-binaries.sh <database> <release-assets-dir>
+#
+# Reads databases.json to determine required binaries (server, client, utilities).
+# Skips enhanced tools, null entries, and binaries provided by dependencies.
+# For each archive in the release-assets directory, extracts and validates.
+
+set -euo pipefail
+
+DB="${1:?Usage: validate-binaries.sh <database> <release-assets-dir>}"
+ASSETS_DIR="${2:?Usage: validate-binaries.sh <database> <release-assets-dir>}"
+
+# Find databases.json relative to this script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+DATABASES_JSON="$REPO_ROOT/databases.json"
+
+if [ ! -f "$DATABASES_JSON" ]; then
+  echo "::error::databases.json not found at $DATABASES_JSON"
+  exit 1
+fi
+
+if [ ! -d "$ASSETS_DIR" ]; then
+  echo "::error::Release assets directory not found: $ASSETS_DIR"
+  exit 1
+fi
+
+echo "=== Binary Validation for $DB ==="
+
+# Collect required binaries from cli_tools (server, client, utilities)
+# Skip null values, empty strings, and enhanced tools
+REQUIRED_BINARIES=$(jq -r "
+  .databases[\"$DB\"].cliTools |
+  [
+    .server,
+    .client,
+    (.utilities // [] | .[])
+  ] |
+  map(select(. != null and . != \"null\" and . != \"\")) |
+  unique |
+  .[]
+" "$DATABASES_JSON")
+
+if [ -z "$REQUIRED_BINARIES" ]; then
+  echo "No required binaries defined for $DB - skipping validation"
+  exit 0
+fi
+
+echo "Required binaries: $(echo "$REQUIRED_BINARIES" | tr '\n' ' ')"
+
+# Collect binaries provided by dependencies (these are NOT expected in this tarball)
+# For example, QuestDB depends on PostgreSQL and lists psql as client,
+# but psql comes from the PostgreSQL install, not the QuestDB tarball
+DEP_BINARIES_FILE=$(mktemp)
+trap "rm -f '$DEP_BINARIES_FILE'" EXIT
+
+DEPS=$(jq -r "
+  .databases[\"$DB\"] |
+  [
+    (.dependencies // [] | .[].database),
+    (.versions | to_entries[] | .value |
+      if type == \"object\" then (.dependencies // [] | .[].database) else empty end
+    )
+  ] | flatten | unique | .[]
+" "$DATABASES_JSON" 2>/dev/null || true)
+
+for dep in $DEPS; do
+  [ -z "$dep" ] && continue
+  jq -r "
+    .databases[\"$dep\"].cliTools // {} |
+    [.server, .client, (.utilities // [] | .[])] |
+    map(select(. != null and . != \"null\")) | .[]
+  " "$DATABASES_JSON" >> "$DEP_BINARIES_FILE" 2>/dev/null || true
+done
+
+if [ -s "$DEP_BINARIES_FILE" ]; then
+  echo "Binaries from dependencies (will skip): $(sort -u "$DEP_BINARIES_FILE" | tr '\n' ' ')"
+fi
+
+# Check if a binary name is provided by a dependency
+is_dep_binary() {
+  grep -qx "$1" "$DEP_BINARIES_FILE" 2>/dev/null
+}
+
+# Find a binary in the extracted archive directory
+# Tries: exact name, .exe/.cmd/.bat extensions, underscore variants, _bin suffix
+find_binary() {
+  local extract_dir="$1"
+  local binary="$2"
+
+  # Build list of names to search for
+  local names=("$binary" "${binary}.exe" "${binary}.cmd" "${binary}.bat")
+
+  # Also try with hyphens replaced by underscores
+  # Handles TypeDB naming: typedb-console -> typedb_console_bin
+  local underscore_name="${binary//-/_}"
+  if [ "$underscore_name" != "$binary" ]; then
+    names+=("$underscore_name" "${underscore_name}_bin")
+    names+=("${underscore_name}.exe" "${underscore_name}_bin.exe" "${underscore_name}.bat")
+  fi
+
+  for name in "${names[@]}"; do
+    if find "$extract_dir" -name "$name" -print -quit 2>/dev/null | grep -q .; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+# Get the cli_tools category for a binary (for error messages)
+get_category() {
+  local binary="$1"
+  local server client
+  server=$(jq -r ".databases[\"$DB\"].cliTools.server // \"\"" "$DATABASES_JSON")
+  client=$(jq -r ".databases[\"$DB\"].cliTools.client // \"\"" "$DATABASES_JSON")
+
+  if [ "$binary" = "$server" ]; then
+    echo "cli_tools.server"
+  elif [ "$binary" = "$client" ]; then
+    echo "cli_tools.client"
+  else
+    echo "cli_tools.utilities"
+  fi
+}
+
+# Track overall validation result
+OVERALL_FAILED=0
+
+# Find all archives
+shopt -s nullglob
+ARCHIVES=("$ASSETS_DIR"/*.tar.gz "$ASSETS_DIR"/*.zip)
+
+if [ ${#ARCHIVES[@]} -eq 0 ]; then
+  echo "::warning::No archives found in $ASSETS_DIR - skipping validation"
+  exit 0
+fi
+
+echo "Found ${#ARCHIVES[@]} archive(s) to validate"
+echo ""
+
+for archive in "${ARCHIVES[@]}"; do
+  FILENAME=$(basename "$archive")
+  echo "--- Validating: $FILENAME ---"
+
+  # Extract to temp directory
+  TEMP_DIR=$(mktemp -d)
+
+  if [[ "$archive" == *.tar.gz ]]; then
+    tar -xzf "$archive" -C "$TEMP_DIR"
+  elif [[ "$archive" == *.zip ]]; then
+    unzip -q "$archive" -d "$TEMP_DIR"
+  fi
+
+  # Validate each required binary
+  ARCHIVE_FAILED=0
+  while IFS= read -r binary; do
+    [ -z "$binary" ] && continue
+
+    # Skip if provided by a dependency
+    if is_dep_binary "$binary"; then
+      echo "  Skip: $binary (provided by dependency)"
+      continue
+    fi
+
+    if find_binary "$TEMP_DIR" "$binary"; then
+      echo "  Found: $binary"
+    else
+      CATEGORY=$(get_category "$binary")
+      echo "  MISSING: $binary (listed in $CATEGORY)"
+      ARCHIVE_FAILED=1
+      OVERALL_FAILED=1
+    fi
+  done <<< "$REQUIRED_BINARIES"
+
+  if [ $ARCHIVE_FAILED -eq 1 ]; then
+    echo ""
+    echo "  Archive contents:"
+    find "$TEMP_DIR" -type f -o -type l | sed "s|$TEMP_DIR/||" | sort | head -50
+  fi
+
+  rm -rf "$TEMP_DIR"
+  echo ""
+done
+
+if [ $OVERALL_FAILED -eq 1 ]; then
+  echo "::error::Binary validation failed for $DB - see above for details"
+  exit 1
+fi
+
+echo "All required binaries validated for $DB"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hostdb",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "description": "Source and download pre-built database binaries for multiple platforms, distributed via GitHub Releases",
   "private": false,
   "type": "module",


### PR DESCRIPTION
## Summary

- **Binary validation in all release workflows** — New `builds/common/validate-binaries.sh` script verifies archives contain all required `cli_tools` binaries before creating GitHub Releases. Handles dependency-aware validation, Windows name variants, and recursive binary search. Added to all 21 workflows.
- **Cloudflare CDN cache purging** — `upload-to-r2.ts` now purges CDN edge cache when using `--force`, all workflows force-upload by default
- **macOS dylib patching** — Generic `fix-macos-dylibs.sh` for relocatable binaries, integrated into MariaDB, Redis, Valkey, CouchDB workflows
- **macOS dylib audit tooling** — `check-macos-dylibs.sh` diagnostic + `audit-dylibs` workflow
- **TigerBeetle and Weaviate releases** — New engines fully built and released
- **FerretDB restructuring** — Consolidated ferretdb-v1 into main ferretdb engine
- **R2 binary hosting migration** — All download URLs now served from `registry.layerbase.host`

## Test plan

- [ ] Verify `pnpm prep` passes
- [ ] Trigger a test release workflow to confirm validate-binaries.sh works in CI
- [ ] Verify releases.json is accurate