### PR TITLE
fix: add actions:write permission for build-missing workflow

### DIFF
--- a/.github/workflows/build-missing-releases.yml
+++ b/.github/workflows/build-missing-releases.yml
@@ -153,6 +153,8 @@ jobs:
     needs: find-missing
     if: github.event.inputs.action == 'build-missing' && needs.find-missing.outputs.has-missing == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
     outputs:
       triggered: ${{ steps.trigger.outputs.triggered }}
     strategy:


### PR DESCRIPTION
## Summary
- Adds `permissions: actions: write` to the `trigger-builds` job in `build-missing-releases.yml`
- Fixes HTTP 403 error when dispatching release workflows via `gh workflow run`

## Test plan
- [x] Trigger `build-missing-releases.yml` with `build-missing` action for libsql and verify it can dispatch `release-libsql.yml`