### PR TITLE
fix: add git pull --rebase before push in all release workflows

### DIFF
--- a/.github/workflows/build-missing-releases.yml
+++ b/.github/workflows/build-missing-releases.yml
@@ -340,6 +340,7 @@ jobs:
           git add releases.json databases.json
           git diff --staged --quiet && echo "No changes" && exit 0
           git commit -m "chore: update releases.json"
+          git pull --rebase origin main
           git push
 
   # Final summary

--- a/.github/workflows/rebuild-releases.yml
+++ b/.github/workflows/rebuild-releases.yml
@@ -50,4 +50,5 @@ jobs:
           git add releases.json databases.json
           git diff --staged --quiet && echo "No changes" && exit 0
           git commit -m "chore: update releases.json"
+          git pull --rebase origin main
           git push

--- a/.github/workflows/release-clickhouse.yml
+++ b/.github/workflows/release-clickhouse.yml
@@ -370,4 +370,5 @@ jobs:
           git add releases.json databases.json
           git diff --staged --quiet && echo "No changes" && exit 0
           git commit -m "chore: update releases.json"
+          git pull --rebase origin main
           git push

--- a/.github/workflows/release-cockroachdb.yml
+++ b/.github/workflows/release-cockroachdb.yml
@@ -263,4 +263,5 @@ jobs:
           git add releases.json databases.json
           git diff --staged --quiet && echo "No changes" && exit 0
           git commit -m "chore: update releases.json"
+          git pull --rebase origin main
           git push

--- a/.github/workflows/release-couchdb.yml
+++ b/.github/workflows/release-couchdb.yml
@@ -598,4 +598,5 @@ jobs:
           git add releases.json databases.json
           git diff --staged --quiet && echo "No changes" && exit 0
           git commit -m "chore: update releases.json"
+          git pull --rebase origin main
           git push

--- a/.github/workflows/release-duckdb.yml
+++ b/.github/workflows/release-duckdb.yml
@@ -271,4 +271,5 @@ jobs:
           git add releases.json databases.json
           git diff --staged --quiet && echo "No changes" && exit 0
           git commit -m "chore: update releases.json"
+          git pull --rebase origin main
           git push

--- a/.github/workflows/release-ferretdb.yml
+++ b/.github/workflows/release-ferretdb.yml
@@ -291,4 +291,5 @@ jobs:
           git add releases.json databases.json
           git diff --staged --quiet && echo "No changes" && exit 0
           git commit -m "chore: update releases.json"
+          git pull --rebase origin main
           git push

--- a/.github/workflows/release-influxdb.yml
+++ b/.github/workflows/release-influxdb.yml
@@ -317,4 +317,5 @@ jobs:
           git add releases.json databases.json
           git diff --staged --quiet && echo "No changes" && exit 0
           git commit -m "chore: update releases.json"
+          git pull --rebase origin main
           git push

--- a/.github/workflows/release-libsql.yml
+++ b/.github/workflows/release-libsql.yml
@@ -263,4 +263,5 @@ jobs:
           git add releases.json databases.json
           git diff --staged --quiet && echo "No changes" && exit 0
           git commit -m "chore: update releases.json"
+          git pull --rebase origin main
           git push

--- a/.github/workflows/release-mariadb.yml
+++ b/.github/workflows/release-mariadb.yml
@@ -517,4 +517,5 @@ jobs:
           git add releases.json databases.json
           git diff --staged --quiet && echo "No changes" && exit 0
           git commit -m "chore: update releases.json"
+          git pull --rebase origin main
           git push

--- a/.github/workflows/release-meilisearch.yml
+++ b/.github/workflows/release-meilisearch.yml
@@ -263,4 +263,5 @@ jobs:
           git add releases.json databases.json
           git diff --staged --quiet && echo "No changes" && exit 0
           git commit -m "chore: update releases.json"
+          git pull --rebase origin main
           git push

--- a/.github/workflows/release-mongodb.yml
+++ b/.github/workflows/release-mongodb.yml
@@ -276,4 +276,5 @@ jobs:
           git add releases.json databases.json
           git diff --staged --quiet && echo "No changes" && exit 0
           git commit -m "chore: update releases.json"
+          git pull --rebase origin main
           git push

--- a/.github/workflows/release-mysql.yml
+++ b/.github/workflows/release-mysql.yml
@@ -270,4 +270,5 @@ jobs:
           git add releases.json databases.json
           git diff --staged --quiet && echo "No changes" && exit 0
           git commit -m "chore: update releases.json"
+          git pull --rebase origin main
           git push

--- a/.github/workflows/release-postgresql-documentdb.yml
+++ b/.github/workflows/release-postgresql-documentdb.yml
@@ -520,4 +520,5 @@ jobs:
           git add releases.json databases.json
           git diff --staged --quiet && echo "No changes" && exit 0
           git commit -m "chore: update releases.json"
+          git pull --rebase origin main
           git push

--- a/.github/workflows/release-postgresql.yml
+++ b/.github/workflows/release-postgresql.yml
@@ -893,4 +893,5 @@ jobs:
           git add releases.json databases.json
           git diff --staged --quiet && echo "No changes" && exit 0
           git commit -m "chore: update releases.json"
+          git pull --rebase origin main
           git push

--- a/.github/workflows/release-qdrant.yml
+++ b/.github/workflows/release-qdrant.yml
@@ -263,4 +263,5 @@ jobs:
           git add releases.json databases.json
           git diff --staged --quiet && echo "No changes" && exit 0
           git commit -m "chore: update releases.json"
+          git pull --rebase origin main
           git push

