### PR TITLE
perf(mysql): re-host linux-x64 as minimal builds (0.33.1)

### DIFF
--- a/.github/workflows/rebuild-minimal-mysql.yml
+++ b/.github/workflows/rebuild-minimal-mysql.yml
@@ -1,0 +1,141 @@
+name: Rebuild Minimal MySQL (linux-x64)
+
+# Re-hosts MySQL linux-x64 binaries as the smaller vendor `-minimal` build by
+# overwriting the canonical R2 object.
+#
+# Why overwrite (not a new URL): spindb constructs binary URLs from a fixed
+# template (registry.layerbase.host/mysql-{ver}/mysql-{ver}-linux-x64.tar.gz)
+# and ignores releases.json's `url`, so the minimal must live at that exact key.
+# spindb never verifies sha256/size, and its post-download check just runs
+# `mysqld --version`, so replacing the object is transparent to every pinned
+# consumer - no hostdb/spindb/layerbase-cloud version bump required.
+#
+# Safety: each binary is BUILT and round-trip-tested (init -> mysqldump backup ->
+# mysql restore -> verify) before the canonical object is overwritten, and the
+# original is backed up to `_backup/<key>` first (revert via the script's
+# --restore mode). Only versions with a vendor `-minimal` are eligible:
+# 8.4.9 and 9.6.0 (8.4.3 has none; 8.0.40/9.1.0/9.5.0 are deprecated).
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'rehost = swap in the minimal build; restore = revert to the backed-up original'
+        required: true
+        type: choice
+        options:
+          - rehost
+          - restore
+        default: rehost
+      version:
+        description: 'MySQL version (linux-x64)'
+        required: true
+        type: choice
+        options:
+          - all
+          - 9.6.0
+          - 8.4.9
+        default: all
+      skip_backup:
+        description: 'Skip backing up the existing R2 object (rehost mode only; NOT recommended)'
+        required: false
+        type: boolean
+        default: false
+
+# Never let two re-host runs race on the same R2 keys.
+concurrency:
+  group: rebuild-minimal-mysql
+  cancel-in-progress: false
+
+jobs:
+  rehost:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build/test/re-host (or restore) minimal linux-x64
+        env:
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_BUCKET_NAME: ${{ secrets.R2_BUCKET_NAME }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+        run: |
+          set -euo pipefail
+
+          MODE="${{ github.event.inputs.mode }}"
+          SELECTED="${{ github.event.inputs.version }}"
+          if [ "$SELECTED" = "all" ]; then
+            VERSIONS="9.6.0 8.4.9"
+          else
+            VERSIONS="$SELECTED"
+          fi
+
+          BACKUP_FLAG=""
+          if [ "${{ github.event.inputs.skip_backup }}" = "true" ]; then
+            BACKUP_FLAG="--no-backup"
+          fi
+
+          chmod +x builds/mysql/test-roundtrip.sh
+
+          for V in $VERSIONS; do
+            FILE="./dist/mysql-$V-linux-x64.tar.gz"
+
+            # RESTORE mode: copy the backed-up original back over the canonical
+            # key (no build/test, just reverts).
+            if [ "$MODE" = "restore" ]; then
+              echo "::group::mysql $V - RESTORE original from _backup/"
+              pnpm tsx scripts/rehost-minimal-r2.ts \
+                --tag "mysql-$V" --filename "mysql-$V-linux-x64.tar.gz" --restore
+              echo "::endgroup::"
+              continue
+            fi
+
+            echo "::group::mysql $V - build minimal linux-x64"
+            rm -rf ./dist
+            pnpm download:mysql -- --version "$V" --platform linux-x64 --output ./dist
+            test -f "$FILE" || { echo "::error::artifact not built: $FILE"; exit 1; }
+            ls -la ./dist
+            echo "::endgroup::"
+
+            # The ubuntu-latest runner is x86_64 with Docker, so the linux/amd64
+            # round-trip runs natively (fast). Fails the job before any R2 write
+            # if backup/restore doesn't work on the minimal build.
+            echo "::group::mysql $V - round-trip test (backup + restore)"
+            ./builds/mysql/test-roundtrip.sh "$FILE" linux-x64
+            echo "::endgroup::"
+
+            echo "::group::mysql $V - re-host to R2 (backup + overwrite + purge)"
+            pnpm tsx scripts/rehost-minimal-r2.ts --tag "mysql-$V" --file "$FILE" $BACKUP_FLAG
+            echo "::endgroup::"
+          done
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "## Rebuild Minimal MySQL"
+            echo ""
+            echo "Re-hosted linux-x64 minimal build(s) over the canonical R2 key."
+            echo ""
+            echo "- Originals backed up to \`_backup/<key>\` (unless skip_backup)."
+            echo "- No version bumps needed - spindb constructs the same URL and gets the smaller binary on next download."
+            echo "- releases.json size/sha metadata is intentionally NOT synced (cosmetic; nothing reads it for the download). Re-run the full Release MySQL workflow if you want the GitHub release + releases.json to match."
+            echo "- Revert: \`pnpm tsx scripts/rehost-minimal-r2.ts --tag mysql-<ver> --filename mysql-<ver>-linux-x64.tar.gz --restore\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.33.1] - 2026-06-05
+
+### Changed
+
+- **MySQL 8.4.9 and 9.6.0 `linux-x64` re-hosted as the official MySQL `-minimal` build.** The re-hosted tarballs shrink from ~872 MB → ~135 MB (8.4.9) and ~1042 MB → ~138 MB (9.6.0) — an ~84% cut. MySQL's `-minimal` distribution removes only never-executed artifacts (the `mysql-test/` suite, debug binaries, debug plugins, and static `.a` libraries) and keeps the entire `bin/` (every CLI tool), all runtime plugins, the bundled OpenSSL/SASL libraries, and the charset/error-message data. The four binaries spindb and layerbase-cloud invoke — `mysqld`, `mysql`, `mysqldump`, `mysqladmin` — are all present, and a full `spindb create → seed → backup → restore → verify` end-to-end run passed on both versions. `resolveVersion` output is unchanged (same inputs resolve to the same full versions); only the `linux-x64` binary payload and its `releases.json` size/sha change.
+
+### Notes
+
+- **`linux-x64` only.** MySQL publishes a `-minimal` build for `x86_64` (glibc2.28 — the same runtime floor as the full tarball, so no new compatibility requirement) but not for `aarch64`, macOS, or Windows, which are unchanged. MySQL 8.4.3 (no vendor `-minimal` available) and the deprecated versions (8.0.40, 9.1.0, 9.5.0) are also unchanged.
+- R2 retains the prior full binaries (`_backup/`), so already-cached containers keep working; new downloads pull the minimal.
+
+### Coordination notes
+
+This is a **patch** bump (0.33.0 → 0.33.1): a binary re-host only, with no `defaults`/resolver change. The downstream exact-pin cascade still applies — bump spindb's `hostdb` pin to 0.33.1 and run its test matrix (the MySQL integration test downloads the minimal and exercises it), then `SPINDB_VERSION` in layerbase-cloud and the `spindb` pin in layerbase-desktop.
+
 ## [0.33.0] - 2026-06-03
 
 ### Added

--- a/builds/mysql/sources.json
+++ b/builds/mysql/sources.json
@@ -4,9 +4,9 @@
   "versions": {
     "9.6.0": {
       "linux-x64": {
-        "url": "https://cdn.mysql.com/Downloads/MySQL-9.6/mysql-9.6.0-linux-glibc2.28-x86_64.tar.xz",
+        "url": "https://cdn.mysql.com/Downloads/MySQL-9.6/mysql-9.6.0-linux-glibc2.28-x86_64-minimal.tar.xz",
         "format": "tar.xz",
-        "sha256": "92271b67eb88cd74931f6bfc1f79edcf6a285508fc437c80d704b16512486374"
+        "sha256": "06ebd32ab32ccac2132c602ec3bfb4d5791b6ff9e98393b2fb04d1e97ff925b7"
       },
       "linux-arm64": {
         "url": "https://cdn.mysql.com/Downloads/MySQL-9.6/mysql-9.6.0-linux-glibc2.28-aarch64.tar.xz",
@@ -58,9 +58,9 @@
     },
     "8.4.9": {
       "linux-x64": {
-        "url": "https://cdn.mysql.com/Downloads/MySQL-8.4/mysql-8.4.9-linux-glibc2.28-x86_64.tar.xz",
+        "url": "https://cdn.mysql.com/Downloads/MySQL-8.4/mysql-8.4.9-linux-glibc2.28-x86_64-minimal.tar.xz",
         "format": "tar.xz",
-        "sha256": "4297fb5d7dfd3b2b2d405efcc44b834237cd5e0d5dbf9b2cb6e49f6b0152940b"
+        "sha256": "d0142fc30e04bae7f15a46567238adf8956acccd35c5bca6e448322644536e3d"
       },
       "linux-arm64": {
         "url": "https://cdn.mysql.com/Downloads/MySQL-8.4/mysql-8.4.9-linux-glibc2.28-aarch64.tar.xz",
@@ -142,6 +142,9 @@
     "glibc": "Linux binaries require glibc 2.28+ (Ubuntu 20.04+, Debian 10+, RHEL 8+)",
     "macos": "macOS binaries target macos14 (Sonoma) for 8.x versions; MySQL 9.5.0+ targets macos15 (Sequoia). Binaries may work on earlier macOS versions.",
     "deprecated": "Versions 8.0.40, 9.1.0, and 9.5.0 are deprecated. Existing binaries are retained but no new builds will be triggered.",
-    "cdn": "Use cdn.mysql.com/archives/ for direct downloads (dev.mysql.com redirects require auth)"
+    "cdn": "Use cdn.mysql.com/archives/ for direct downloads (dev.mysql.com redirects require auth)",
+    "minimal-builds": "linux-x64 (8.4.9, 9.6.0) uses MySQL's official -minimal tarball: test suite, debug binaries, and static libs removed, all CLI tools (mysqld/mysql/mysqldump/mysqladmin) retained. Cuts re-hosted size ~6x. Only x86_64 has a vendor -minimal (no aarch64/macOS/Windows). 8.4.3 has no minimal; 8.0.40/9.1.0/9.5.0 are deprecated. Validate any minimal swap with builds/mysql/test-roundtrip.sh before publishing.",
+    "8.4.9-linux-x64-full-revert": "REVERT: set versions.8.4.9.linux-x64 back to url=https://cdn.mysql.com/Downloads/MySQL-8.4/mysql-8.4.9-linux-glibc2.28-x86_64.tar.xz sha256=4297fb5d7dfd3b2b2d405efcc44b834237cd5e0d5dbf9b2cb6e49f6b0152940b",
+    "9.6.0-linux-x64-full-revert": "REVERT: set versions.9.6.0.linux-x64 back to url=https://cdn.mysql.com/Downloads/MySQL-9.6/mysql-9.6.0-linux-glibc2.28-x86_64.tar.xz sha256=92271b67eb88cd74931f6bfc1f79edcf6a285508fc437c80d704b16512486374"
   }
 }

--- a/builds/mysql/test-roundtrip.sh
+++ b/builds/mysql/test-roundtrip.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+#
+# Functional round-trip test for a re-wrapped MySQL tarball.
+#
+# Proves that the four binaries spindb actually uses all work against a freshly
+# initialized server:
+#   mysqld     -> initialize + start
+#   mysql      -> create/insert + RESTORE (pipe SQL in)
+#   mysqldump  -> BACKUP
+#   mysqladmin -> shutdown
+#
+# This is the guard against the "minimal build dropped a needed binary" failure
+# mode (the pg_dump/pg_restore incident). If this exits 0, backup+restore work.
+#
+# linux-x64 binaries are exercised inside a linux/amd64 container (so it runs on
+# an Apple Silicon host via Docker's emulation). Requires Docker to be running.
+#
+# Usage:
+#   ./builds/mysql/test-roundtrip.sh <path-to-tarball> [platform]
+#     platform defaults to linux-x64
+#
+# Example:
+#   ./builds/mysql/test-roundtrip.sh downloads/mysql-8.4.9-linux-x64.tar.gz linux-x64
+
+set -euo pipefail
+
+TARBALL="${1:?usage: test-roundtrip.sh <tarball> [platform]}"
+PLATFORM="${2:-linux-x64}"
+
+if [ ! -f "$TARBALL" ]; then
+  echo "ERROR: tarball not found: $TARBALL" >&2
+  exit 1
+fi
+
+ABS_TARBALL="$(cd "$(dirname "$TARBALL")" && pwd)/$(basename "$TARBALL")"
+TARBALL_DIR="$(dirname "$ABS_TARBALL")"
+TARBALL_NAME="$(basename "$ABS_TARBALL")"
+
+case "$PLATFORM" in
+  linux-x64)   DOCKER_PLATFORM="linux/amd64" ;;
+  linux-arm64) DOCKER_PLATFORM="linux/arm64" ;;
+  *)
+    echo "ERROR: this harness only runs linux-* tarballs (got: $PLATFORM)." >&2
+    echo "       macOS/Windows must be tested natively." >&2
+    exit 1
+    ;;
+esac
+
+if ! docker info >/dev/null 2>&1; then
+  echo "ERROR: Docker is not running. Start Docker Desktop and retry." >&2
+  exit 1
+fi
+
+echo "=== MySQL round-trip test ==="
+echo "  tarball:  $TARBALL_NAME"
+echo "  platform: $PLATFORM ($DOCKER_PLATFORM)"
+echo
+
+# The in-container test script. Extracts the tarball, initializes a server,
+# round-trips a small dataset through mysqldump -> mysql, and verifies the data
+# survived intact.
+CONTAINER_SCRIPT='
+set -euo pipefail
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -qq >/dev/null
+# MySQL glibc tarballs need libaio + libnuma at runtime; ncurses for the client;
+# xz-utils so tar can read .tar.xz inputs.
+apt-get install -y -qq libaio1 libnuma1 libncurses6 xz-utils >/dev/null
+
+WORK=/work
+BASE=$WORK/mysql
+DATA=$WORK/data
+mkdir -p "$BASE" "$DATA"
+
+echo "[extract] $TARBALL_NAME"
+tar xf "/input/$TARBALL_NAME" -C "$BASE" --strip-components=1
+
+echo "[assert ] required binaries present + executable"
+for b in mysqld mysql mysqldump mysqladmin; do
+  if [ ! -x "$BASE/bin/$b" ]; then
+    echo "FAIL: missing or non-executable bin/$b" >&2
+    exit 1
+  fi
+done
+
+echo "[init   ] mysqld --initialize-insecure"
+"$BASE/bin/mysqld" --no-defaults --basedir="$BASE" --datadir="$DATA" \
+  --user=root --initialize-insecure --log-error="$WORK/init.log" \
+  || { echo "FAIL: initialize"; cat "$WORK/init.log" 2>/dev/null; exit 1; }
+
+echo "[start  ] mysqld (127.0.0.1:3399)"
+"$BASE/bin/mysqld" --no-defaults --basedir="$BASE" --datadir="$DATA" \
+  --user=root --bind-address=127.0.0.1 --port=3399 \
+  --socket="$WORK/mysql.sock" --mysqlx=OFF --log-error="$WORK/server.log" &
+SERVER_PID=$!
+
+ok=0
+for i in $(seq 1 60); do
+  if "$BASE/bin/mysqladmin" -h 127.0.0.1 -P 3399 -u root ping >/dev/null 2>&1; then
+    ok=1; break
+  fi
+  sleep 1
+done
+if [ "$ok" != "1" ]; then
+  echo "FAIL: server never became ready" >&2
+  cat "$WORK/server.log" 2>/dev/null
+  exit 1
+fi
+
+CONN="-h 127.0.0.1 -P 3399 -u root"
+
+echo "[seed   ] create db + 3 rows"
+"$BASE/bin/mysql" $CONN -e "CREATE DATABASE t; USE t; CREATE TABLE x(id INT PRIMARY KEY, v VARCHAR(64)); INSERT INTO x VALUES (1,\"alpha\"),(2,\"beta\"),(3,\"gamma\");"
+
+echo "[backup ] mysqldump --set-gtid-purged=OFF t > dump.sql"
+"$BASE/bin/mysqldump" $CONN --set-gtid-purged=OFF t > "$WORK/dump.sql"
+test -s "$WORK/dump.sql" || { echo "FAIL: empty dump"; exit 1; }
+
+echo "[restore] drop db, then mysql t < dump.sql"
+"$BASE/bin/mysql" $CONN -e "DROP DATABASE t; CREATE DATABASE t;"
+"$BASE/bin/mysql" $CONN t < "$WORK/dump.sql"
+
+echo "[verify ] row count + values"
+COUNT=$("$BASE/bin/mysql" $CONN -N -e "SELECT COUNT(*) FROM t.x")
+VALS=$("$BASE/bin/mysql" $CONN -N -e "SELECT GROUP_CONCAT(v ORDER BY id) FROM t.x")
+
+"$BASE/bin/mysqladmin" $CONN shutdown >/dev/null 2>&1 || kill "$SERVER_PID" 2>/dev/null || true
+
+if [ "$COUNT" = "3" ] && [ "$VALS" = "alpha,beta,gamma" ]; then
+  echo "ROUNDTRIP_OK"
+else
+  echo "FAIL: data mismatch after restore (count=$COUNT vals=$VALS)" >&2
+  exit 1
+fi
+'
+
+set +e
+docker run --rm --platform "$DOCKER_PLATFORM" \
+  -v "$TARBALL_DIR":/input:ro \
+  -e TARBALL_NAME="$TARBALL_NAME" \
+  debian:bookworm-slim \
+  bash -c "$CONTAINER_SCRIPT"
+STATUS=$?
+set -e
+
+echo
+if [ "$STATUS" -eq 0 ]; then
+  echo "=== PASS: backup + restore round-trip succeeded on $PLATFORM ==="
+else
+  echo "=== FAIL (exit $STATUS): do NOT ship this tarball ===" >&2
+fi
+exit "$STATUS"

