### PR TITLE
Release: hostdb 0.31.1 (move tsx to devDependencies)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.31.1] - 2026-05-16
+
+### Fixed
+
+- **`tsx` moved from `dependencies` to `devDependencies`.** hostdb ships compiled JS in `dist/` and `bin/cli.js` is pre-compiled too, so end users do not need `tsx` at runtime. Having it as a regular dep caused downstream consumers (the spindb bundle in layerbase-desktop) to pull in platform-specific `@esbuild/<platform>` binaries via tsx's transitive deps, which broke electron-builder's universal-macOS merge with a misleading "same file in both arches" error. No functional change — `dist/index.js` and `bin/cli.js` are unchanged.
+
 ## [0.31.0] - 2026-05-15
 
 ### Added — npm package surface

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hostdb",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "description": "Pre-built database binaries for multiple platforms, plus a typed registry library for resolving versions and download URLs offline.",
   "private": false,
   "type": "module",
@@ -80,9 +80,6 @@
     "upload:r2": "tsx scripts/upload-to-r2.ts",
     "audit:r2-orphans": "tsx scripts/audit-r2-orphans.ts"
   },
-  "dependencies": {
-    "tsx": "^4.19.0"
-  },
   "devDependencies": {
     "@aws-sdk/client-s3": "^3.990.0",
     "@eslint/js": "^9.17.0",
@@ -93,6 +90,7 @@
     "eslint": "^9.17.0",
     "ora": "^9.3.0",
     "prettier": "^3.4.0",
+    "tsx": "^4.19.0",
     "typescript": "^5.7.0",
     "typescript-eslint": "^8.18.0",
     "yaml": "^2.8.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      tsx:
-        specifier: ^4.19.0
-        version: 4.21.0
     devDependencies:
       '@aws-sdk/client-s3':
         specifier: ^3.990.0
@@ -39,6 +35,9 @@ importers:
       prettier:
         specifier: ^3.4.0
         version: 3.7.4
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
       typescript:
         specifier: ^5.7.0
         version: 5.9.3


### PR DESCRIPTION
## Summary

Patch release. Moves \`tsx\` from \`dependencies\` to \`devDependencies\`. hostdb ships compiled JS in \`dist/\` and a pre-compiled \`bin/cli.js\` — end users do not need tsx at runtime.

## Why

Having tsx as a regular dep dragged in tsx → esbuild → platform-specific \`@esbuild/<platform>\` binaries (a 20MB+ native blob). Downstream, the spindb bundle in layerbase-desktop pulled those in via \`npm install --production\`, and electron-builder's universal-macOS merge tripped on a misleading "same file in both x64 and arm64 builds" error.

That was patched in layerbase-desktop with a strip-step in \`prepare-spindb.mjs\` plus \`x64ArchFiles\` in electron-builder.json (PRs #78 + #80). This release lets us eventually remove the strip-step once spindb is rebuilt against \`hostdb@0.31.1\`. For now, **spindb stays on hostdb@0.31.0** — the desktop workaround is in place and there's no functional issue to chase.

## Test plan

- [x] \`pnpm install\` regenerates lockfile (tsx still installed via devDependencies)
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` — 167/167 pass
- [x] CHANGELOG entry added
- [ ] CI green on this PR
- [ ] After merge: publish workflow fires, \`npm view hostdb version\` returns \`0.31.1\`
- [ ] Provenance attestation present on 0.31.1 (verified post-publish)

## Compatibility

- **No API surface change.** All exports from \`dist/index.js\` unchanged. Resolver signatures unchanged. \`bin/cli.js\` unchanged.
- **No spindb action needed** — spindb 0.50.0 stays pinned to hostdb 0.31.0. The strip-tsx workaround in layerbase-desktop covers it. When spindb next releases (e.g., for a feature/version bump), bump its hostdb pin to 0.31.1 and the desktop workaround can be removed.