--- a/.github/workflows/release-questdb.yml
+++ b/.github/workflows/release-questdb.yml
@@ -263,4 +263,5 @@ jobs:
           git add releases.json databases.json
           git diff --staged --quiet && echo "No changes" && exit 0
           git commit -m "chore: update releases.json"
+          git pull --rebase origin main
           git push

--- a/.github/workflows/release-redis.yml
+++ b/.github/workflows/release-redis.yml
@@ -483,4 +483,5 @@ jobs:
           git add releases.json databases.json
           git diff --staged --quiet && echo "No changes" && exit 0
           git commit -m "chore: update releases.json"
+          git pull --rebase origin main
           git push

--- a/.github/workflows/release-sqlite.yml
+++ b/.github/workflows/release-sqlite.yml
@@ -361,4 +361,5 @@ jobs:
           git add releases.json databases.json
           git diff --staged --quiet && echo "No changes" && exit 0
           git commit -m "chore: update releases.json"
+          git pull --rebase origin main
           git push

--- a/.github/workflows/release-surrealdb.yml
+++ b/.github/workflows/release-surrealdb.yml
@@ -263,4 +263,5 @@ jobs:
           git add releases.json databases.json
           git diff --staged --quiet && echo "No changes" && exit 0
           git commit -m "chore: update releases.json"
+          git pull --rebase origin main
           git push

--- a/.github/workflows/release-tigerbeetle.yml
+++ b/.github/workflows/release-tigerbeetle.yml
@@ -269,4 +269,5 @@ jobs:
           git add releases.json databases.json
           git diff --staged --quiet && echo "No changes" && exit 0
           git commit -m "chore: update releases.json"
+          git pull --rebase origin main
           git push

--- a/.github/workflows/release-typedb.yml
+++ b/.github/workflows/release-typedb.yml
@@ -276,4 +276,5 @@ jobs:
           git add releases.json databases.json
           git diff --staged --quiet && echo "No changes" && exit 0
           git commit -m "chore: update releases.json"
+          git pull --rebase origin main
           git push

--- a/.github/workflows/release-valkey.yml
+++ b/.github/workflows/release-valkey.yml
@@ -543,4 +543,5 @@ jobs:
           git add releases.json databases.json
           git diff --staged --quiet && echo "No changes" && exit 0
           git commit -m "chore: update releases.json"
+          git pull --rebase origin main
           git push

--- a/.github/workflows/release-weaviate.yml
+++ b/.github/workflows/release-weaviate.yml
@@ -268,4 +268,5 @@ jobs:
           git add releases.json databases.json
           git diff --staged --quiet && echo "No changes" && exit 0
           git commit -m "chore: update releases.json"
+          git pull --rebase origin main
           git push

--- a/releases.json
+++ b/releases.json
@@ -233,6 +233,35 @@
         }
       }
     },
+    "libsql": {
+      "0.24.32": {
+        "version": "0.24.32",
+        "releaseTag": "libsql-0.24.32",
+        "releasedAt": "2026-03-12T21:13:38Z",
+        "platforms": {
+          "darwin-arm64": {
+            "url": "https://registry.layerbase.host/libsql-0.24.32/libsql-0.24.32-darwin-arm64.tar.gz",
+            "sha256": "ba5092016f299f73ee03011e12e3c4c49467e9a87eda236c27ee43ee46b517df",
+            "size": 14951364
+          },
+          "darwin-x64": {
+            "url": "https://registry.layerbase.host/libsql-0.24.32/libsql-0.24.32-darwin-x64.tar.gz",
+            "sha256": "26ae8f6131fc40ac1a05f064a62d4d7f6262d57319968fabd9f44a9340126b96",
+            "size": 15883714
+          },
+          "linux-arm64": {
+            "url": "https://registry.layerbase.host/libsql-0.24.32/libsql-0.24.32-linux-arm64.tar.gz",
+            "sha256": "c40cb6e966701074a275e6e8953a6047a96dd0e78bdd45d4aafa6ee2b1fac442",
+            "size": 16466831
+          },
+          "linux-x64": {
+            "url": "https://registry.layerbase.host/libsql-0.24.32/libsql-0.24.32-linux-x64.tar.gz",
+            "sha256": "8b224df013ebf1ddbda39f0fa74f03e98010aedb085ffd99bd3a65d06e0e070d",
+            "size": 16492900
+          }
+        }
+      }
+    },
     "mariadb": {
       "11.8.5": {
         "version": "11.8.5",
@@ -732,12 +761,12 @@
         "platforms": {
           "darwin-arm64": {
             "url": "https://registry.layerbase.host/postgresql-15.15.0/postgresql-15.15.0-darwin-arm64.tar.gz",
-            "sha256": "4f0908b45fa87c22e5926504944b69cb7ed51676f7532d9f6de706c6e490e046",
+            "sha256": "43c02493e46b67b9dba200084edc91b5ea5f29935a2edf0f7ae8a36a4e553e18",
             "size": 27732505
           },
           "darwin-x64": {
             "url": "https://registry.layerbase.host/postgresql-15.15.0/postgresql-15.15.0-darwin-x64.tar.gz",
-            "sha256": "d707692702067fd0ce5fa84a313e5dc391901fb2c908ebf715445fa531481436",
+            "sha256": "3e4d4b1c57cc361f926516fa3d1f6255d769f89afc11b91c5d61185319e25009",
             "size": 27444850
           },
           "linux-arm64": {


### PR DESCRIPTION
## Summary
- Adds `git pull --rebase origin main` before `git push` in all 24 release/rebuild workflows
- Prevents push rejection when main moves forward during long-running builds

## Test plan
- [x] Trigger build-missing-releases and verify finalize job can push even if main has new commits