--- a/builds/mysql/test-spindb-e2e.sh
+++ b/builds/mysql/test-spindb-e2e.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+#
+# End-to-end test: spindb's OWN published CLI driving a hostdb minimal binary.
+#
+# Unlike test-roundtrip.sh (which drives the binaries directly), this installs
+# the real published `spindb`, pre-places the minimal at spindb's binary-cache
+# path (so spindb USES it instead of downloading the full from R2), and runs the
+# real product lifecycle as a NON-root user (mirroring prod's `gosu` user):
+#
+#   spindb create --start  ->  query (seed)  ->  backup  ->  restore  ->  verify
+#
+# If this prints SPINDB_E2E_OK, the actual product (and therefore layerbase-cloud,
+# which shells out to spindb) works with the minimal build. linux-x64 binaries
+# run in a linux/amd64 container (native on an amd64 host). Requires Docker.
+#
+# Usage: ./builds/mysql/test-spindb-e2e.sh <tarball> <version>
+#   e.g. ./builds/mysql/test-spindb-e2e.sh /tmp/.../mysql-8.4.9-linux-x64.tar.gz 8.4.9
+
+set -euo pipefail
+
+TARBALL="${1:?usage: test-spindb-e2e.sh <tarball> <version>}"
+VERSION="${2:?usage: test-spindb-e2e.sh <tarball> <version>}"
+[ -f "$TARBALL" ] || { echo "ERROR: tarball not found: $TARBALL" >&2; exit 1; }
+docker info >/dev/null 2>&1 || { echo "ERROR: Docker is not running." >&2; exit 1; }
+
+ABS="$(cd "$(dirname "$TARBALL")" && pwd)/$(basename "$TARBALL")"
+DIR="$(dirname "$ABS")"
+NAME="$(basename "$ABS")"
+
+echo "=== spindb end-to-end test (minimal binary) ==="
+echo "  tarball: $NAME"
+echo "  version: $VERSION"
+echo
+
+# Container script. Runs as root for setup (apt/npm/place binary), then runs the
+# spindb lifecycle as the unprivileged 'node' user. SQL uses integer columns
+# only, so there are no nested quotes to escape, and a distinctive marker-sum
+# (666666) proves all rows survived the restore.
+OUTER='
+set -euo pipefail
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -qq >/dev/null
+apt-get install -y -qq libaio1 libnuma1 libncurses6 >/dev/null
+
+echo "[setup] installing published spindb"
+npm install -g spindb >/tmp/npm.log 2>&1 || { echo "npm install spindb FAILED"; tail -30 /tmp/npm.log; exit 1; }
+echo "[setup] spindb $(spindb --version 2>/dev/null || echo "?"), node $(node --version)"
+
+BINDIR="/work/.spindb/bin/mysql-${VERSION}-linux-x64"
+mkdir -p "$BINDIR"
+tar xf "/input/${TARBALL_NAME}" -C "$BINDIR" --strip-components=1
+test -x "$BINDIR/bin/mysqld" || { echo "FAIL: mysqld not placed at $BINDIR/bin"; ls -R "$BINDIR" | head -20; exit 1; }
+echo "[setup] placed minimal $(du -sm "$BINDIR" | cut -f1)MB | $("$BINDIR/bin/mysqld" --version)"
+
+# Inner lifecycle runs as non-root (prod parity). ${VERSION} is baked in here.
+cat > /work/inner.sh <<INNER
+set -e
+export SPINDB_HOME=/work/.spindb
+export USER=node
+echo "[e2e] spindb create + start"
+spindb create appcon -e mysql --db-version ${VERSION} -d appdb -p 3399 --start -f --json
+echo "[e2e] spindb query: seed 3 rows"
+spindb query appcon "CREATE TABLE smoke(id INT PRIMARY KEY, marker INT); INSERT INTO smoke VALUES (1,111111),(2,222222),(3,333333);" -d appdb
+echo "[e2e] spindb backup"
+mkdir -p /work/backups
+spindb backup appcon -d appdb -o /work/backups --json
+echo "[e2e] spindb query: drop table"
+spindb query appcon "DROP TABLE smoke;" -d appdb
+echo "[e2e] locate backup file"
+BK=\$(find /work /root /home/node -maxdepth 4 -type f \( -name "*.sql" -o -name "*.sql.gz" -o -name "*.dump" -o -name "*.dump.gz" \) 2>/dev/null | head -1)
+echo "[e2e] backup file: \$BK"
+test -n "\$BK"
+echo "[e2e] spindb restore"
+spindb restore appcon "\$BK" -d appdb -f --json
+echo "[e2e] spindb query: verify (SUM of markers must be 666666)"
+spindb query appcon "SELECT SUM(marker) FROM smoke;" -d appdb | tee /work/q.out
+spindb stop appcon >/dev/null 2>&1 || true
+INNER
+
+chown -R node:node /work
+echo "[run] executing spindb lifecycle as non-root user (node)"
+su - node -c "bash /work/inner.sh"
+
+# Guard: prove spindb used our minimal and did NOT silently download the full.
+AFTER=$(du -sm "$BINDIR" | cut -f1)
+echo "[check] binary dir after run: ${AFTER}MB (minimal ~450MB; full would be ~3GB)"
+[ "$AFTER" -lt 800 ] || { echo "FAIL: binary grew to ${AFTER}MB - spindb downloaded the FULL build, test invalid"; exit 1; }
+
+grep -q "666666" /work/q.out || { echo "FAIL: data did not survive restore"; echo "--- query output ---"; cat /work/q.out; exit 1; }
+echo "SPINDB_E2E_OK"
+'
+
+set +e
+docker run --rm --platform linux/amd64 \
+  -v "$DIR":/input:ro \
+  -e TARBALL_NAME="$NAME" -e VERSION="$VERSION" \
+  node:22-bookworm bash -c "$OUTER"
+STATUS=$?
+set -e
+
+echo
+if [ "$STATUS" -eq 0 ]; then
+  echo "=== PASS: spindb end-to-end works on the minimal $VERSION linux-x64 build ==="
+else
+  echo "=== FAIL (exit $STATUS) ===" >&2
+fi
+exit "$STATUS"

