### PR TITLE
fix(ci): drop broken npm self-upgrade from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,7 +53,10 @@ jobs:
 
       - name: Install dependencies
         if: steps.check.outputs.publish == 'true'
-        run: npm install -g npm@latest && pnpm install --frozen-lockfile
+        # Node 22's bundled npm 10.9.7 already supports OIDC trusted publishing.
+        # Self-upgrading npm via `npm install -g npm@latest` corrupts the install
+        # ("Cannot find module 'promise-retry'") so we skip it.
+        run: pnpm install --frozen-lockfile
 
       # Pre-publish guards. If any of these fail, the publish below is skipped.
       # Tests run against bundled databases.json/releases.json — if the registry


### PR DESCRIPTION
## Summary

The publish workflow on main exited red on 2026-05-16 due to `npm install -g npm@latest` corrupting npm's install state on the GitHub Actions runner (`Cannot find module 'promise-retry'`). As a result, hostdb 0.31.0 was bumped in package.json and merged to main, but never actually published to the npm registry — `npm view hostdb version` still returns `0.30.0`.

Node 22.22.2 (the version we set up in the workflow) ships with npm 10.9.7, which already supports OIDC trusted publishing. The self-upgrade was unnecessary and is now harmful.

## What changed

One line in `.github/workflows/publish.yml`:

\`\`\`diff
-        run: npm install -g npm@latest && pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile
\`\`\`

## Effect on the cascade

After this PR merges to main, publish.yml fires again. The version-check gate sees package.json at 0.31.0 vs npm at 0.30.0 → proceeds → publishes. Once `npm view hostdb version` returns 0.31.0, spindb's flip-hostdb-pin script can run and the rest of the integration cascade resumes.

## Test plan

- [x] Diff confirmed minimal: 1 step body change + 3-line comment
- [ ] CI green on this PR
- [ ] After merge: publish workflow fires on push-to-main, succeeds
- [ ] `npm view hostdb version` returns `0.31.0`