### PR TITLE
Release 0.32.0: Redis 7.2.14 (BSD) + bundle 0.31.2 docs reshuffle

### DIFF
--- a/.github/workflows/release-redis.yml
+++ b/.github/workflows/release-redis.yml
@@ -9,8 +9,7 @@ on:
         type: choice
         options:
           - 8.4.0
-          - 7.4.9
-          - 7.4.7
+          - 7.2.14
         default: 8.4.0
       platforms:
         description: 'Platforms to build'

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -382,3 +382,65 @@ User: spindb start mysql@8.4.7
 │   --datadir=...                │
 └─────────────────────────────────┘
 ```
+
+## Binary Hosting (Cloudflare R2)
+
+Binaries are hosted on Cloudflare R2 behind `registry.layerbase.host`. GitHub Releases are still created (as the build artifact source), but all public download URLs point to R2.
+
+**URL pattern:** `https://registry.layerbase.host/{tag}/{filename}`
+
+### Configuration
+
+| File | Purpose |
+|---|---|
+| `lib/registry.ts` | Single source of truth for `REGISTRY_BASE_URL` |
+| `lib/r2.ts` | Shared R2 client utilities (S3-compatible) |
+| `scripts/upload-to-r2.ts` | Per-release upload (called by CI after each release) |
+| `scripts/migrate-to-r2.ts` | One-time bulk migration of existing releases |
+
+### Workflow
+
+Each `release-*.yml` workflow has an `upload-to-r2` job that mirrors assets from GitHub Releases to R2, followed by `update-releases` which rebuilds `releases.json` from all GitHub releases and publishes it to R2.
+
+### CDN caching
+
+R2 tarballs are served through Cloudflare's CDN with `Cache-Control: public, max-age=31536000, immutable` (1-year cache):
+
+- Normal releases work fine — each version gets a unique URL that's cached forever.
+- **Re-uploading a file to R2 does NOT update the CDN** — the edge cache continues serving the old version.
+- When using `--force` on `upload-to-r2.ts`, the script automatically purges affected URLs from Cloudflare's CDN cache (requires `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ZONE_ID` secrets).
+- If those secrets aren't set, the purge step is skipped with a warning — you'd need to purge manually via **Cloudflare Dashboard > layerbase.host > Caching > Configuration > Purge Everything**.
+
+### Migration & orphan cleanup
+
+- **Bulk migration:** `pnpm migrate:r2 [--dry-run] [--database mysql] [--concurrency 3]`
+- **Orphan audit:** `pnpm audit:r2-orphans` lists every R2 object not referenced by `releases.json`, grouped by engine prefix. R2 retains binaries forever by design (existing containers keep working), but after months of R&D the bucket may contain binaries from abandoned engines or removed version lines. Pass `--delete` to remove them after confirmation. Pass `--engine <name>` to scope the audit to one engine.
+
+### Required GitHub Actions secrets
+
+| Secret | Purpose |
+|---|---|
+| `R2_ACCOUNT_ID` | Cloudflare account ID |
+| `R2_ACCESS_KEY_ID` | R2 API token access key |
+| `R2_SECRET_ACCESS_KEY` | R2 API token secret key |
+| `R2_BUCKET_NAME` | R2 bucket name (e.g., `hostdb-registry`) |
+| `CLOUDFLARE_API_TOKEN` | Cloudflare API token with `Zone.Cache Purge` permission |
+| `CLOUDFLARE_ZONE_ID` | Cloudflare zone ID for `registry.layerbase.host` |
+
+### Setting up Cloudflare secrets
+
+**1. Zone ID**
+
+Go to [Cloudflare Dashboard](https://dash.cloudflare.com) → select the `layerbase.host` zone → the **Zone ID** is in the right sidebar of the **Overview** page under "API".
+
+**2. API Token**
+
+Go to [Cloudflare Dashboard](https://dash.cloudflare.com) → **My Profile** (top-right avatar) → **API Tokens** → **Create Token** → use the **"Custom token"** template:
+
+- **Token name:** `hostdb-cache-purge`
+- **Permissions:** Zone → Cache Purge → Purge
+- **Zone resources:** Include → Specific zone → `layerbase.host`
+
+**3. Add to repo**
+
+Add both values as GitHub Actions secrets in the hostdb repository settings (Settings → Secrets and variables → Actions).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.32.0] - 2026-05-23
+
+### Added
+
+- **Redis 7.2.14** — latest patch in the BSD-3-Clause 7.2.x line, the newest Redis version permissively licensed for managed/DBaaS-style self-hosting. Built from source on linux-x64, linux-arm64, darwin-x64, darwin-arm64; Windows binary from [redis-windows](https://github.com/redis-windows/redis-windows). Adds a third Redis license tier alongside the existing 7.4.x (RSALv2/SSPLv1) and 8.x (RSALv2/SSPLv1/AGPL-3.0) lines.
+
+### Changed — defaults block policy
+
+- **Redis `defaults["7"]` repointed from `7.4.9` → `7.2.14`.** This is a user-visible policy change: `resolveVersion('redis', '7')` now returns the BSD-licensed 7.2.14 instead of the source-available 7.4.9. Driven by managed-service license compatibility — downstream consumers (spindb/layerbase-cloud) need a BSD path so `hostedServiceAllowed: true` is unambiguous. `defaults["8"]` is unchanged (still `8.4.0`); consumers that want a newer Redis can still pass an explicit 7.4.x or 8.x version.
+
+### Deprecated
+
+- **Redis 7.4.9 and 7.4.7** — marked deprecated due to RSALv2/SSPLv1 license restricting competing managed services. Existing R2 binaries remain available; the workflow dropdowns skip them and `isVersionDeprecated()` returns true. Use 7.2.14 for managed-service use or stay on 7.4.x for self-contained applications.
+
+### Coordination notes
+
+This is a **minor** bump (0.31.2 → 0.32.0), not patch, because the `defaults` block policy change is user-visible — per the project rule: "Always write a CHANGELOG entry when changing a `defaults` value — it's policy, not data." Downstream pin cascade applies (spindb exact-pin, layerbase-cloud `SPINDB_VERSION`, layerbase-desktop `spindb` pin).
+
 ## [0.31.2] - 2026-05-22
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.31.2] - 2026-05-22
+
+### Changed
+
+- **Docs reshuffle.** `CLAUDE.md` slimmed from 43k to 14k chars (was tripping the Claude Code harness performance warning). Build-script and macOS dylib reference moved to a new `builds/common/README.md`. Cloudflare R2 hosting + secret setup moved into `ARCHITECTURE.md`. No code or shipped-file changes — the published npm tarball contents are byte-identical to 0.31.1.
+
 ## [0.31.1] - 2026-05-16
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,150 +1,81 @@
 # hostdb
 
-Pre-built database binaries for all major platforms, hosted on Cloudflare R2 via `registry.layerbase.host`.
+Pre-built database binaries for all major platforms, hosted on Cloudflare R2 via `registry.layerbase.host`. Also a typed npm package (`hostdb`) that bundles a snapshot of the registry so consumers can resolve versions and download URLs offline.
 
-**Primary consumer:** [spindb](https://github.com/robertjbass/spindb) - a CLI tool for spinning up local database instances
+**Primary consumer:** [spindb](https://github.com/robertjbass/spindb) — CLI tool for spinning up local database instances. Pins `hostdb` exactly and consumes the bundled snapshot.
 
-**Ecosystem docs:** `~/dev/layerbase-architecture/` — Shared architecture, infrastructure inventory, cross-project rules, and agent configs.
+## Ecosystem
 
-**Ecosystem invariants:** `~/dev/layerbase-architecture/INVARIANTS.md` — Non-negotiable rules (scripting-first, thin desktop wrapper, platform-agnostic cloud, binary ownership). Read before making architectural changes.
+- **hostdb** (this repo) — builds + publishes database binaries to R2; publishes an npm package with the registry snapshot.
+- **spindb** (`~/dev/spindb`) — CLI tool. Downloads hostdb binaries on demand. Pins `hostdb` exactly.
+- **layerbase-cloud** (`~/dev/layerbase-cloud`) — universal Docker image at `ghcr.io/layerbase-llc/` that runs spindb to fetch binaries on demand.
+- **layerbase-desktop** (`~/dev/layerbase-desktop`) — Electron GUI over spindb.
+- **layerbase** (`~/dev/layerbase`) — web app at layerbase.com.
 
-**Ecosystem:** hostdb builds database binaries and publishes them to Cloudflare R2. **spindb** (`~/dev/spindb`) downloads them to run databases locally. **layerbase-cloud** (`~/dev/layerbase-cloud`) uses a universal Docker image at `ghcr.io/layerbase-llc/`, and spindb downloads hostdb binaries on demand inside that container. **layerbase-desktop** (`~/dev/layerbase-desktop`) is an Electron GUI over spindb. **layerbase** (`~/dev/layerbase`) is the web app at layerbase.com.
+**Ecosystem docs:** `~/dev/layerbase-architecture/` — shared architecture, cross-project rules, infrastructure inventory.
+**Ecosystem invariants:** `~/dev/layerbase-architecture/INVARIANTS.md` — non-negotiable rules. Read before architectural changes.
+
+## Read Before You Edit
+
+| Doc | When you need it |
+|---|---|
+| [`ARCHITECTURE.md`](./ARCHITECTURE.md) | Visual data flow, R2 hosting, npm package structure, Cloudflare secret setup |
+| [`UPGRADE_PLAYBOOK.md`](./UPGRADE_PLAYBOOK.md) | Long-form playbook for upgrading engine versions across the stack |
+| [`CHECKLIST.md`](./CHECKLIST.md) | Adding a new database engine, step-by-step |
+| [`BINARIES.md`](./BINARIES.md) | Archive structure reference (top-level dirs, binary locations) |
+| [`WINDOWS_BUILD.md`](./WINDOWS_BUILD.md) | Windows build strategies (Cygwin, MSYS2, cross-compile) |
+| [`builds/common/README.md`](./builds/common/README.md) | Shared build scripts + macOS SDK / dylib reference |
+| [`builds/postgresql-documentdb/README.md`](./builds/postgresql-documentdb/README.md) | Reference implementation of a macOS source build with relocatable dylibs |
+| [`UPGRADE_VERSIONS.md`](./UPGRADE_VERSIONS.md) | Current upgrade backlog, organized by priority tier |
+| [`PROSPECTS.md`](./PROSPECTS.md) | Planned and unsupported databases |
+
+## Sources of Truth
+
+| File | Schema | Purpose |
+|---|---|---|
+| `databases.yml` | (hand-edited) | **Edit this.** Engines, versions, platforms, `defaults` blocks, `cli_tools`. `pnpm prep` regenerates `databases.json`. |
+| `databases.json` | `schemas/databases.schema.json` | Generated. Drives all workflow validation. |
+| `builds/<engine>/sources.json` | `schemas/sources.schema.json` | Download URLs per version/platform. |
+| `releases.json` | `schemas/releases.schema.json` | Generated from GitHub releases. Bundled in the npm package as the queryable manifest. |
+
+**`databases.yml` uses snake_case keys** (`display_name`, `cli_tools`, `spindb_status`) — `pnpm prep` converts them to camelCase in `databases.json`.
+
+**If you change the shape of any of these files, update the schema in the same commit.**
 
 ## Versioning & Changelog
 
-hostdb is **published to npm as `hostdb`** (see "npm Package" section below). Bumping `package.json` triggers a publish via `.github/workflows/publish.yml` on merge to main. Every spindb / layerbase-cloud release pins an exact hostdb version, so every `package.json` bump matters.
+hostdb is **published to npm as `hostdb`** via `.github/workflows/publish.yml` on merge to main. Every spindb / layerbase-cloud release pins an exact hostdb version, so every `package.json` bump matters.
 
-When adding a **new database engine**:
-1. Bump the **minor version** in `package.json` (e.g., 0.8.0 → 0.9.0)
-2. Add a changelog entry in `CHANGELOG.md` with the new version and date
-3. Include what was added, any special notes about the implementation
+- **New database engine** → bump **minor** (0.8.0 → 0.9.0). CHANGELOG entry required.
+- **New version of an existing database** (patch wave, security fix) → bump **patch** (0.30.0 → 0.30.1).
+- **`defaults` block policy change** (e.g., MongoDB '8' rolls from 8.0 LTS to 8.2) → bump **minor at least** even though the schema didn't change. The behavior change is user-visible; write a CHANGELOG entry explaining the LTS-vs-latest shift.
 
-When adding a **new version of an existing database** (patch wave, security fix, etc.):
-- Bump the **patch version** in `package.json` (e.g., 0.30.0 → 0.30.1) so consumers can detect and adopt the change.
-- Update `databases.yml` (run `pnpm prep` to regenerate `databases.json`) and `builds/{engine}/sources.json`.
+## Coordination Rules — Do Not Break
 
-When changing a **defaults block policy** (e.g., MongoDB '8' rolls from 8.0 LTS to 8.2):
-- Bump the **minor version** at least, even though the schema didn't change. The behavior change is user-visible.
-- Add a clear CHANGELOG entry explaining the LTS-vs-latest policy shift.
+Captured in the repo (not just personal memory) so they're accessible from any machine. Violating any of these breaks downstream builds or silently changes user behavior.
 
-## Philosophy
+### Publish cascade order (database-version patch wave)
 
-This repository exists to solve one problem: **database binaries should be available for download on every major platform, for every supported version, without relying on third-party sources that may disappear.**
+1. Edit `databases.yml` (+ `defaults` block if needed) and `builds/<engine>/sources.json`. Bump `package.json` patch.
+2. Commit + push hostdb branch. Run the engine release workflow. Merge to main. `publish.yml` fires → npm publish via OIDC.
+3. **Verify** `npm view hostdb version` shows the new version before touching anything downstream.
+4. Bump `"hostdb": "X.Y.Z"` in `spindb/package.json` (exact pin). Tests, version bump, merge.
+5. Bump `SPINDB_VERSION` in `layerbase-cloud/images/Dockerfile.base`. Image build + deploy fires.
+6. Bump `"spindb": "X.Y.Z"` in `layerbase-desktop/package.json`. Next desktop release ships it.
 
-### Binary Sourcing Priority
+If you bump step 5 before step 3 completes, `npm install -g spindb@X.Y.Z` in the Dockerfile fails — the image build goes red.
 
-When adding a database, source binaries in this order:
+See `UPGRADE_PLAYBOOK.md` for the long-form playbook (mental model, why each step exists, troubleshooting).
 
-1. **Official binaries** - Direct from vendor CDNs (Oracle for MySQL, MariaDB Foundation, EnterpriseDB for PostgreSQL Windows, etc.)
-2. **Third-party repositories** - Trusted sources like [MariaDB4j](https://github.com/MariaDB4j/MariaDB4j) Maven JARs
-3. **Build from source** - Docker builds for Linux, native GitHub Actions builds for macOS
+### Spindb pins hostdb exactly
 
-### Key Principles
+`"hostdb": "0.31.0"`, never `^0.31.0` or `~0.31.0`. A hostdb patch can add new database versions; with a caret, an end-user installing an old spindb would pick up versions spindb's tests never validated against. Lockfiles enforce this for CI/dev but lockfiles aren't published to npm — `package.json` is the contract for end-user installs.
 
-- **Full platform coverage**: Every version must have binaries for all 5 platforms
-- **Build once, host forever**: Binaries are uploaded to GitHub Releases and never rebuilt
-- **Queryable manifest**: `releases.json` lets CLI tools discover available downloads
-- **Single source of truth**: `databases.json` controls which databases/versions/platforms are supported
+### Wrappers, not maps
 
-### Complete, Embeddable Binaries
+`spindb/engines/<X>/version-maps.ts` are thin wrappers over the `hostdb` package. They auto-rebuild MAP + SUPPORTED_MAJOR_VERSIONS from hostdb's bundled snapshot at module-load time. **Do not hand-edit MAP entries.** To add a new database version: update hostdb, publish, bump spindb's hostdb pin. The wrapper picks it up automatically.
 
-Every hostdb release should be **self-contained and ready to use** without additional downloads. This means:
-
-1. **Bundle related components**: If a database vendor distributes components separately (like MongoDB's server, shell, and tools), hostdb bundles them into a single package. Users should get everything needed to run the database, connect to it, and manage it.
-
-2. **Include client tools**: Releases should include both server binaries and essential client/management tools (shells, backup utilities, etc.) where available.
-
-3. **No external dependencies**: Downloaded binaries should work immediately without requiring users to install additional packages or tools from other sources.
-
-**Example - MongoDB**: Since MongoDB 4.4, the shell (`mongosh`) and database tools (`mongodump`, `mongorestore`, etc.) are distributed separately. hostdb bundles all three components (server + shell + tools) into a single release, so users get a complete MongoDB installation.
-
-This philosophy ensures SpinDB and other consumers can embed database binaries without managing multiple downloads or worrying about component compatibility.
-
-## Supported Platforms
-
-- `linux-x64` - Linux x86_64 (glibc 2.28+)
-- `linux-arm64` - Linux ARM64 (glibc 2.28+)
-- `darwin-x64` - macOS Intel
-- `darwin-arm64` - macOS Apple Silicon
-- `win32-x64` - Windows x64
-
-## How It Works
-
-1. **databases.json** defines which databases, versions, and platforms are supported
-2. **Build scripts** download official binaries or build from source
-3. **GitHub Actions** run builds in parallel, upload to GitHub Releases, then mirror to Cloudflare R2
-4. **releases.json** is auto-updated with R2 download URLs (`registry.layerbase.host`) for each release
-5. **SpinDB** (or any consumer) queries releases.json to find and download binaries
-
-## Binary Hosting (Cloudflare R2)
-
-Binaries are hosted on Cloudflare R2 behind `registry.layerbase.host`. GitHub Releases are still created (as the build artifact source), but all public download URLs point to R2.
-
-**URL pattern:** `https://registry.layerbase.host/{tag}/{filename}`
-
-**Configuration:**
-- `lib/registry.ts` — single source of truth for `REGISTRY_BASE_URL`
-- `lib/r2.ts` — shared R2 client utilities (S3-compatible)
-- `scripts/upload-to-r2.ts` — per-release upload (called by CI after each release)
-- `scripts/migrate-to-r2.ts` — one-time bulk migration of existing releases
-
-**Required GitHub Actions secrets:**
-- `R2_ACCOUNT_ID` — Cloudflare account ID
-- `R2_ACCESS_KEY_ID` — R2 API token access key
-- `R2_SECRET_ACCESS_KEY` — R2 API token secret key
-- `R2_BUCKET_NAME` — R2 bucket name (e.g., `hostdb-registry`)
-- `CLOUDFLARE_API_TOKEN` — Cloudflare API token with `Zone.Cache Purge` permission (see setup below)
-- `CLOUDFLARE_ZONE_ID` — Cloudflare zone ID for `registry.layerbase.host` (see setup below)
-
-**Setting up Cloudflare secrets:**
-1. **Zone ID** — Go to [Cloudflare Dashboard](https://dash.cloudflare.com) > select the `layerbase.host` zone > the Zone ID is in the right sidebar of the **Overview** page under "API"
-2. **API Token** — Go to [Cloudflare Dashboard](https://dash.cloudflare.com) > **My Profile** (top-right avatar) > **API Tokens** > **Create Token** > use the **"Custom token"** template:
-   - Token name: `hostdb-cache-purge`
-   - Permissions: **Zone** > **Cache Purge** > **Purge**
-   - Zone resources: **Include** > **Specific zone** > `layerbase.host`
-3. Add both values as GitHub Actions secrets in the hostdb repository settings
-
-**Workflow:** Each `release-*.yml` workflow has an `upload-to-r2` job that mirrors assets from GitHub Releases to R2, followed by `update-releases` which rebuilds `releases.json` from all GitHub releases and publishes it to R2.
-
-**CDN Caching:** R2 tarballs are served through Cloudflare's CDN with `Cache-Control: public, max-age=31536000, immutable` (1-year cache). This means:
-- Normal releases work fine — each version gets a unique URL that's cached forever
-- **Re-uploading a file to R2 does NOT update the CDN** — the edge cache continues serving the old version
-- When using `--force` on `upload-to-r2.ts`, the script automatically purges affected URLs from Cloudflare's CDN cache (requires `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ZONE_ID` secrets)
-- If those secrets aren't set, the purge step is skipped with a warning — you'd need to purge manually via **Cloudflare Dashboard > layerbase.host > Caching > Configuration > Purge Everything**
-
-**Migration:** To migrate existing releases: `pnpm migrate:r2 [--dry-run] [--database mysql] [--concurrency 3]`
-
-**Orphan cleanup:** R2 retains binaries forever by design (existing containers keep working). But after months of R&D, the bucket may contain binaries from engines we abandoned or version lines we removed. `pnpm audit:r2-orphans` lists every R2 object that isn't referenced by `releases.json`, grouped by engine prefix. Pass `--delete` to remove them after confirmation. Pass `--engine <name>` to scope the audit to one engine.
-
-## npm Package (`hostdb`)
-
-This repo is **published to npm as `hostdb`** so consumers (spindb, layerbase-cloud, third parties) can resolve versions, query CLI tool metadata, and look up download URLs offline — no runtime fetch from `registry.layerbase.host` for the registry itself. R2 is still the source of truth for binary tarballs; the npm package ships a *snapshot* of the registry JSON files.
-
-### What's bundled in the tarball
-
-- `dist/index.js` + `dist/index.d.ts` (compiled from `lib/`) — public resolver API.
-- `databases.json` — version + platform + CLI tools per engine (also the source for the resolver's `defaults` block).
-- `releases.json` — R2 URLs + sha256 + size per (engine, version, platform).
-- `downloads.json` — package-manager install commands per CLI tool.
-- `cli/bin.ts` + `bin/cli.js` — the `hostdb` CLI command (runs via tsx).
-
-The `lib/` source TS is **not** shipped (consumers use the compiled dist/). See `package.json:files`.
-
-### Public API surface
-
-Snapshotted in `tests/api-shape.test.ts` (19 names). Most-used exports:
-
-- `resolveVersion(engine, version)` — `'17'` → `'17.10.0'`, `'8'` → LTS pick from defaults block. Returns `null` if unknown. Handles 4-part ClickHouse versions and `17-0.107.0` compound format.
-- `normalizeVersion(engine, version)` — like `resolveVersion` but returns the input unchanged on miss (so wrappers can drop in).
-- `listVersions(engine, { format: 'full' | 'major' | 'major-minor' })` — list available versions, descending sort.
-- `getSupportedMajorVersions(engine)` — keys of the engine's `defaults` block. Used by spindb's wrappers that expect 1-part majors.
-- `getMajorDefault(engine, major)` / `getEngineDefaults(engine)` — explicit-policy queries (defaultVersion vs latestVersion can differ for LTS-tracked engines).
-- `getReleaseInfo(engine, version, platform)` — `{ url, sha256, size }` straight from the bundled releases.json.
-- `getCliTools(engine, version)` — engine-level cli_tools with version-level overrides honored.
-- `isVersionDeprecated(engine, version)` — distinct from `enabled !== false` (deprecated versions still resolve; only `enabled: false` removes them from resolution entirely).
-- `loadDatabasesJson()` / `loadReleasesJson()` / `loadDownloadsJson()` — direct bundled-JSON access. Memoized on first call; tests reset via `_resetLoaderCachesForTests` from `lib/databases.ts`.
-
-### Defaults block — major-version resolution policy
+### `defaults` block changes are user-visible
 
 Every engine in `databases.yml` has a `defaults` block mapping 1-part major versions to the full version the resolver should return:
 
@@ -153,649 +84,163 @@ mongodb:
   defaults:
     '7': 7.0.34
     '8': 8.0.23    # LTS pick — NOT 8.2.x (the highest)
-mariadb:
-  defaults:
-    '10': 10.11.16
-    '11': 11.8.6   # Highest LTS line in 11.x
 ```
 
-This makes silent LTS-vs-latest decisions explicit. Without the defaults block, `resolveVersion('mongodb', '8')` would prefix-match to `'8.2.9'` (highest), which contradicts the MongoDB project's LTS guidance. The block IS the policy declaration.
+Without the defaults block, `resolveVersion('mongodb', '8')` would prefix-match to `'8.2.9'` (highest), which contradicts MongoDB's LTS guidance. **The block IS the policy declaration. Always write a CHANGELOG entry when changing a `defaults` value — it's policy, not data.**
 
-When changing a `defaults` value (e.g., MongoDB rolls forward to `'8': 8.2.0` once 8.2 becomes LTS), bump at least a minor version and document in CHANGELOG — this is a user-visible behavior change for every spindb / layerbase-cloud install that bumps to the new hostdb.
+### `SUPPORTED_MAJOR_VERSIONS` format divergence is intentional
 
-### Pre-publish guardrails (`.github/workflows/publish.yml`)
+Five engines (MongoDB, MySQL, MariaDB, ClickHouse, TigerBeetle) export 2-part majors (`'8.0'`, `'11.8'`); the other 16 export 1-part (`'18'`, `'8'`). The 2-part form is required for `spindb/core/version-migration.ts:getMajorVersion()` to correctly group LTS-vs-current tracks (MongoDB 8.0.x ≠ 8.2.x). **Don't flatten.**
 
-The publish workflow runs these gates before `npm publish`:
+The wrappers signal this via `listVersions(ENGINE, { format: 'major-minor' })` vs `getSupportedMajorVersions(ENGINE)`.
+
+## npm Package (`hostdb`)
+
+The repo is published to npm so consumers can resolve versions offline — no runtime fetch from `registry.layerbase.host` for the registry itself. R2 is still the source of truth for binary tarballs; npm ships a snapshot of `databases.json` / `releases.json`.
+
+**Bundled in the tarball:** `dist/index.js` (+ `.d.ts`, compiled from `lib/`), `databases.json`, `releases.json`, `downloads.json`, `cli/bin.ts` + `bin/cli.js`. The `lib/` source TS is not shipped — see `package.json:files`.
+
+**Public API** is snapshotted in `tests/api-shape.test.ts` (19 exports). Most-used:
+
+- `resolveVersion(engine, version)` — `'17'` → `'17.10.0'`, `'8'` → LTS pick from defaults block. Returns `null` on miss. Handles 4-part ClickHouse and `17-0.107.0` compound.
+- `normalizeVersion(engine, version)` — like `resolveVersion` but returns the input unchanged on miss.
+- `listVersions(engine, { format })` — `'full' | 'major' | 'major-minor'`, descending sort.
+- `getReleaseInfo(engine, version, platform)` — `{ url, sha256, size }`.
+- `getCliTools(engine, version)` — version-level overrides honored.
+- `isVersionDeprecated(engine, version)` — distinct from `enabled !== false` (deprecated versions still resolve).
+
+**Pre-publish guardrails** (`.github/workflows/publish.yml`):
 
 1. `pnpm build:releases` regenerates releases.json from live GitHub Releases.
-2. `git diff --exit-code releases.json` aborts the publish if the regenerated file differs from the committed snapshot — preventing publishing a stale registry.
+2. `git diff --exit-code releases.json` aborts if the regenerated file differs from the committed snapshot.
 3. `pnpm build` compiles `lib/` → `dist/`.
-4. `pnpm test` runs all 167 tests (resolver + defaults-sync + api-shape). The defaults-sync test is the critical one: it asserts the resolver returns the same full-version for every input that spindb's MAPs returned at integration time. If hostdb's behavior drifts, publish fails.
+4. `pnpm test` runs all tests. The **defaults-sync test** is the critical one — it asserts the resolver returns the same full-version for every input that spindb's MAPs returned at integration time.
 
-### Spindb wrapper pattern
+`prepare` (in `package.json`) runs `pnpm build` on `pnpm install` for this repo and on `npm publish`. It does NOT run for `file:` deps in pnpm 9 consumers (security policy) — cross-repo dev workflow is: clone hostdb, `pnpm install` (builds dist), then clone spindb (links to pre-built dist).
 
-Spindb's `engines/<X>/version-maps.ts` are now thin wrappers that build their legacy `<ENGINE>_VERSION_MAP` and `SUPPORTED_MAJOR_VERSIONS` at module-load time from hostdb's resolver. To bump a version: update hostdb's `databases.yml`, publish a new hostdb, then bump the `hostdb` dep pin in spindb. The wrapper rebuilds automatically — no spindb code edits.
+## Common Tasks
 
-Five engines (MongoDB, MySQL, MariaDB, ClickHouse, TigerBeetle) export 2-part `SUPPORTED_MAJOR_VERSIONS` (`['8.0', '8.2']` rather than `['8']`) because spindb's `core/version-migration.ts:getMajorVersion()` uses the array to reverse-map a full version to its grouping — and conflating MongoDB 8.0.x with 8.2.x would break the LTS/current distinction. The wrappers signal this choice via `listVersions(ENGINE, { format: 'major-minor' })` vs `getSupportedMajorVersions(ENGINE)`.
-
-### Spindb pinning
-
-Spindb must pin `hostdb` **exactly** (`"hostdb": "0.31.0"`, no caret/tilde) so that older spindb versions deterministically resolve to a single hostdb snapshot. See spindb's CLAUDE.md for the rationale — short version: a patch hostdb release can add new versions, which changes the user-visible spindb output for an already-published spindb.
-
-### Pre-publish dev setup
-
-`prepare` script (in `package.json`) runs `pnpm build` automatically on `pnpm install` in this repo's own dir and on `npm publish`. It does NOT run for `file:` deps in pnpm 9 consumers (pnpm security policy) — so the cross-repo dev workflow is: clone hostdb, `pnpm install` (builds dist), then clone spindb (which links to hostdb's pre-built dist).
-
-### Coordination rules — do not break these
-
-After the May 2026 integration, these rules are enforceable invariants. Violating any of them breaks downstream builds or silently changes user behavior. Captured here in the repo (not just in personal memory) so the rules are accessible from any machine.
-
-**Publish cascade order** (MUST be in this order for a database-version patch wave):
-
-1. Edit `databases.yml` (+ `defaults` block if needed), `sources.json`. Bump `package.json` patch version.
-2. Commit + push hostdb feature branch. Run the engine release workflow. Merge to main. `publish.yml` fires → npm publish via OIDC.
-3. **Verify** `npm view hostdb version` shows the new version before touching anything downstream.
-4. Bump `"hostdb": "X.Y.Z"` in `spindb/package.json` (exact pin). Run tests. Bump spindb version. Merge spindb feature → dev → main.
-5. Bump `SPINDB_VERSION` in `layerbase-cloud/images/Dockerfile.base`. The image build + deploy fires.
-6. Bump `"spindb": "X.Y.Z"` in `layerbase-desktop/package.json`. Next desktop release ships it.
-
-If you bump step 5 before step 3 completes, `npm install -g spindb@X.Y.Z` in the Dockerfile fails — the image build goes red.
-
-**Exact pin only.** Spindb pins hostdb as `"hostdb": "0.31.0"`, never `^0.31.0` or `~0.31.0`. A hostdb patch can add new database versions; with a caret, an end-user installing an old spindb would pick up versions spindb's tests never validated against, and shorthand-version containers would re-resolve to different patches. Lockfiles enforce this for CI/dev but lockfiles aren't published to npm — the package.json IS the contract for end-user installs.
-
-**Wrappers, not maps.** `spindb/engines/<X>/version-maps.ts` files are thin wrappers over the `hostdb` package. They auto-rebuild from hostdb's bundled snapshot at module-load time. **Do not hand-edit MAP entries.** To add a new database version: update hostdb, publish, bump spindb's hostdb pin. The wrapper picks it up automatically.
-
-**Defaults block changes are user-visible.** Changing `mongodb: '8' → 8.0.23` to `mongodb: '8' → 8.2.0` (LTS rollforward) changes resolution for every consumer pinning the new hostdb. **Always write a CHANGELOG entry** when changing a `defaults` value — it's policy, not data.
-
-**SUPPORTED_MAJOR_VERSIONS format divergence is intentional.** Five engines (MongoDB, MySQL, MariaDB, ClickHouse, TigerBeetle) export 2-part majors (`'8.0'`, `'11.8'`); the other 16 export 1-part (`'18'`, `'8'`). The 2-part form is required for `spindb/core/version-migration.ts:getMajorVersion()` to correctly group LTS-vs-current tracks (MongoDB 8.0.x ≠ 8.2.x). Don't flatten.
-
-## Project Structure
-
-```
-hostdb/
-├── databases.yml           # Source of truth (edit this, generates databases.json)
-├── databases.json          # Generated from databases.yml by pnpm prep
-├── releases.json           # Queryable manifest of GitHub Releases (auto-updated)
-├── downloads.json          # CLI tools, prerequisites, fallback downloads
-├── schemas/
-│   ├── databases.schema.json
-│   ├── sources.schema.json
-│   └── releases.schema.json
-├── builds/                 # Per-database build configurations
-│   ├── common/
-│   │   ├── validate-binaries.sh  # Validate archives contain all required cli_tools binaries
-│   │   ├── fix-macos-dylibs.sh   # Bundle Homebrew dylibs for relocatable binaries
-│   │   └── check-macos-dylibs.sh # Audit packages for non-relocatable paths
-│   ├── mysql/
-│   │   ├── download.ts     # Downloads/repackages binaries
-│   │   ├── sources.json    # Version → URL mappings
-│   │   ├── Dockerfile      # Source build for Linux
-│   │   ├── build-local.sh  # Local Docker build script
-│   │   └── README.md
-│   ├── postgresql/
-│   ├── mariadb/
-│   └── ...
-├── scripts/
-│   ├── add-engine.ts         # pnpm add:engine - scaffold new database
-│   ├── fetch-edb-fileids.ts  # pnpm edb:fileids - fetch PostgreSQL Windows file IDs
-│   ├── list-databases.ts     # pnpm dbs
-│   ├── sync-versions.ts      # pnpm sync:versions - sync workflow dropdowns
-│   └── build-releases-json.ts # pnpm build:releases - rebuild releases.json from GitHub
-└── .github/workflows/
-    ├── release-mysql.yml
-    ├── release-postgresql.yml
-    └── ...
-```
-
-## Configuration Files
-
-**IMPORTANT:** All configuration files have JSON schemas. If you modify the structure of these files (add/remove/rename keys), you must also update the corresponding schema.
-
-| Config File | Schema File | Description |
-|-------------|-------------|-------------|
-| `databases.json` | `schemas/databases.schema.json` | **Single source of truth** - drives all automation |
-| `builds/*/sources.json` | `schemas/sources.schema.json` | Binary download URLs per version/platform |
-| `releases.json` | `schemas/releases.schema.json` | Manifest of GitHub Releases (queryable) |
-
-### databases.json
-
-The central source of truth that **drives all automation**. GitHub Actions workflows validate against this file before building. The key for each database (e.g., `mysql`, `postgresql`, `mariadb`) is the normalized ID used for:
-- Workflow files: `.github/workflows/release-{id}.yml`
-- Build directories: `builds/{id}/`
-- Release tags: `{id}-{version}`
-
-Each database entry includes:
-
-```json
-{
-  "displayName": "MySQL",
-  "description": "...",
-  "type": "Relational",
-  "license": "GPL-2.0",
-  "commercialUse": true,
-  "spindbStatus": "completed",
-  "versions": { "8.4.7": true, "8.0.40": true },
-  "platforms": ["linux-x64", "linux-arm64", "darwin-x64", "darwin-arm64", "win32-x64"]
-}
-```
-
-**Note:** `databases.yml` uses snake_case keys (`display_name`, `spindb_status`, etc.). The `pnpm prep` script converts them to camelCase for `databases.json`.
-
-**spindbStatus values:**
-- `completed` - Fully built and released
-- `in-progress` - Currently being implemented
-
-See `PROSPECTS.md` for planned and unsupported databases.
-
-### sources.json (per database)
-
-Maps versions and platforms to download URLs:
-
-```json
-{
-  "database": "mysql",
-  "versions": {
-    "8.4.7": {
-      "linux-x64": {
-        "url": "https://dev.mysql.com/get/Downloads/...",
-        "format": "tar.gz",
-        "sourceType": "official"
-      },
-      "linux-arm64": {
-        "sourceType": "build-required"
-      }
-    }
-  }
-}
-```
-
-**Source types:**
-- `official` - Direct from vendor CDN
-- `mariadb4j` - Third-party repository (MariaDB4j Maven JARs)
-- `build-required` - Must build from source
-
-## GitHub Actions Workflows
-
-Each database has a release workflow that **validates against databases.json**:
-
-1. Triggered via `workflow_dispatch` (manual)
-2. **Dropdown selects version** - options synced from databases.json via `pnpm sync:versions`
-3. **Validate job** checks version is enabled in `databases.json` and exists in `sources.json`
-4. Matrix builds all platforms in parallel
-5. Downloads official binaries OR builds from source
-6. **Validate binaries** - extracts archives and verifies all `cli_tools` binaries exist
-7. Creates GitHub Release with artifacts
-8. `upload-to-r2` job mirrors release assets to Cloudflare R2
-9. `update-releases` job rebuilds `releases.json` from all GitHub releases and publishes to R2
-
-**Validation flow:**
-```
-User selects version "8.4.7" from dropdown
-        ↓
-Check databases.json: versions["8.4.7"] == true?
-        ↓
-Check sources.json: versions["8.4.7"] exists?
-        ↓
-Proceed with build (or fail with helpful error)
-```
-
-**Build methods by platform:**
-| Platform | Method |
-|----------|--------|
-| linux-x64 | Download or Docker build |
-| linux-arm64 | Docker build (QEMU emulation) |
-| darwin-x64 | Native build on macos-15-intel runner |
-| darwin-arm64 | Native build on macos-14 runner |
-| win32-x64 | Download official binary or source build (see [WINDOWS_BUILD.md](./WINDOWS_BUILD.md)) |
-
-### macOS Native Build Considerations
-
-Native macOS builds (darwin-x64, darwin-arm64) require careful SDK configuration to avoid conflicts between Xcode and Command Line Tools:
-
-**The Problem:** CMake can find libraries from Command Line Tools (`/Library/Developer/CommandLineTools/SDKs/`) while using Xcode's SDK for compilation. This causes C++ header search path errors like:
-```
-error: <cstddef> tried including <stddef.h> but didn't find libc++'s <stddef.h> header.
-```
-
-**The Solution:** Force all tools to use a single SDK by:
-1. Setting `xcode-select` to the Xcode app (not Command Line Tools)
-2. Exporting `SDKROOT`, `CC`, `CXX`, `CFLAGS`, `CXXFLAGS`, `LDFLAGS` with `--sysroot`
-3. Using `CMAKE_FIND_ROOT_PATH` to restrict library search to Xcode SDK + Homebrew only
-4. Running cmake via `xcrun` to inherit the correct environment
-
-See `release-mariadb.yml` for a working example of this configuration.
-
-## Adding a New Database
-
-Use the scaffolding script to create the basic structure:
+### Add a new database engine
 
 ```bash
-pnpm add:engine redis
-pnpm add:engine sqlite
+pnpm add:engine <name>
 ```
 
-This creates:
-- `builds/<id>/` directory with template files
-- `.github/workflows/release-<id>.yml` with validation
-- `download:<id>` script in package.json
+Scaffolds `builds/<id>/`, `.github/workflows/release-<id>.yml`, and a `download:<id>` script. Then follow [`CHECKLIST.md`](./CHECKLIST.md).
 
-Then follow the printed instructions to implement the download logic.
+### Add a new version of an existing database
 
-See [CHECKLIST.md](./CHECKLIST.md) for the complete checklist.
+1. Update `databases.yml` — add the version. If it should be the LTS/default pick for a major, update `defaults` too.
+2. Update `builds/<engine>/sources.json` — URLs for all platforms.
+3. `pnpm prep` — regenerates `databases.json`, syncs workflow dropdowns, populates checksums.
+4. Run the release workflow on GitHub Actions — uploads binaries, mirrors to R2, rebuilds `releases.json`.
+5. Bump `package.json` **patch** so consumers see the new version through the npm package.
+6. Merge to main — `publish.yml` runs pre-publish guards and publishes via OIDC.
 
-See [BINARIES.md](./BINARIES.md) for archive structure reference (top-level dirs, binary locations, single vs multi-file).
+### Deprecate a version
 
-**Windows builds:** If no official Windows binary exists, see [WINDOWS_BUILD.md](./WINDOWS_BUILD.md) for strategies (Cygwin, MSYS2 CLANG64, cross-compilation, etc.).
+In `databases.yml`, change the entry from `true` to:
 
-### Download Script Requirements
+```yaml
+versions:
+  9.5.0:
+    deprecated: true
+    note: "Deprecated; superseded by 9.6.0"
+```
 
-When implementing `builds/<database>/download.ts`:
+`pnpm prep` regenerates `databases.json` (workflow dropdowns auto-skip deprecated). Existing binaries stay on R2 — deprecation is UI-only and consumers can still download.
 
-1. **Handle `--` delimiter**: pnpm passes `--` literally when running `pnpm script -- args`. Add a case to ignore it:
-   ```typescript
-   case '--':
-     // Ignore -- (end of options delimiter from pnpm)
-     break
-   ```
+### Version-level `cli_tools` overrides
 
-2. **ESLint no-fallthrough**: Even after `process.exit()`, ESLint requires a `break` statement:
-   ```typescript
-   case '--help':
-     console.log('...')
-     process.exit(0)
-     break // unreachable, but required for no-fallthrough rule
-   ```
-
-3. **Vendor URL encoding**: Some vendors use unique version encoding in URLs. Document the formula:
-   - SQLite: `3.51.2` → `3510200` (MAJOR×1000000 + MINOR×10000 + PATCH×100)
-   - Add notes in `sources.json` explaining any encoding schemes
-
-### Dockerfile Requirements
-
-When implementing `builds/<database>/Dockerfile` for source builds:
-
-1. **ARG vs ENV scoping**: Docker `ARG` values are only available during build (RUN), not at runtime (CMD/ENTRYPOINT). To use a build arg in CMD:
-   ```dockerfile
-   ARG VERSION
-   ENV VERSION=${VERSION}  # Persist ARG to runtime
-   CMD cp /build/output-${VERSION}.tar.gz /dist/
-   ```
-
-2. **Version number calculations**: If version needs encoding, do it in a RUN step and save to a file:
-   ```dockerfile
-   RUN VERSION_NUM=$(echo "${VERSION}" | awk -F. '{printf "%d%02d%02d00", $1, $2, $3}') && \
-       echo "VERSION_NUM=${VERSION_NUM}" > /tmp/version_env
-   ```
-
-### Workflow Requirements
-
-When implementing `.github/workflows/release-<database>.yml`:
-
-1. **Release job condition**: If you have multiple build jobs (e.g., one for downloads, one for source builds), use this pattern to prevent partial releases:
-   ```yaml
-   release:
-     needs: [build-download, build-source]
-     if: always() && (needs.build-download.result == 'success' || needs.build-download.result == 'skipped') && (needs.build-source.result == 'success' || needs.build-source.result == 'skipped')
-   ```
-   This ensures the release only happens if all required jobs either succeed or were intentionally skipped.
-
-2. **Conditional artifact downloads**: Only download artifacts from jobs that actually ran:
-   ```yaml
-   - name: Download source build artifacts
-     if: needs.build-source.result == 'success'
-     uses: actions/download-artifact@v4
-   ```
-
-3. **Binary validation step**: Every release workflow must validate archives before creating the GitHub Release. Add this step in the `release` job, after preparing release assets and before the "Create Release" step:
-   ```yaml
-   - name: Validate required binaries
-     run: |
-       chmod +x builds/common/validate-binaries.sh
-       ./builds/common/validate-binaries.sh <database-id> ./release-assets
-   ```
-
-## Adding New Versions
-
-When adding a new version to an existing database:
-
-1. Update `databases.yml` - add version with `true` (or a version config object). If the new version should be the LTS or default pick for a major, also update the engine's `defaults` block.
-2. Update `builds/<database>/sources.json` - add URLs for all platforms
-3. Run `pnpm prep` - generates databases.json, syncs workflows, and populates checksums
-4. Run the release workflow on GitHub Actions — uploads binaries to GitHub Releases, mirrors to R2, rebuilds releases.json
-5. **Bump `package.json` patch version** (e.g., 0.30.0 → 0.30.1) so the new binaries propagate via the npm package. Without this bump, consumers pinning `hostdb@0.30.0` won't see the new version.
-6. Merge to main — `publish.yml` runs the pre-publish guards (build:releases drift check, build, tests) and publishes to npm via OIDC.
-
-**That's it.** The prep script handles syncing workflow dropdowns and populating SHA256 checksums automatically. The publish workflow handles npm.
-
-### Downstream Impact (spindb + layerbase-cloud)
-
-Changes in hostdb ripple to two downstream projects. After the npm-package migration the spindb side is **almost fully automatic**, but a publish + dep-bump is still required.
-
-**spindb** (`~/dev/spindb`) — after the npm-package migration most of the version-related code is automatic:
-- `engines/<db>/version-maps.ts` — **no longer hand-edited**. The wrappers rebuild MAP + SUPPORTED_MAJOR_VERSIONS from hostdb's resolver at module-load time.
-- `config/engines.json` and `config/engine-defaults.ts` — still hand-maintained for now (`supportedVersions`, `defaultVersion`, `latestVersion`). A future refactor could derive these from hostdb's resolver too.
-- `engines/<db>/hostdb-releases.ts` / `engines/<db>/index.ts` — `fetchDeprecatedVersions` overrides only needed for engines newly gaining deprecation support.
-- `cli/ui/prompts.ts` — already handles `[deprecated]` tags generically; no changes needed unless UI behavior changes.
-- `package.json` — **bump the `hostdb` exact-pin** to the newly-published version so the bundled snapshot picks up the new releases. This is the actual "shipping" step.
-
-**layerbase-cloud** (`~/dev/layerbase-cloud`) — uses major.minor version tags (e.g., `11.8`) that spindb resolves to a full semver (e.g., `11.8.5`) via its static `engines/<db>/version-maps.ts` MAP. The cloud runs a single universal Docker image (`ghcr.io/layerbase-llc/universal`); engine binaries are **not** baked into the image — spindb downloads them on demand from `registry.layerbase.host`. The version resolution authority is the spindb baked into the image, not the registry. Practical impact per change shape:
-- **Patch bump within same major.minor** (e.g., `11.8.5 → 11.8.6`): No cloud changes. The new spindb release (with the updated MAP) takes effect when the universal image is rebuilt with the new `SPINDB_VERSION`.
-- **New major.minor** (e.g., adding `11.9`): Update `src/config/engine-registry.ts` (`supportedVersions` array). No workflow file changes — cloud's `build-images.yml`/`deploy.yml` are engine-agnostic.
-- **Change defaultVersion**: Update `src/config/engine-registry.ts` (`defaultVersion`). Also update `images/entrypoints/<engine>.sh` if a hardcoded `SPINDB_VERSION` default exists (only `clickhouse.sh` and `cockroachdb.sh` carry these).
-
-## Deprecating Versions
-
-To deprecate a version (stop building it but keep existing binaries downloadable):
-
-1. **Update `databases.yml`** — change the version entry from `true` to an object with `deprecated: true`:
-   ```yaml
-   versions:
-     9.5.0:
-       deprecated: true
-       note: "Deprecated; superseded by 9.6.0"
-   ```
-
-2. **Run `pnpm prep`** — this regenerates databases.json and syncs workflow dropdowns. Deprecated versions are automatically excluded from workflow dropdowns by `sync-versions.ts`.
-
-3. **Rebuild releases.json** — `build-releases-json.ts` propagates the `deprecated` flag from databases.json into releases.json entries, so consumers like spindb can read it.
-
-4. **Update spindb** — see "Downstream Impact" above. The key files are version-maps, engines.json, and engine-defaults.
-
-**Important:** Deprecation does NOT delete binaries. Existing releases remain on R2 and in releases.json. Users can still download and use deprecated versions — they just won't appear in workflow build dropdowns or be recommended in spindb's UI.
-
-### Version-Level cliTools Overrides
-
-When a vendor removes or adds binaries between versions (e.g., MySQL removed `mysqlpump` in 9.0), use version-level `cli_tools` overrides in `databases.yml`:
+When a vendor removes/adds binaries between versions (e.g., MySQL removed `mysqlpump` in 9.0):
 
 ```yaml
 mysql:
   cli_tools:
     server: mysqld
     client: mysql
-    utilities:
-      - mysqldump
-      - mysqladmin
-      - mysqlpump     # present in 8.x
+    utilities: [mysqldump, mysqladmin, mysqlpump]   # 8.x has mysqlpump
   versions:
     9.6.0:
-      note: "mysqlpump removed in MySQL 9.0"
-      cli_tools:       # overrides engine-level cli_tools
+      cli_tools:
         server: mysqld
         client: mysql
-        utilities:
-          - mysqldump
-          - mysqladmin
-    8.4.3: true        # uses engine-level cli_tools (includes mysqlpump)
+        utilities: [mysqldump, mysqladmin]           # 9.0+ removed it
+    8.4.3: true                                       # uses engine-level cli_tools
 ```
 
-`validate-binaries.sh` extracts the version from archive filenames and checks for version-level `cliTools` overrides before falling back to engine-level. This prevents build failures when the binary list differs between versions.
+`validate-binaries.sh` extracts the version from filenames and prefers version-level overrides.
 
-## Version Tracking
+### Downstream impact
 
-**`UPGRADE_VERSIONS.md`** tracks which engines need upgrades, organized by priority tier. Run `/audit-hostdb-versions` to refresh it with latest upstream versions.
+After publishing a hostdb version:
+- **spindb** — bump the `hostdb` exact-pin in `spindb/package.json`. Wrappers auto-rebuild MAP/SUPPORTED_MAJOR_VERSIONS. `config/engines.json` and `config/engine-defaults.ts` are still hand-maintained for `supportedVersions` / `defaultVersion` / `latestVersion`.
+- **layerbase-cloud** — patch within same major.minor → no cloud change (auto via `SPINDB_VERSION` bump). New major.minor → update `src/config/engine-registry.ts` (`supportedVersions`). Change `defaultVersion` → update the same file plus any `images/entrypoints/<engine>.sh` hardcoded fallbacks (only `clickhouse.sh` and `cockroachdb.sh` carry these).
+
+## Binary Hosting (Cloudflare R2)
+
+URL pattern: `https://registry.layerbase.host/{tag}/{filename}`
+
+- `lib/registry.ts` — single source of truth for `REGISTRY_BASE_URL`.
+- `lib/r2.ts` — shared R2 client utilities (S3-compatible).
+- `scripts/upload-to-r2.ts` — per-release upload (called by CI after each release).
+- `scripts/migrate-to-r2.ts` — bulk migration.
+
+R2 tarballs are served via Cloudflare CDN with `Cache-Control: public, max-age=31536000, immutable` (1-year). Each version gets a unique URL cached forever. **Re-uploading a file does NOT update the CDN** — `upload-to-r2.ts --force` purges affected URLs (requires `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ZONE_ID` secrets).
+
+R2 retains binaries forever by design (existing containers keep working). `pnpm audit:r2-orphans` lists objects not referenced by `releases.json`; `--delete` removes them.
+
+See `ARCHITECTURE.md` for secret setup (Cloudflare Zone ID, API token) and the full list of required GH Actions secrets.
 
 ## Engine-Specific Notes
 
 ### MariaDB
 
-Three versions are hosted: 10.11, 11.4, and 11.8 — all LTS releases. This is intentional:
-
-- **10.11** (LTS, EOL Feb 2028) — Last LTS in the 10.x line. Many production deployments still run 10.x because the jump to 11.x had breaking changes (removed `mysql_install_db`, system table changes). Users need this to match their production version.
-- **11.4** (LTS, EOL May 2029) — First long-term-supported release in 11.x. The "safe upgrade target" for users migrating from 10.x.
-- **11.8** (LTS, EOL ~2028) — Latest LTS with newer features. Same major line as 11.4 but both are independently supported LTS releases with different EOL dates.
-
-All three are justified. Do not consolidate.
+Three versions are hosted: 10.11, 11.4, 11.8 — all LTS. **Do not consolidate.** The 10.x → 11.x jump had breaking changes; users need 10.11 to match production. 11.4 is the first 11.x LTS; 11.8 has a different EOL than 11.4. All three are independently justified.
 
 ### FerretDB
 
-Both v1 (1.24.x) and v2 (2.x) are hosted. **v1 must be kept for backwards compatibility** — do not deprecate it. v2 uses DocumentDB (PostgreSQL extension) while v1 uses its own storage engine. Users may depend on either.
+Both v1 (1.24.x) and v2 (2.x) are hosted. **v1 must be kept for backwards compatibility** — do not deprecate it. v2 uses DocumentDB (PostgreSQL extension); v1 uses its own storage engine. Users may depend on either.
 
-## Checksums
+### SQLite checksums
 
-Most databases use **SHA-256** checksums. The `pnpm checksums:populate` script downloads files and computes checksums automatically.
-
-**Exception - SQLite**: SQLite uses **SHA3-256** checksums (different algorithm). These are provided directly on [sqlite.org/download.html](https://sqlite.org/download.html) and must be copied manually to `sources.json` using the `sha3_256` field instead of `sha256`.
-
-When adding a new database:
-1. Check the vendor's download page for checksum format (SHA-256, SHA3-256, SHA-512, etc.)
-2. If SHA-256, use `pnpm checksums:populate <database>` to auto-populate
-3. If different algorithm, copy checksums manually and use appropriate field name (e.g., `sha3_256`)
-
-```bash
-# Sync all workflows
-pnpm sync:versions
-
-# Sync specific database
-pnpm sync:versions mysql
-
-# Check if sync needed (for CI)
-pnpm sync:versions --check
-```
+Most databases use **SHA-256**. SQLite uses **SHA3-256** (different algorithm) provided on sqlite.org/download.html — copied manually to `sources.json` using the `sha3_256` field instead of `sha256`. When adding a new database, check the vendor's checksum format first.
 
 ## Development Commands
 
 ```bash
-# Pre-commit preparation (run before committing)
+# Pre-commit
 pnpm prep              # Type-check, lint, sync versions, populate checksums
-pnpm prep --fix        # Same as above + auto-fix lint/format issues
-pnpm prep --check      # Check only, don't modify files (for CI)
+pnpm prep --fix        # Same + auto-fix lint/format
+pnpm prep --check      # Check only (for CI)
 
-# List databases
-pnpm dbs              # Show all databases
+# Database listing
+pnpm dbs                                        # Show all databases
 
 # Download binaries locally
-pnpm download:mysql -- --version 8.4.7
-pnpm download:mysql -- --version 8.4.7 --all-platforms
-pnpm download:mariadb -- --version 11.8.5 --build-fallback
+pnpm download:<engine> -- --version X.Y.Z
+pnpm download:<engine> -- --version X.Y.Z --all-platforms
 
 # Local Docker builds
-./builds/mariadb/build-local.sh --version 11.8.5 --platform linux-arm64
+./builds/<engine>/build-local.sh --version X.Y.Z --platform linux-arm64
 
-# Scaffolding and maintenance
-pnpm add:engine redis              # Scaffold new database
-pnpm sync:versions                 # Sync workflow dropdowns with databases.json
-pnpm checksums:populate <database> # Populate missing SHA256 checksums
+# Scaffolding & maintenance
+pnpm add:engine <name>                          # Scaffold new database
+pnpm sync:versions [<database>] [--check]       # Sync workflow dropdowns
+pnpm checksums:populate <database>              # Populate SHA256 checksums
 
-# PostgreSQL: Fetch EDB Windows file IDs
-pnpm edb:fileids                   # Show available file IDs from EDB
-pnpm edb:fileids -- --update       # Update sources.json with latest IDs
+# PostgreSQL: EDB Windows file IDs
+pnpm edb:fileids [-- --update]
 
 # macOS dylib auditing
-pnpm check:dylibs                              # Scan ./dist for Homebrew paths
-pnpm check:dylibs -- ./dist/redis              # Scan specific package
+pnpm check:dylibs [-- <path>]                   # Scan for non-relocatable paths
 
-# R2 binary hosting
-pnpm upload:r2 -- --tag mysql-8.4.3            # Upload single release to R2
-pnpm migrate:r2                                 # Migrate all releases to R2
-pnpm migrate:r2 -- --dry-run                    # Preview migration
-pnpm migrate:r2 -- --database mysql             # Migrate one database only
+# R2
+pnpm upload:r2 -- --tag <release-tag>           # Upload single release
+pnpm migrate:r2 [-- --dry-run --database X]     # Bulk migrate
+pnpm audit:r2-orphans [-- --delete --engine X]  # Find/clean orphans
 ```
 
-## Querying Available Binaries
+## Version Tracking
 
-```bash
-# Raw URL for releases.json
-https://raw.githubusercontent.com/robertjbass/hostdb/main/releases.json
-```
-
-**Download URL pattern:**
-```
-https://registry.layerbase.host/{tag}/{filename}
-```
-
-**releases.json structure:**
-```json
-{
-  "repository": "robertjbass/hostdb",
-  "databases": {
-    "mysql": {
-      "8.4.3": {
-        "releaseTag": "mysql-8.4.3",
-        "platforms": {
-          "darwin-arm64": {
-            "url": "https://registry.layerbase.host/mysql-8.4.3/mysql-8.4.3-darwin-arm64.tar.gz",
-            "sha256": "abc123...",
-            "size": 165000000
-          }
-        }
-      }
-    }
-  }
-}
-```
-
-## Package Configuration
-
-The root `package.json` has `"private": true` because:
-- The root package is not published to npm
-- Only the future `cli/` package will be published as `@hostdb/cli` or `hostdb`
-
-## GitHub Constraints (Public Repo)
-
-| Resource | Limit |
-|----------|-------|
-| Actions minutes | Unlimited (public repo) |
-| Job timeout | 6 hours per job |
-| Release file size | 2 GB per file |
-| Total release storage | No limit |
-
-**Build times vary significantly:**
-- Downloads: 2-5 minutes
-- Docker builds (QEMU): 45-90+ minutes
-- Native macOS builds: 30-60 minutes
-
-## macOS Source Build Learnings (PostgreSQL-DocumentDB)
-
-Building PostgreSQL with extensions from source on macOS requires careful handling of library paths and code signing. These lessons apply to any macOS source build that needs relocatable binaries.
-
-### Why Build from Source Instead of Homebrew?
-
-Homebrew binaries have **hardcoded absolute paths** (e.g., `/opt/homebrew/lib/libssl.3.dylib`). For relocatable binaries that work on any machine:
-
-1. Build PostgreSQL from source with relative paths
-2. Build extensions (PostGIS, DocumentDB) from source against that PostgreSQL
-3. Bundle all Homebrew dependencies and rewrite their paths
-
-### macOS dylib Path Rewriting
-
-macOS dynamic libraries use special path prefixes:
-
-| Prefix | Meaning | When to Use |
-|--------|---------|-------------|
-| `@rpath` | Search paths defined in the binary's LC_RPATH | Libraries that could be in multiple locations |
-| `@loader_path` | Directory containing the loading binary | Bundled libraries next to executables |
-| `@executable_path` | Directory containing the main executable | App bundles |
-
-**Workflow for making binaries relocatable:**
-
-1. **Copy dependencies recursively** - Use `otool -L` to find dependencies, copy them to bundle
-2. **Handle `@rpath` references** - Resolve by searching Homebrew locations (`/opt/homebrew/lib`, `/usr/local/lib`)
-3. **Rewrite paths with install_name_tool**:
-   ```bash
-   # Change library's own ID
-   install_name_tool -id "@loader_path/libfoo.dylib" libfoo.dylib
-
-   # Change reference to another library
-   install_name_tool -change "/opt/homebrew/lib/libbar.dylib" "@loader_path/libbar.dylib" libfoo.dylib
-
-   # Add rpath for finding libraries
-   install_name_tool -add_rpath "@loader_path" binary
-
-   # Remove Homebrew rpaths
-   install_name_tool -delete_rpath "/opt/homebrew/lib" binary
-   ```
-
-4. **Re-sign after modification** - macOS requires code signing after any binary modification:
-   ```bash
-   codesign -s - --force --preserve-metadata=entitlements,requirements,flags,runtime binary
-   ```
-
-### Recursive Dependency Bundling
-
-Libraries have transitive dependencies. A recursive function is needed:
-
-```bash
-copy_lib_recursive() {
-    local lib_path="$1"
-    # Skip system libraries (/usr/lib/*, /System/*)
-    # Skip already-processed libraries (track in a file)
-    # Copy to bundle if from Homebrew
-    # Recursively process dependencies from otool -L
-    # Handle @rpath references by searching known locations
-    # Handle @loader_path references relative to library directory
-}
-```
-
-### DocumentDB SQL Patching
-
-FerretDB's DocumentDB extension has upstream SQL issues that need patching:
-
-1. **Token concatenation (`##`)** - PostgreSQL doesn't support C preprocessor-style `##`:
-   ```bash
-   # Fix patterns like "documentdb## _rum_" → "documentdb_rum_"
-   sed -i '' -e 's/## //g' -e 's/##_/_/g' -e 's/_##/_/g' -e 's/##//g' file.sql
-   ```
-
-2. **Wrong library references** - Some functions reference `MODULE_PATHNAME` but are in `pg_documentdb_core`:
-   ```bash
-   # Fix: bson_in, bson_out, bson_send, bson_recv, bsonquery_* functions
-   sed -i '' -E "s/AS 'MODULE_PATHNAME', \\\$function\\\$(bson_in|bson_out|...)...\$/AS '\$libdir\/pg_documentdb_core', .../" file.sql
-   ```
-
-### Linux ARM64 Builds (QEMU)
-
-ARM64 Linux builds use QEMU emulation on x64 runners:
-- Build times: 45-90+ minutes (vs 3-5 minutes for native)
-- Builds can appear "frozen" during long compilation steps
-- Use `docker buildx` with `--platform linux/arm64`
-
-### Workflow Concurrency
-
-The release workflow uses concurrency groups to prevent conflicts:
-```yaml
-concurrency:
-  group: release-postgresql-documentdb
-  cancel-in-progress: false
-```
-
-This means only one build runs at a time - subsequent triggers are queued, not cancelled.
-
-## macOS Dylib Patching (Shared Script)
-
-macOS source builds that link against Homebrew (OpenSSL, pcre2, etc.) produce binaries with absolute paths like `/opt/homebrew/opt/openssl@3/lib/libssl.3.dylib`. These break on any Mac without those exact Homebrew packages installed.
-
-**`builds/common/fix-macos-dylibs.sh <package-root>`** fixes this by:
-1. Bundling Homebrew dylibs into the package's `lib/` directory
-2. Rewriting all absolute paths to `@loader_path` relative references
-3. Re-signing modified binaries (required by macOS)
-4. Verifying no Homebrew paths remain (fails the build if any found)
-
-**When to use:** Add to any release workflow's macOS build step if the database links against Homebrew libraries at build time. Insert between metadata creation and tarball creation:
-```bash
-chmod +x "$GITHUB_WORKSPACE/builds/common/fix-macos-dylibs.sh"
-"$GITHUB_WORKSPACE/builds/common/fix-macos-dylibs.sh" "$GITHUB_WORKSPACE/install/<database>"
-```
-
-**Currently used by:** MariaDB, Redis, Valkey, CouchDB workflows. PostgreSQL-DocumentDB has its own inline implementation.
-
-**Diagnostic:** `pnpm check:dylibs [<path>]` scans packages for non-relocatable paths without modifying anything. The `audit-dylibs` workflow (`workflow_dispatch`) audits published releases on R2.
-
-## Binary Validation (Shared Script)
-
-Every release workflow validates that archives contain all required binaries before creating the GitHub Release. This prevents shipping incomplete releases (e.g., PostgreSQL 17.7.0 once shipped without `psql`, `pg_dump`, and other client tools, breaking SpinDB's backup/restore).
-
-**`builds/common/validate-binaries.sh <database> <release-assets-dir>`** does the following:
-1. Extracts the version from archive filenames (e.g., `mysql-9.6.0-darwin-arm64.tar.gz` → `9.6.0`)
-2. Checks for version-level `cliTools` overrides in `databases.json` before falling back to engine-level `cliTools`
-3. Collects all non-null binary names from those fields (skips `enhanced` tools)
-4. For each archive (`.tar.gz` / `.zip`) in the release assets directory, extracts and searches for each required binary
-5. Fails the build with clear error messages if any binary is missing
-
-**Dependency-aware:** Some databases depend on others for client tools. For example, QuestDB lists `psql` as its client but depends on PostgreSQL — `psql` comes from the PostgreSQL install, not the QuestDB tarball. The script reads `dependencies` from `databases.json` (both top-level and per-version) and skips binaries provided by dependency databases.
-
-**Name variant handling:** The script handles naming differences between `cli_tools` and actual binaries:
-- Windows extensions: `.exe`, `.cmd`, `.bat`
-- Hyphen-to-underscore: `typedb-console` → `typedb_console`, `typedb_console_bin`
-- Searches recursively through the entire extracted archive (handles `bin/`, root, and custom paths like TypeDB's `server/` and `console/`)
-
-**Currently used by:** All 21 release workflows. Added as a "Validate required binaries" step in each workflow's `release` job, positioned after artifact preparation and before "Create Release".
+`UPGRADE_VERSIONS.md` tracks which engines need upgrades, organized by priority tier. Run `/audit-hostdb-versions` to refresh it with latest upstream versions.

--- a/PROSPECTS.md
+++ b/PROSPECTS.md
@@ -86,6 +86,23 @@ Databases we intend to add to hostdb. Listed roughly by priority/readiness.
 - **Why:** Graph-relational database built on PostgreSQL with strict typing and declarative schema.
 - **Notes:** No Windows binary (Docker only). No GitHub Release assets — distributed via custom install script. linux-arm64 support uncertain.
 
+### RabbitMQ
+
+- **Type:** Message Queue (would be a new type — hostdb has no Message Queue category today)
+- **License:** Apache-2.0 / MPL-2.0
+- **Repo:** https://github.com/rabbitmq/rabbitmq-server
+- **Platforms:** linux-x64, linux-arm64, darwin-x64, darwin-arm64, win32-x64
+- **Version:** 4.1.x (latest stable line)
+- **Why:** Industry-standard open-source message broker; natural complement to Redis (already in hostdb as a broker-capable engine). Expands hostdb's scope from "databases" to "stateful services."
+- **Dependencies:** Requires Erlang/OTP runtime bundled with every platform tarball — no other hostdb engine drags a full language VM along. Tight version coupling: each RabbitMQ minor supports a narrow OTP range. Likely use compound version keys (`4.1.5-otp27`), same shape as `postgresql-documentdb` uses `17-0.107.0`.
+- **Notes:**
+  - Linux is easy — Docker-extract from `rabbitmq:X.Y-management` (same pattern as CouchDB, which is also Erlang-based and already ships a bundled Erlang inside its image).
+  - macOS is the hard part — needs a relocatable Erlang/OTP built from source on the runner, with `install_name_tool` dylib patching for the crypto/ssl NIFs (existing `builds/common/fix-macos-dylibs.sh` pattern). ~30–60 min/platform build.
+  - Windows: extract Erlang's official installer via `7z`, ship a `.bat` wrapper that sets `ERLANG_HOME` to the bundled path.
+  - epmd is a node-wide singleton on port 4369 — spindb's port-mapping needs per-instance `RABBITMQ_NODENAME`s for multiple concurrent instances.
+  - Decide before starting: ship `rabbitmq_management` plugin enabled by default (most dev workflows want the UI on :15672)?
+  - **Strategic question first:** does hostdb want to broaden from "databases" to "stateful services"? If yes, NATS / Kafka / Temporal become obvious next entries (and are all easier than RabbitMQ — none drag a VM along).
+
 ---
 
 ## Unsupported

--- a/builds/common/README.md
+++ b/builds/common/README.md
@@ -1,0 +1,166 @@
+# builds/common
+
+Shared build scripts used by all engine release workflows, plus general reference material for macOS native builds.
+
+## Shared scripts
+
+### `validate-binaries.sh <database> <release-assets-dir>`
+
+Every release workflow validates that archives contain all required binaries before creating the GitHub Release. This prevents shipping incomplete releases (e.g., PostgreSQL 17.7.0 once shipped without `psql`, `pg_dump`, and other client tools, breaking SpinDB's backup/restore).
+
+The script:
+
+1. Extracts the version from archive filenames (e.g., `mysql-9.6.0-darwin-arm64.tar.gz` → `9.6.0`).
+2. Checks for version-level `cliTools` overrides in `databases.json`, then falls back to engine-level `cliTools`.
+3. Collects all non-null binary names (skips `enhanced` tools).
+4. For each `.tar.gz` / `.zip` in the release-assets directory, extracts and searches for each required binary.
+5. Fails the build with clear errors if any binary is missing.
+
+**Dependency-aware:** Some databases depend on others for client tools. For example, QuestDB lists `psql` as its client but depends on PostgreSQL — `psql` comes from the PostgreSQL install, not the QuestDB tarball. The script reads `dependencies` from `databases.json` (top-level and per-version) and skips binaries provided by dependency databases.
+
+**Name-variant handling:** The script handles naming differences between `cli_tools` and actual binaries:
+- Windows extensions: `.exe`, `.cmd`, `.bat`
+- Hyphen-to-underscore: `typedb-console` → `typedb_console`, `typedb_console_bin`
+- Searches recursively through the entire extracted archive (handles `bin/`, root, and custom paths like TypeDB's `server/` and `console/`).
+
+**Used by:** all 21 release workflows. Add a "Validate required binaries" step in each workflow's `release` job, after artifact preparation and before "Create Release":
+
+```yaml
+- name: Validate required binaries
+  run: |
+    chmod +x builds/common/validate-binaries.sh
+    ./builds/common/validate-binaries.sh <database-id> ./release-assets
+```
+
+### `fix-macos-dylibs.sh <package-root>`
+
+macOS source builds that link against Homebrew (OpenSSL, pcre2, etc.) produce binaries with absolute paths like `/opt/homebrew/opt/openssl@3/lib/libssl.3.dylib`. These break on any Mac without those exact Homebrew packages installed.
+
+The script makes packages relocatable by:
+
+1. Bundling Homebrew dylibs into the package's `lib/` directory.
+2. Rewriting all absolute paths to `@loader_path` relative references.
+3. Re-signing modified binaries (macOS requires this after `install_name_tool` changes).
+4. Verifying no Homebrew paths remain (fails the build if any found).
+
+**When to use:** Add to any release workflow's macOS build step if the database links against Homebrew libraries at build time. Insert between metadata creation and tarball creation:
+
+```bash
+chmod +x "$GITHUB_WORKSPACE/builds/common/fix-macos-dylibs.sh"
+"$GITHUB_WORKSPACE/builds/common/fix-macos-dylibs.sh" "$GITHUB_WORKSPACE/install/<database>"
+```
+
+**Currently used by:** MariaDB, Redis, Valkey, CouchDB. PostgreSQL-DocumentDB has its own inline implementation (see `builds/postgresql-documentdb/build-macos.sh`).
+
+### `check-macos-dylibs.sh [<path>]`
+
+Diagnostic — scans packages for non-relocatable Homebrew paths without modifying anything. Runs locally via `pnpm check:dylibs [-- <path>]`. The `audit-dylibs` workflow (`workflow_dispatch`) audits published releases on R2.
+
+---
+
+## macOS native build reference
+
+Native macOS builds (darwin-x64, darwin-arm64) require careful SDK configuration and dylib path rewriting. This section is the general reference; per-engine specifics live in each engine's build script.
+
+### SDK conflict: Xcode vs Command Line Tools
+
+**The problem.** CMake can find libraries from Command Line Tools (`/Library/Developer/CommandLineTools/SDKs/`) while using Xcode's SDK for compilation. This causes C++ header search-path errors like:
+
+```
+error: <cstddef> tried including <stddef.h> but didn't find libc++'s <stddef.h> header.
+```
+
+**The fix.** Force all tools to use a single SDK by:
+
+1. `sudo xcode-select -s /Applications/Xcode.app/Contents/Developer` (not Command Line Tools).
+2. Export `SDKROOT`, `CC`, `CXX`, `CFLAGS`, `CXXFLAGS`, `LDFLAGS` with `--sysroot`.
+3. Use `CMAKE_FIND_ROOT_PATH` to restrict library search to Xcode SDK + Homebrew only.
+4. Run cmake via `xcrun` to inherit the correct environment.
+
+See `release-mariadb.yml` for a working example of this configuration.
+
+### Why build from source instead of Homebrew?
+
+Homebrew binaries have **hardcoded absolute paths** (e.g., `/opt/homebrew/lib/libssl.3.dylib`). For relocatable binaries that work on any machine:
+
+1. Build the database from source with relative paths.
+2. Build any extensions (PostGIS, DocumentDB) from source against that build.
+3. Bundle all Homebrew dependencies and rewrite their paths.
+
+### macOS dylib path prefixes
+
+| Prefix | Meaning | When to use |
+|---|---|---|
+| `@rpath` | Search paths defined in the binary's LC_RPATH | Libraries that could be in multiple locations |
+| `@loader_path` | Directory containing the loading binary | Bundled libraries next to executables |
+| `@executable_path` | Directory containing the main executable | App bundles |
+
+**`fix-macos-dylibs.sh` uses `@loader_path`** because hostdb tarballs ship the binary and its dylibs side-by-side in `bin/` and `lib/`.
+
+### Workflow for making binaries relocatable
+
+1. **Copy dependencies recursively** — use `otool -L` to find dependencies; copy non-system libs into the bundle.
+2. **Handle `@rpath` references** — resolve by searching Homebrew locations (`/opt/homebrew/lib`, `/usr/local/lib`).
+3. **Rewrite paths with `install_name_tool`:**
+
+   ```bash
+   # Change library's own ID
+   install_name_tool -id "@loader_path/libfoo.dylib" libfoo.dylib
+
+   # Change a reference to another library
+   install_name_tool -change "/opt/homebrew/lib/libbar.dylib" "@loader_path/libbar.dylib" libfoo.dylib
+
+   # Add rpath
+   install_name_tool -add_rpath "@loader_path" binary
+
+   # Remove Homebrew rpaths
+   install_name_tool -delete_rpath "/opt/homebrew/lib" binary
+   ```
+
+4. **Re-sign after modification** — macOS requires code signing after any binary modification:
+
+   ```bash
+   codesign -s - --force --preserve-metadata=entitlements,requirements,flags,runtime binary
+   ```
+
+### Recursive dependency bundling
+
+Libraries have transitive dependencies. A recursive routine is needed:
+
+```bash
+copy_lib_recursive() {
+  local lib_path="$1"
+  # Skip system libraries (/usr/lib/*, /System/*)
+  # Skip already-processed libraries (track in a file)
+  # Copy to bundle if from Homebrew
+  # Recursively process dependencies from otool -L
+  # Handle @rpath references by searching known locations
+  # Handle @loader_path references relative to library directory
+}
+```
+
+**Don't miss extension dylibs.** If an engine has a `lib/postgresql/` (or similar) subdirectory of extension dylibs, scan it too — extension dylibs can reference Homebrew libraries that aren't dependencies of anything in `bin/`. The bundler must follow them or `dlopen` fails at runtime. See `builds/postgresql-documentdb/build-macos.sh` step 10 for the reference implementation.
+
+---
+
+## Linux ARM64 builds (QEMU)
+
+ARM64 Linux builds use QEMU emulation on x64 runners:
+
+- Build times: 45–90+ minutes (vs 3–5 minutes for native).
+- Builds can appear "frozen" during long compilation steps — that's normal.
+- Use `docker buildx` with `--platform linux/arm64`.
+
+---
+
+## Workflow concurrency
+
+Release workflows use concurrency groups to prevent conflicts:
+
+```yaml
+concurrency:
+  group: release-<engine>
+  cancel-in-progress: false
+```
+
+Only one build runs at a time per engine — subsequent triggers are queued, not cancelled.

--- a/builds/redis/sources.json
+++ b/builds/redis/sources.json
@@ -61,6 +61,26 @@
         "sourceType": "redis-windows",
         "sha256": "195be9d6de498825373010a321c4aeac4d88437e31964767ac7fc2dc45c50d75"
       }
+    },
+    "7.2.14": {
+      "linux-x64": {
+        "sourceType": "build-required"
+      },
+      "linux-arm64": {
+        "sourceType": "build-required"
+      },
+      "darwin-x64": {
+        "sourceType": "build-required"
+      },
+      "darwin-arm64": {
+        "sourceType": "build-required"
+      },
+      "win32-x64": {
+        "url": "https://github.com/redis-windows/redis-windows/releases/download/7.2.14/Redis-7.2.14-Windows-x64-msys2.zip",
+        "format": "zip",
+        "sourceType": "redis-windows",
+        "sha256": "b31d0f867608017f0b0962624d55a4c569a745587ad4b08f7fe9eea59d6916c1"
+      }
     }
   },
   "notes": {

--- a/databases.json
+++ b/databases.json
@@ -770,19 +770,28 @@
       "description": "In-memory data store used as database, cache, and message broker",
       "type": "Key-Value",
       "sourceRepo": "https://github.com/redis/redis",
-      "license": "RSALv2/SSPLv1 (7.4+), AGPL-3.0 (8.0+)",
+      "license": "BSD-3-Clause (7.2.x), RSALv2/SSPLv1 (7.4+), AGPL-3.0 (8.0+)",
       "commercialUse": true,
       "hostedServiceAllowed": false,
       "protocol": null,
-      "note": "RSALv2 restricts building competing products to Redis itself. AGPL-3.0 (8.0+) requires source disclosure if you modify Redis and offer it as a network service. Commercial use in applications, local dev, and internal use is fine. Valkey available as BSD-licensed drop-in alternative.",
+      "note": "Redis 7.2.x is BSD-3-Clause licensed — fully open-source, safe to host as a managed service. The 7.4+ relicense (RSALv2/SSPLv1) restricts building competing managed services to Redis itself; AGPL-3.0 (8.0+) additionally requires source disclosure if you modify Redis and offer it as a network service. Commercial use in applications, local dev, and internal use is fine on all versions. Valkey is a BSD-licensed drop-in alternative for newer Redis features.",
       "defaults": {
-        "7": "7.4.9",
+        "7": "7.2.14",
         "8": "8.4.0"
       },
       "versions": {
         "8.4.0": true,
-        "7.4.9": true,
-        "7.4.7": true
+        "7.4.9": {
+          "deprecated": true,
+          "note": "Deprecated; RSALv2/SSPLv1 license forbids offering Redis as a competing managed service. Use 7.2.14 (BSD) for managed-service use cases, or stay on 7.4.9 only for self-contained app use."
+        },
+        "7.4.7": {
+          "deprecated": true,
+          "note": "Deprecated; RSALv2/SSPLv1 license forbids offering Redis as a competing managed service. Use 7.2.14 (BSD) for managed-service use cases, or 7.4.9 if you need the latest 7.4 patch for self-contained app use."
+        },
+        "7.2.14": {
+          "note": "Latest patch in the BSD-3-Clause 7.2.x line — the newest Redis version permissively licensed for self-hosting as a managed/DBaaS service. 7.4+ (RSALv2/SSPLv1) forbids competing managed services; 8.0+ AGPL-3.0 requires source disclosure to network users."
+        }
       },
       "platforms": [
         "linux-x64",

--- a/databases.yml
+++ b/databases.yml
@@ -636,18 +636,29 @@ databases:
     description: In-memory data store used as database, cache, and message broker
     type: Key-Value
     source_repo: https://github.com/redis/redis
-    license: RSALv2/SSPLv1 (7.4+), AGPL-3.0 (8.0+)
+    license: BSD-3-Clause (7.2.x), RSALv2/SSPLv1 (7.4+), AGPL-3.0 (8.0+)
     commercial_use: true
     hosted_service_allowed: false
     protocol: null
-    note: RSALv2 restricts building competing products to Redis itself. AGPL-3.0 (8.0+) requires source disclosure if you modify Redis and offer it as a network service. Commercial use in applications, local dev, and internal use is fine. Valkey available as BSD-licensed drop-in alternative.
+    note: Redis 7.2.x is BSD-3-Clause licensed — fully open-source, safe to host as a managed service. The 7.4+ relicense (RSALv2/SSPLv1) restricts building competing managed services to Redis itself; AGPL-3.0 (8.0+) additionally requires source disclosure if you modify Redis and offer it as a network service. Commercial use in applications, local dev, and internal use is fine on all versions. Valkey is a BSD-licensed drop-in alternative for newer Redis features.
+    # TODO(managed-service): 8.x is dual-licensed RSALv2/SSPLv1/AGPL-3.0. AGPL alone (ignoring
+    # the other two options) MIGHT be workable for a managed-service offering, but it requires
+    # publishing source of any modifications + arguably the surrounding management stack to
+    # network users. Worth a legal review before flipping. For now we're defaulting to 7.2.14
+    # (BSD) so hostedServiceAllowed:true downstream is unambiguous.
     defaults:
-      "7": "7.4.9"
+      "7": "7.2.14"
       "8": "8.4.0"
     versions:
       8.4.0: true
-      7.4.9: true
-      7.4.7: true
+      7.4.9:
+        deprecated: true
+        note: Deprecated; RSALv2/SSPLv1 license forbids offering Redis as a competing managed service. Use 7.2.14 (BSD) for managed-service use cases, or stay on 7.4.9 only for self-contained app use.
+      7.4.7:
+        deprecated: true
+        note: Deprecated; RSALv2/SSPLv1 license forbids offering Redis as a competing managed service. Use 7.2.14 (BSD) for managed-service use cases, or 7.4.9 if you need the latest 7.4 patch for self-contained app use.
+      7.2.14:
+        note: Latest patch in the BSD-3-Clause 7.2.x line — the newest Redis version permissively licensed for self-hosting as a managed/DBaaS service. 7.4+ (RSALv2/SSPLv1) forbids competing managed services; 8.0+ AGPL-3.0 requires source disclosure to network users.
     platforms:
       - linux-x64
       - linux-arm64

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hostdb",
-  "version": "0.31.2",
+  "version": "0.32.0",
   "description": "Pre-built database binaries for multiple platforms, plus a typed registry library for resolving versions and download URLs offline.",
   "private": false,
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hostdb",
-  "version": "0.31.1",
+  "version": "0.31.2",
   "description": "Pre-built database binaries for multiple platforms, plus a typed registry library for resolving versions and download URLs offline.",
   "private": false,
   "type": "module",

--- a/releases.json
+++ b/releases.json
@@ -1368,7 +1368,8 @@
             "sha256": "f6f3886f8b3427867a39cabc613489cf6bd98191c995a73c077aa9aa2d5e004a",
             "size": 11489268
           }
-        }
+        },
+        "deprecated": true
       },
       "7.4.7": {
         "version": "7.4.7",
@@ -1400,7 +1401,8 @@
             "sha256": "8846aaf20860063263542ebf535bc874e475a17f82e5e4aee9540958abf583cf",
             "size": 11481934
           }
-        }
+        },
+        "deprecated": true
       }
     },
     "sqlite": {

--- a/scripts/prep.ts
+++ b/scripts/prep.ts
@@ -303,10 +303,11 @@ ${colors.yellow}Checks:${colors.reset}
   1. Generate databases.json from databases.yml
   2. Type checking (tsc --noEmit)
   3. Linting (eslint)
-  4. Workflow version sync (sync:versions --check)
-  5. Missing checksums detection
-  6. Build releases.json from GitHub releases
-  7. Check for discrepancies between databases.json and releases.json
+  4. Tests (node --test tests/*.test.ts — includes the defaults-sync snapshot)
+  5. Workflow version sync (sync:versions --check)
+  6. Missing checksums detection
+  7. Build releases.json from GitHub releases
+  8. Check for discrepancies between databases.json and releases.json
 `)
     process.exit(0)
   }
@@ -345,7 +346,13 @@ ${colors.yellow}Checks:${colors.reset}
     runCommand('pnpm prettier --write .', 'Formatting', { allowFailure: true })
   }
 
-  // 5. Sync workflow versions
+  // 5. Tests (includes defaults-sync snapshot — catches policy changes
+  // before they reach CI, e.g. when defaults block keys are repointed)
+  if (!runCommand('pnpm test', 'Tests')) {
+    allPassed = false
+  }
+
+  // 6. Sync workflow versions
   const syncCmd = checkOnly
     ? 'pnpm sync:versions --check'
     : 'pnpm sync:versions'

--- a/tests/defaults-sync.test.ts
+++ b/tests/defaults-sync.test.ts
@@ -151,10 +151,15 @@ const SNAPSHOT: Record<string, Record<string, string>> = {
     '9.2.3': '9.2.3',
   },
   redis: {
-    '7': '7.4.9',
+    // 0.32.0 policy change: '7' now resolves to 7.2.14 (BSD-3-Clause) instead of
+    // 7.4.9 (RSALv2/SSPLv1) so managed-service consumers get the open-source line
+    // by default. 7.4.x entries kept — deprecated versions still resolve.
+    '7': '7.2.14',
     '8': '8.4.0',
+    '7.2': '7.2.14',
     '7.4': '7.4.9',
     '8.4': '8.4.0',
+    '7.2.14': '7.2.14',
     '7.4.7': '7.4.7',
     '7.4.9': '7.4.9',
     '8.4.0': '8.4.0',


### PR DESCRIPTION
## Summary

This PR has grown — originally opened for the 0.31.2 docs reshuffle, now bumped to **0.32.0** to bundle the Redis 7.2.14 work.

- **Redis 7.2.14 added** — latest patch in the BSD-3-Clause 7.2.x line. Built and uploaded to R2 via run [26341087625](https://github.com/robertjbass/hostdb/actions/runs/26341087625). All 5 platform artifacts live at `registry.layerbase.host/redis-7.2.14/*`.
- **Redis defaults policy flipped:** `defaults["7"]: 7.4.9 → 7.2.14`. `resolveVersion('redis', '7')` now returns the BSD-licensed version. Minor bump (not patch) per the project rule: defaults block changes are user-visible policy.
- **Redis 7.4.9 and 7.4.7 deprecated** — RSALv2/SSPLv1 forbids competing managed services. R2 binaries remain hosted; workflow dropdown skips them; `isVersionDeprecated()` returns true.
- **RabbitMQ added to PROSPECTS.md** as a planned engine (analysis only, no build target yet).
- **Bundled: 0.31.2 docs reshuffle** (`bfc3c3d` CLAUDE.md slim + `c9ddae1` 0.31.2 release commit). 0.31.2 was committed to dev but never merged — npm is still at 0.31.1. After this merge, `publish.yml` will publish 0.32.0 directly. CHANGELOG retains both \[0.31.2] and \[0.32.0] entries so the history isn't lost.

## Coordination cascade (after merge)

Per UPGRADE_PLAYBOOK.md publish cascade order:

1. Merge this PR → \`publish.yml\` fires → npm publishes \`hostdb@0.32.0\` via OIDC.
2. Verify with \`npm view hostdb version\`.
3. Bump \`hostdb\` exact-pin in \`spindb/package.json\` to \`0.32.0\`. (Wrapper for \`version-maps.ts\` auto-rebuilds.)
4. Flip \`defaultVersion: '7.2'\` and \`hostedServiceAllowed: true\` for Redis in spindb's \`engine-registry.ts\`.
5. Bump \`SPINDB_VERSION\` in \`layerbase-cloud/images/Dockerfile.base\`.
6. Bump \`spindb\` pin in \`layerbase-desktop/package.json\` on next desktop release.

## Test plan

- [x] release-redis workflow green (5 platform artifacts in GitHub Release \`redis-7.2.14\`)
- [x] R2 upload verified (HTTP 200 on \`https://registry.layerbase.host/redis-7.2.14/redis-7.2.14-darwin-arm64.tar.gz\`)
- [x] \`releases.json\` on main has 7.2.14 with all 5 platform URLs + SHA256s
- [x] \`releases.json\` retains \`deprecated: true\` on 7.4.7 and 7.4.9 after the merge
- [x] \`pnpm prep\` passes locally (54 versions, no missing-release warnings)
- [ ] After merge: \`npm view hostdb version\` shows 0.32.0
- [ ] After publish: \`hostdb redis 7\` resolves to 7.2.14 via the bundled snapshot
- [ ] Smoke test the 7.2.14 darwin-arm64 binary (download, redis-server start, redis-cli ping)