--- a/lib/r2.ts
+++ b/lib/r2.ts
@@ -10,6 +10,7 @@ import {
   HeadObjectCommand,
   DeleteObjectCommand,
   ListObjectsV2Command,
+  CopyObjectCommand,
 } from '@aws-sdk/client-s3'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
@@ -108,6 +109,44 @@ export async function deleteFromR2(options: {
     new DeleteObjectCommand({
       Bucket: bucket,
       Key: key,
+    }),
+  )
+}
+
+/**
+ * Server-side copy of an R2 object (no download round-trip).
+ *
+ * By default the copy preserves the source object's metadata. Pass
+ * cacheControl/contentType to override them (used when restoring a backup
+ * over the canonical key, which must keep the immutable 1-year cache header).
+ */
+export async function copyR2Object(options: {
+  client: S3Client
+  bucket: string
+  sourceKey: string
+  destKey: string
+  cacheControl?: string
+  contentType?: string
+}): Promise<void> {
+  const { client, bucket, sourceKey, destKey, cacheControl, contentType } =
+    options
+
+  const overrideMetadata = Boolean(cacheControl || contentType)
+
+  await client.send(
+    new CopyObjectCommand({
+      Bucket: bucket,
+      // CopySource must be `<bucket>/<key>`, URL-encoded. encodeURI leaves the
+      // path separators and `-._` in our keys untouched.
+      CopySource: encodeURI(`${bucket}/${sourceKey}`),
+      Key: destKey,
+      ...(overrideMetadata
+        ? {
+            MetadataDirective: 'REPLACE' as const,
+            ...(cacheControl ? { CacheControl: cacheControl } : {}),
+            ...(contentType ? { ContentType: contentType } : {}),
+          }
+        : {}),
     }),
   )
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hostdb",
-  "version": "0.33.0",
+  "version": "0.33.1",
   "description": "Pre-built database binaries for multiple platforms, plus a typed registry library for resolving versions and download URLs offline.",
   "private": false,
   "type": "module",

--- a/scripts/rehost-minimal-r2.ts
+++ b/scripts/rehost-minimal-r2.ts
@@ -1,0 +1,275 @@
+#!/usr/bin/env tsx
+/**
+ * Re-host a pre-built "minimal" binary over its canonical R2 key.
+ *
+ * Why this exists: spindb builds binary download URLs from a fixed template
+ * (registry.layerbase.host/{engine}-{ver}/{engine}-{ver}-{platform}.tar.gz) and
+ * never reads the per-asset `url` from releases.json, nor verifies sha256/size.
+ * So the ONLY way to deliver a smaller binary without a spindb release is to
+ * replace the object sitting at that canonical key. This does it safely:
+ *
+ *   1. (default) back up the existing canonical object to `_backup/<key>`,
+ *      but only if no backup exists yet - so the TRUE original is preserved
+ *      even if this script is run multiple times.
+ *   2. upload the new (minimal) file over the canonical key (immutable cache).
+ *   3. purge the Cloudflare CDN cache for that URL.
+ *
+ * Reverse it with --restore: copies `_backup/<key>` back over `<key>` + purges.
+ *
+ * Usage:
+ *   pnpm tsx scripts/rehost-minimal-r2.ts --tag mysql-8.4.9 \
+ *     --file ./dist/mysql-8.4.9-linux-x64.tar.gz
+ *   pnpm tsx scripts/rehost-minimal-r2.ts --tag mysql-8.4.9 --file ... --no-backup
+ *   pnpm tsx scripts/rehost-minimal-r2.ts --tag mysql-8.4.9 \
+ *     --filename mysql-8.4.9-linux-x64.tar.gz --restore
+ *   pnpm tsx scripts/rehost-minimal-r2.ts --tag mysql-8.4.9 --file ... --dry-run
+ *
+ * Required env: R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY,
+ *               R2_BUCKET_NAME
+ * Optional env: CLOUDFLARE_API_TOKEN, CLOUDFLARE_ZONE_ID (for CDN purge)
+ */
+
+import { statSync, readFileSync, existsSync } from 'node:fs'
+import { basename } from 'node:path'
+import {
+  loadR2Config,
+  createR2Client,
+  uploadToR2,
+  objectExists,
+  copyR2Object,
+  purgeCloudflareCache,
+} from '../lib/r2.js'
+import { getDownloadUrl } from '../lib/registry.js'
+
+// Refuse to overwrite the canonical key with anything larger than this. A
+// minimal linux-x64 MySQL tarball is ~135-140 MB; a FULL one is ~870 MB+. This
+// guards against accidentally re-hosting a full build (e.g. if sources.json was
+// reverted) over the canonical key.
+const DEFAULT_MAX_SIZE_MB = 400
+
+const BACKUP_PREFIX = '_backup'
+
+type Args = {
+  tag: string
+  file: string | null
+  filename: string | null
+  restore: boolean
+  noBackup: boolean
+  dryRun: boolean
+  maxSizeMb: number
+}
+
+function parseArgs(): Args {
+  const argv = process.argv.slice(2)
+  const args: Args = {
+    tag: '',
+    file: null,
+    filename: null,
+    restore: false,
+    noBackup: false,
+    dryRun: false,
+    maxSizeMb: DEFAULT_MAX_SIZE_MB,
+  }
+
+  for (let i = 0; i < argv.length; i++) {
+    switch (argv[i]) {
+      case '--tag':
+        args.tag = argv[++i] ?? ''
+        break
+      case '--file':
+        args.file = argv[++i] ?? null
+        break
+      case '--filename':
+        args.filename = argv[++i] ?? null
+        break
+      case '--restore':
+        args.restore = true
+        break
+      case '--no-backup':
+        args.noBackup = true
+        break
+      case '--dry-run':
+        args.dryRun = true
+        break
+      case '--max-size-mb':
+        args.maxSizeMb = Number(argv[++i])
+        break
+      case '--':
+        break
+      case '--help':
+      case '-h':
+        console.log(
+          `Usage: rehost-minimal-r2.ts --tag <tag> (--file <path> | --filename <name>) [options]\n\n` +
+            `Options:\n` +
+            `  --tag TAG          Release tag / R2 folder (e.g. mysql-8.4.9)\n` +
+            `  --file PATH        Local artifact to upload (re-host mode)\n` +
+            `  --filename NAME    Asset name (defaults to basename of --file)\n` +
+            `  --restore          Restore _backup/<key> over <key> instead of uploading\n` +
+            `  --no-backup        Skip backing up the existing object (re-host mode)\n` +
+            `  --max-size-mb N    Reject uploads larger than N MB (default ${DEFAULT_MAX_SIZE_MB})\n` +
+            `  --dry-run          Print actions without touching R2\n`,
+        )
+        process.exit(0)
+    }
+  }
+
+  if (!args.tag) {
+    console.error('Error: --tag is required')
+    process.exit(1)
+  }
+  if (!args.restore && !args.file) {
+    console.error('Error: --file is required (or use --restore)')
+    process.exit(1)
+  }
+  if (!args.filename && !args.file) {
+    console.error('Error: --filename is required when --file is omitted')
+    process.exit(1)
+  }
+  if (!Number.isFinite(args.maxSizeMb) || args.maxSizeMb <= 0) {
+    console.error('Error: --max-size-mb must be a positive number')
+    process.exit(1)
+  }
+
+  return args
+}
+
+function contentTypeFor(name: string): string {
+  return name.endsWith('.zip') ? 'application/zip' : 'application/gzip'
+}
+
+const IMMUTABLE_CACHE = 'public, max-age=31536000, immutable'
+
+async function main() {
+  const args = parseArgs()
+  const assetName = args.filename ?? basename(args.file as string)
+  const key = `${args.tag}/${assetName}`
+  const backupKey = `${BACKUP_PREFIX}/${key}`
+  const url = getDownloadUrl(args.tag, assetName)
+  const contentType = contentTypeFor(assetName)
+
+  console.log(`Mode:        ${args.restore ? 'RESTORE' : 're-host'}`)
+  console.log(`Canonical:   ${key}`)
+  console.log(`Backup:      ${backupKey}`)
+  console.log(`URL:         ${url}`)
+
+  // Size guard / preview (re-host mode) - done before any R2 access so a bad
+  // input fails fast and --dry-run is usable without credentials.
+  let body: Buffer | null = null
+  if (!args.restore) {
+    const file = args.file as string
+    if (!existsSync(file)) {
+      console.error(`Error: file not found: ${file}`)
+      process.exit(1)
+    }
+    const sizeMb = statSync(file).size / 1024 / 1024
+    console.log(`File:        ${file} (${sizeMb.toFixed(1)} MB)`)
+    if (sizeMb > args.maxSizeMb) {
+      console.error(
+        `Error: ${sizeMb.toFixed(1)} MB exceeds --max-size-mb ${args.maxSizeMb}. ` +
+          `Refusing to overwrite the canonical key - is this actually the minimal build? ` +
+          `(check builds/mysql/sources.json points linux-x64 at the -minimal tarball)`,
+      )
+      process.exit(1)
+    }
+    body = readFileSync(file)
+  }
+
+  if (args.dryRun) {
+    console.log('\n[dry-run] would:')
+    if (args.restore) {
+      console.log(`  - copy ${backupKey} -> ${key} (immutable cache)`) // restore
+    } else {
+      if (!args.noBackup) {
+        console.log(`  - copy ${key} -> ${backupKey} (only if backup absent)`)
+      }
+      console.log(`  - put  ${key} (overwrite, immutable cache, ${contentType})`)
+    }
+    console.log(`  - purge CDN: ${url}`)
+    return
+  }
+
+  const config = loadR2Config()
+  const client = createR2Client(config)
+  const bucket = config.bucket
+
+  if (args.restore) {
+    const hasBackup = await objectExists({ client, bucket, key: backupKey })
+    if (!hasBackup) {
+      console.error(
+        `Error: no backup at ${backupKey} - nothing to restore. ` +
+          `(Backups are only created when re-hosting without --no-backup.)`,
+      )
+      process.exit(1)
+    }
+    console.log(`\nRestoring ${backupKey} -> ${key} ...`)
+    await copyR2Object({
+      client,
+      bucket,
+      sourceKey: backupKey,
+      destKey: key,
+      cacheControl: IMMUTABLE_CACHE,
+      contentType,
+    })
+    console.log('  restored.')
+  } else {
+    if (!args.noBackup) {
+      const canonicalExists = await objectExists({ client, bucket, key })
+      if (!canonicalExists) {
+        console.log('\nNo existing canonical object - nothing to back up.')
+      } else {
+        const backupExists = await objectExists({
+          client,
+          bucket,
+          key: backupKey,
+        })
+        if (backupExists) {
+          console.log(
+            `\nBackup already exists at ${backupKey} - leaving the original original intact.`,
+          )
+        } else {
+          console.log(`\nBacking up ${key} -> ${backupKey} ...`)
+          await copyR2Object({ client, bucket, sourceKey: key, destKey: backupKey })
+          console.log('  backed up.')
+        }
+      }
+    }
+
+    console.log(`\nUploading minimal -> ${key} (overwrite) ...`)
+    await uploadToR2({
+      client,
+      bucket,
+      key,
+      body: body as Buffer,
+      contentType,
+      cacheControl: IMMUTABLE_CACHE,
+    })
+    console.log('  uploaded.')
+  }
+
+  console.log(`\nPurging CDN cache for ${url} ...`)
+  const { purged, count } = await purgeCloudflareCache([url])
+  if (purged) {
+    console.log(`  purged ${count} URL.`)
+  } else {
+    console.log(
+      '  CDN purge SKIPPED (CLOUDFLARE_API_TOKEN/CLOUDFLARE_ZONE_ID not set). ' +
+        'The old binary may stay cached for up to a year - set those secrets to purge.',
+    )
+  }
+
+  console.log('\nDone.')
+  if (!args.restore && !args.noBackup) {
+    console.log(
+      `Revert with: pnpm tsx scripts/rehost-minimal-r2.ts --tag ${args.tag} --filename ${assetName} --restore`,
+    )
+    console.log(
+      `Note: the ${BACKUP_PREFIX}/ backup is not referenced by releases.json, so ` +
+        `do NOT run 'pnpm audit:r2-orphans --delete' while you rely on it for revert.`,
+    )
+  }
+}
+
+main().catch((error) => {
+  console.error('Error:', error instanceof Error ? error.message : error)
+  process.exit(1)
+})


### PR DESCRIPTION
## What

Re-hosts MySQL **8.4.9** and **9.6.0** `linux-x64` binaries as MySQL's official `-minimal` tarball.

| Version | Before | After |
|---|---|---|
| `mysql-8.4.9` linux-x64 | 872 MB | **135 MB** |
| `mysql-9.6.0` linux-x64 | 1042 MB | **138 MB** |

~84% smaller. Addresses the per-user binary-download bandwidth/disk issue tracked in layerbase-cloud's `plans/active/binary-download-bandwidth-and-mysql-trim.md`.

## Why it's safe

The `-minimal` build keeps the **entire `bin/`** (every CLI tool), all runtime plugins, the bundled OpenSSL/SASL libraries, and charset/error-message data. It drops only **never-executed** artifacts: the `mysql-test/` suite, debug binaries/plugins, and static `.a` libraries. `resolveVersion` output is unchanged (same inputs resolve to the same full versions).

The four binaries spindb and layerbase-cloud invoke — `mysqld`, `mysql`, `mysqldump`, `mysqladmin` — are all present.

## Verification

- Full **`spindb create -> seed -> backup -> restore -> verify`** e2e against the real published spindb (0.54.0) on both versions — `builds/mysql/test-spindb-e2e.sh`.
- Direct + password-auth round-trips mirroring cloud's entrypoint — `builds/mysql/test-roundtrip.sh`.
- Live R2 is already serving the minimal (sha matches the e2e-tested artifacts); the prior full binaries are preserved in R2 `_backup/` and (verified) locally.

## Scope

`linux-x64` only — MySQL publishes no `-minimal` for aarch64/macOS/Windows, so those are unchanged. 8.4.3 (no vendor minimal) and the deprecated versions (8.0.40, 9.1.0, 9.5.0) are unchanged.

## Tooling added

- `scripts/rehost-minimal-r2.ts` — backup -> overwrite -> purge, with a `--restore` reverse mode + size guard.
- `.github/workflows/rebuild-minimal-mysql.yml` — repeatable rehost/restore (linux-x64).
- `lib/r2.ts` — `copyR2Object` helper.

## Follow-up (not in this PR)

After merge: run `release-mysql.yml` for 8.4.9 + 9.6.0 to refresh the GitHub releases + R2 and regenerate `releases.json` (so the size/sha labels match), then bump spindb's `hostdb` pin to 0.33.1 and run its CI matrix.
