### PR TITLE
fix: validate-binaries.sh fails when no .zip archives exist

### DIFF
--- a/builds/common/validate-binaries.sh
+++ b/builds/common/validate-binaries.sh
@@ -31,7 +31,7 @@ echo "=== Binary Validation for $DB ==="
 
 # Extract version from the first archive filename (e.g., mysql-9.6.0-darwin-arm64.tar.gz → 9.6.0)
 # All archives in a single release run share the same version
-FIRST_ARCHIVE=$(ls "$ASSETS_DIR"/*.tar.gz "$ASSETS_DIR"/*.zip 2>/dev/null | head -1)
+FIRST_ARCHIVE=$(find "$ASSETS_DIR" -maxdepth 1 \( -name '*.tar.gz' -o -name '*.zip' \) -print -quit)
 VERSION=""
 if [ -n "$FIRST_ARCHIVE" ]; then
   BASENAME=$(basename "$FIRST_ARCHIVE")

--- a/databases.json
+++ b/databases.json
@@ -15,11 +15,19 @@
       "versions": {
         "25.12.3.21": true
       },
-      "platforms": ["linux-x64", "linux-arm64", "darwin-x64", "darwin-arm64"],
+      "platforms": [
+        "linux-x64",
+        "linux-arm64",
+        "darwin-x64",
+        "darwin-arm64"
+      ],
       "cliTools": {
         "server": "clickhouse-server",
         "client": "clickhouse-client",
-        "utilities": ["clickhouse-local", "clickhouse-benchmark"],
+        "utilities": [
+          "clickhouse-local",
+          "clickhouse-benchmark"
+        ],
         "enhanced": []
       },
       "connection": {
@@ -56,7 +64,10 @@
         "server": "cockroach",
         "client": "cockroach",
         "utilities": [],
-        "enhanced": ["pgcli", "usql"],
+        "enhanced": [
+          "pgcli",
+          "usql"
+        ],
         "note": "Single binary; use 'cockroach start-single-node' for server, 'cockroach sql' for client"
       },
       "connection": {
@@ -130,7 +141,9 @@
         "server": null,
         "client": "duckdb",
         "utilities": [],
-        "enhanced": ["usql"]
+        "enhanced": [
+          "usql"
+        ]
       },
       "connection": {
         "runtime": "embedded",
@@ -188,7 +201,10 @@
       "cliTools": {
         "server": "ferretdb",
         "client": "mongosh",
-        "utilities": ["mongodump", "mongorestore"],
+        "utilities": [
+          "mongodump",
+          "mongorestore"
+        ],
         "enhanced": []
       },
       "connection": {
@@ -251,12 +267,20 @@
       "versions": {
         "0.24.32": true
       },
-      "platforms": ["linux-x64", "linux-arm64", "darwin-x64", "darwin-arm64"],
+      "platforms": [
+        "linux-x64",
+        "linux-arm64",
+        "darwin-x64",
+        "darwin-arm64"
+      ],
       "cliTools": {
         "server": "sqld",
         "client": null,
         "utilities": [],
-        "enhanced": ["litecli", "usql"],
+        "enhanced": [
+          "litecli",
+          "usql"
+        ],
         "note": "HTTP API; use Turso client SDKs or any libSQL/SQLite client"
       },
       "connection": {
@@ -294,8 +318,15 @@
       "cliTools": {
         "server": "mariadbd",
         "client": "mariadb",
-        "utilities": ["mariadb-dump", "mariadb-import", "mariadb-admin"],
-        "enhanced": ["mycli", "usql"]
+        "utilities": [
+          "mariadb-dump",
+          "mariadb-import",
+          "mariadb-admin"
+        ],
+        "enhanced": [
+          "mycli",
+          "usql"
+        ]
       },
       "connection": {
         "runtime": "server",
@@ -403,8 +434,14 @@
           "cliTools": {
             "server": "mysqld",
             "client": "mysql",
-            "utilities": ["mysqldump", "mysqladmin"],
-            "enhanced": ["mycli", "usql"]
+            "utilities": [
+              "mysqldump",
+              "mysqladmin"
+            ],
+            "enhanced": [
+              "mycli",
+              "usql"
+            ]
           }
         },
         "9.5.0": {
@@ -413,8 +450,14 @@
           "cliTools": {
             "server": "mysqld",
             "client": "mysql",
-            "utilities": ["mysqldump", "mysqladmin"],
-            "enhanced": ["mycli", "usql"]
+            "utilities": [
+              "mysqldump",
+              "mysqladmin"
+            ],
+            "enhanced": [
+              "mycli",
+              "usql"
+            ]
           }
         },
         "9.1.0": {
@@ -423,8 +466,14 @@
           "cliTools": {
             "server": "mysqld",
             "client": "mysql",
-            "utilities": ["mysqldump", "mysqladmin"],
-            "enhanced": ["mycli", "usql"]
+            "utilities": [
+              "mysqldump",
+              "mysqladmin"
+            ],
+            "enhanced": [
+              "mycli",
+              "usql"
+            ]
           }
         },
         "8.4.3": true,
@@ -443,8 +492,15 @@
       "cliTools": {
         "server": "mysqld",
         "client": "mysql",
-        "utilities": ["mysqldump", "mysqlpump", "mysqladmin"],
-        "enhanced": ["mycli", "usql"]
+        "utilities": [
+          "mysqldump",
+          "mysqlpump",
+          "mysqladmin"
+        ],
+        "enhanced": [
+          "mycli",
+          "usql"
+        ]
       },
       "connection": {
         "runtime": "server",
@@ -489,7 +545,10 @@
           "createdb",
           "dropdb"
         ],
-        "enhanced": ["pgcli", "usql"]
+        "enhanced": [
+          "pgcli",
+          "usql"
+        ]
       },
       "connection": {
         "runtime": "server",
@@ -514,12 +573,24 @@
       "versions": {
         "17-0.107.0": true
       },
-      "platforms": ["linux-x64", "linux-arm64", "darwin-x64", "darwin-arm64"],
+      "platforms": [
+        "linux-x64",
+        "linux-arm64",
+        "darwin-x64",
+        "darwin-arm64"
+      ],
       "cliTools": {
         "server": "postgres",
         "client": "psql",
-        "utilities": ["pg_dump", "pg_restore", "initdb", "pg_ctl"],
-        "enhanced": ["pgcli"]
+        "utilities": [
+          "pg_dump",
+          "pg_restore",
+          "initdb",
+          "pg_ctl"
+        ],
+        "enhanced": [
+          "pgcli"
+        ]
       },
       "connection": {
         "runtime": "server",
@@ -599,7 +670,10 @@
         "server": "questdb",
         "client": "psql",
         "utilities": [],
-        "enhanced": ["pgcli", "usql"],
+        "enhanced": [
+          "pgcli",
+          "usql"
+        ],
         "note": "PostgreSQL wire protocol; use psql or pgcli"
       },
       "connection": {
@@ -636,8 +710,14 @@
       "cliTools": {
         "server": "redis-server",
         "client": "redis-cli",
-        "utilities": ["redis-benchmark", "redis-check-aof", "redis-check-rdb"],
-        "enhanced": ["iredis"]
+        "utilities": [
+          "redis-benchmark",
+          "redis-check-aof",
+          "redis-check-rdb"
+        ],
+        "enhanced": [
+          "iredis"
+        ]
       },
       "connection": {
         "runtime": "server",
@@ -673,7 +753,10 @@
         "server": null,
         "client": "sqlite3",
         "utilities": [],
-        "enhanced": ["litecli", "usql"]
+        "enhanced": [
+          "litecli",
+          "usql"
+        ]
       },
       "connection": {
         "runtime": "embedded",
@@ -820,8 +903,12 @@
       "cliTools": {
         "server": "valkey-server",
         "client": "valkey-cli",
-        "utilities": ["valkey-benchmark"],
-        "enhanced": ["iredis"]
+        "utilities": [
+          "valkey-benchmark"
+        ],
+        "enhanced": [
+          "iredis"
+        ]
       },
       "connection": {
         "runtime": "server",

--- a/releases.json
+++ b/releases.json
@@ -636,12 +636,12 @@
         "platforms": {
           "darwin-arm64": {
             "url": "https://registry.layerbase.host/postgresql-18.1.0/postgresql-18.1.0-darwin-arm64.tar.gz",
-            "sha256": "41b9a9f0b02d6bb9d4960a0fed4949e413d5dd4c9087d1ef9fff80480ad26221",
+            "sha256": "275d9ceda8e4756758c0318824bb2d6df52a3e28d02bda0031653284b165853c",
             "size": 29191486
           },
           "darwin-x64": {
             "url": "https://registry.layerbase.host/postgresql-18.1.0/postgresql-18.1.0-darwin-x64.tar.gz",
-            "sha256": "7dbbf27186e1cb8ce630c3a4f87a239dfb2593fb35e319a16d963892f0b8df5c",
+            "sha256": "ddc444e375d5ccec7921a6e7134c0343b57884dfde73cb6402d6debfc2806ba0",
             "size": 28944135
           },
           "linux-arm64": {
@@ -668,12 +668,12 @@
         "platforms": {
           "darwin-arm64": {
             "url": "https://registry.layerbase.host/postgresql-17.7.0/postgresql-17.7.0-darwin-arm64.tar.gz",
-            "sha256": "0ecbca90a47638f88599b29c232a826085c86bee06f1de5118d3d939eac73f70",
+            "sha256": "283937f371ca2460806a5f44ea9fcd34baa9b4b2b0a54adfc8ed4049bda7c0a3",
             "size": 28797739
           },
           "darwin-x64": {
             "url": "https://registry.layerbase.host/postgresql-17.7.0/postgresql-17.7.0-darwin-x64.tar.gz",
-            "sha256": "659865a0de855e5472404188ea58ac26237427a547b271319e99e98dc267017b",
+            "sha256": "440a70e994f62775888edc91156693b36b172c04b9fdff7183b7689cfb31b290",
             "size": 28566989
           },
           "linux-arm64": {
@@ -700,12 +700,12 @@
         "platforms": {
           "darwin-arm64": {
             "url": "https://registry.layerbase.host/postgresql-16.11.0/postgresql-16.11.0-darwin-arm64.tar.gz",
-            "sha256": "14263aa593747300d1b11c766810a3949e2d5f14e79c6bed4ed4224072ebac2e",
+            "sha256": "d387bd9ed051fc03a0c584d57dd720735aa256aa4e5db165e1e91064291f7a52",
             "size": 28119952
           },
           "darwin-x64": {
             "url": "https://registry.layerbase.host/postgresql-16.11.0/postgresql-16.11.0-darwin-x64.tar.gz",
-            "sha256": "83ea273c6cc8f40ebd53bfce819d80f8437724344053f4920201a00f70a13ac0",
+            "sha256": "8409f3897ca2f63f21b6b7b44642c36ac3370f3fe52b7f53865f49ccb4086d9e",
             "size": 27880406
           },
           "linux-arm64": {


### PR DESCRIPTION
## Summary
- Fixes `validate-binaries.sh` exiting with code 2 when a database has no `.zip` archives (e.g., libSQL)
- `ls *.zip` fails with exit 2 when no zips exist, and `set -euo pipefail` kills the script
- Replaced `ls` with `find` which exits 0 regardless

## Test plan
- [x] Re-run Release libSQL workflow and verify validate-binaries step passes