### PR TITLE
fix(ci): bump Node to 24 + re-add npm self-upgrade for OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,15 +47,22 @@ jobs:
         if: steps.check.outputs.publish == 'true'
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
 
+      # npm trusted publishing requires npm CLI >= 11.5.1 for the current OIDC
+      # handshake; otherwise the registry treats the request as anonymous and
+      # returns a misleading 404. Node 24 ships with npm 11.x by default;
+      # this step is belt-and-suspenders to ensure latest npm regardless.
+      # Kept as a SEPARATE step (not combined with the install below) so
+      # shell-state corruption from the self-upgrade can't break the install.
+      - name: Upgrade npm for OIDC support
+        if: steps.check.outputs.publish == 'true'
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         if: steps.check.outputs.publish == 'true'
-        # Node 22's bundled npm 10.9.7 already supports OIDC trusted publishing.
-        # Self-upgrading npm via `npm install -g npm@latest` corrupts the install
-        # ("Cannot find module 'promise-retry'") so we skip it.
         run: pnpm install --frozen-lockfile
 
       # Pre-publish guards. If any of these fail, the publish below is skipped.


### PR DESCRIPTION
## Summary

npm trusted publishing requires npm CLI >= 11.5.1 for the current OIDC handshake protocol. Node 22 ships with npm 10.x, which silently falls back to anonymous auth and yields a misleading 404 'hostdb@0.31.0' is not in this registry on PUT, even when the trusted publisher is correctly configured on npmjs.com.

This is the root cause of why hostdb 0.31.0 has failed to publish multiple times tonight despite valid trusted publisher config and provenance signing succeeding.

## Why we got here

- The original publish.yml had \`npm install -g npm@latest && pnpm install --frozen-lockfile\` as a combined step. The self-upgrade worked back in March 2026 (last successful publish: hostdb 0.30.0).
- The npm self-upgrade now has a corruption bug ('Cannot find module \"promise-retry\"') on the current GHA Ubuntu image.
- The first attempted fix removed the self-upgrade entirely, leaving npm at v10 — which works for everything EXCEPT trusted publishing OIDC.

## The fix (mirrors spindb's working publish.yml)

\`\`\`diff
-          node-version: '22'
+          node-version: '24'
...
+      - name: Upgrade npm for OIDC support
+        if: steps.check.outputs.publish == 'true'
+        run: npm install -g npm@latest
\`\`\`

1. Node 24 ships with npm 11.x by default, supporting the OIDC handshake out of the box
2. The self-upgrade is kept as belt-and-suspenders, but as a SEPARATE step from \`pnpm install\` so any shell-state corruption from the upgrade can't break the install

## Test plan

- [x] Diff matches spindb's working publish.yml pattern
- [ ] CI green on this PR
- [ ] After merge: publish.yml fires on push-to-main, succeeds
- [ ] \`npm view hostdb version\` returns \`0.31.0\`

## Sources

- npm/cli#8730 — OIDC publish failing from GitHub Actions
- npm/cli#9088 — Trusted publishing failures report misleading 404 errors
- Comparison with \`~/dev/spindb/.github/workflows/publish.yml\` (Node 24 + separate npm upgrade step) which publishes successfully today