### PR TITLE
chore(mysql): disable 8.4.3 + minimal docs (0.33.2)

### DIFF
--- a/.github/workflows/release-mysql.yml
+++ b/.github/workflows/release-mysql.yml
@@ -10,7 +10,6 @@ on:
         options:
           - 9.6.0
           - 8.4.9
-          - 8.4.3
         default: 9.6.0
       platforms:
         description: 'Platforms'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.33.2] - 2026-06-06
+
+### Removed
+
+- **MySQL 8.4.3 disabled (`enabled: false`).** Superseded by 8.4.9 (the current 8.4 LTS patch, which is the minimal build). `resolveVersion('mysql', '8.4.3')` now returns `null`, 8.4.3 is dropped from `listVersions` and from the release-workflow version dropdown, and `'8.4'` continues to resolve to 8.4.9. The ~953 MB R2 binary is **retained** (not deleted), so any already-running container is unaffected. Nothing in the ecosystem pins `8.4.3` explicitly (layerbase uses `'8.4'`). Note: this leaves 8.4.3's released binaries flagged as orphans by `pnpm prep`'s discrepancy check (expected for a disabled-but-retained version; would clear if the binary is later deleted via `delete:releases`).
+
 ## [0.33.1] - 2026-06-05
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,8 @@ Pre-built database binaries for all major platforms, hosted on Cloudflare R2 via
 | [`builds/postgresql-documentdb/README.md`](./builds/postgresql-documentdb/README.md) | Reference implementation of a macOS source build with relocatable dylibs |
 | [`UPGRADE_VERSIONS.md`](./UPGRADE_VERSIONS.md) | Current upgrade backlog, organized by priority tier |
 | [`PROSPECTS.md`](./PROSPECTS.md) | Planned and unsupported databases |
+| [`MINIMAL_BINARIES.md`](./MINIMAL_BINARIES.md) | Which binaries are minimal (MySQL linux-x64), vendor-minimal availability, how to extend to other platforms, and known non-uniformities |
+| [`REPLACE_BINARY_PLAYBOOK.md`](./REPLACE_BINARY_PLAYBOOK.md) | Replacing an already-published binary on R2 in place (backup -> overwrite -> purge), rollback, and the cascade |
 
 ## Sources of Truth
 
@@ -193,6 +195,10 @@ R2 retains binaries forever by design (existing containers keep working). `pnpm 
 See `ARCHITECTURE.md` for secret setup (Cloudflare Zone ID, API token) and the full list of required GH Actions secrets.
 
 ## Engine-Specific Notes
+
+### MySQL minimal binaries (linux-x64)
+
+MySQL **8.4.9** and **9.6.0** `linux-x64` are re-hosted as MySQL's official `-minimal` tarball (872 MB -> 135 MB, 1042 MB -> 138 MB). `sources.json` points those `linux-x64` entries at the `-minimal` URL; all other platforms/versions are full. Vendor `-minimal` exists for `x86_64` Linux ONLY - other platforms (incl. linux-arm64, the other ~1 GB) need custom trimming. See [`MINIMAL_BINARIES.md`](./MINIMAL_BINARIES.md) for status, the extend-to-other-platforms process, and the known non-uniformities (stale `releases.json`/GitHub-release labels + `_backup/` objects from the in-place overwrite). To replace any binary in place, see [`REPLACE_BINARY_PLAYBOOK.md`](./REPLACE_BINARY_PLAYBOOK.md).
 
 ### MariaDB
 

--- a/MINIMAL_BINARIES.md
+++ b/MINIMAL_BINARIES.md
@@ -1,0 +1,57 @@
+# Minimal Binaries
+
+## Status
+
+MySQL **8.4.9** and **9.6.0** `linux-x64` are re-hosted as MySQL's official `-minimal` tarball:
+
+| Binary | Full | Minimal |
+|---|---|---|
+| `mysql-8.4.9` linux-x64 | 872 MB | **135 MB** |
+| `mysql-9.6.0` linux-x64 | 1042 MB | **138 MB** |
+
+The `-minimal` build keeps the entire `bin/` (every CLI tool), all runtime plugins, the bundled OpenSSL/SASL libraries, and the charset/error-message data. It drops only never-executed artifacts: the `mysql-test/` suite, debug binaries/plugins, and static `.a` libs. `resolveVersion` output is unchanged. Validated end-to-end (`spindb create -> seed -> backup -> restore`) on both versions - see `builds/mysql/test-roundtrip.sh` and `builds/mysql/test-spindb-e2e.sh`.
+
+Shipped in hostdb 0.33.1 -> spindb 0.54.1.
+
+## Vendor `-minimal` availability: linux-x64 ONLY
+
+MySQL publishes a `-minimal` build only for `x86_64` Linux. Every other platform 404s (verified):
+
+| Platform | full size (9.6.0) | vendor minimal? | worth trimming? |
+|---|---|---|---|
+| linux-x64 | now 138 MB | yes (in use) | done |
+| linux-arm64 | ~1033 MB | no | yes (high - the other ~1 GB) |
+| win32-x64 | ~290 MB | no | optional (moderate) |
+| darwin-x64 | ~168 MB | no | no (already small) |
+| darwin-arm64 | ~163 MB | no | no (already small) |
+
+macOS is already small because Apple's MySQL builds do not bundle the test suite. **linux-arm64 is the only other big one (~1 GB)**, for the same reason linux-x64 was (test suite + debug + unstripped symbols) - but it has no vendor minimal.
+
+## Adding a vendor-minimal for a NEW x64 version
+
+If a future MySQL x64 version ships a `-minimal` tarball: point its `linux-x64` entry in `builds/mysql/sources.json` at the `-minimal` URL + sha256 (confirm the URL exists first - naming varies: `glibc2.28` for recent versions, `glibc2.17` for some). Then follow `REPLACE_BINARY_PLAYBOOK.md`. Note: 8.4.3 and the deprecated versions (8.0.40 / 9.1.0 / 9.5.0) have no vendor minimal and stay full.
+
+## Extending to non-x64 platforms (custom trim, NOT a URL swap)
+
+No vendor minimal exists for these, so you trim the full tarball yourself. Only do it where it pays off: **linux-arm64 (high value, ~1 GB)**; macOS (skip, already ~160 MB); Windows (optional, ~270 MB).
+
+1. Add a trim step to `builds/mysql/download.ts` -> `repackage()`, after extract / before re-tar:
+   - delete: `mysql-test/`, `lib/plugin/debug/`, `lib/*.a`, `man/`, `include/`, `docs/`
+   - `strip` the ELF binaries (**Linux only** - this recovers most of the size; the full Linux binaries are unstripped). Do NOT `strip` on macOS (Mach-O `@rpath`/dylib relocatability is fragile - dir-deletion only there).
+   - DENYLIST, never allowlist: keep all of `bin/` so you cannot recreate the pg_dump/pg_restore loss.
+2. Build: `pnpm download:mysql -- --version <X> --platform linux-arm64 --output ./dist`.
+3. Validate: `builds/mysql/test-roundtrip.sh <tarball> linux-arm64` and `builds/mysql/test-spindb-e2e.sh <tarball> <X>`. (linux-arm64 runs natively on Apple Silicon, so it tests faster than x64 did under emulation.)
+4. Re-host + cascade: see `REPLACE_BINARY_PLAYBOOK.md`.
+
+A custom-trim step is more general than the vendor swap: it also covers versions that lack a vendor minimal (e.g. 8.4.3) uniformly across all platforms.
+
+## Known non-uniformities (the direct-overwrite residue)
+
+The 8.4.9 / 9.6.0 linux-x64 minimal binaries were shipped via a direct R2 overwrite (fast, no full rebuild), which left these cosmetic inconsistencies. All are harmless - nothing reads size/sha for the actual download (spindb constructs the URL and verifies neither size nor sha) - but they are real:
+
+1. **`releases.json` size/sha for those 2 entries are stale** (label 872 / 1042 MB; R2 serves 135 / 138 MB).
+2. **The GitHub release assets for those 2 are still the full binaries** (diverge from R2; harmless because spindb's GitHub fallback is disabled).
+3. **`_backup/mysql-8.4.9/...` and `_backup/mysql-9.6.0/...`** hold the full originals on R2 for rollback. They are not referenced by `releases.json`, so `pnpm audit:r2-orphans --delete` WOULD remove them - do not run that while you rely on them.
+4. **`sources.json` mixes** minimal URLs (8.4.9 / 9.6.0 linux-x64) with full URLs (everything else).
+
+**To fully heal #1 and #2** (make `releases.json` + the GitHub releases match R2): run `release-mysql.yml` for 8.4.9 + 9.6.0. It rebuilds, updates the GitHub releases + R2, and regenerates a correct `releases.json`. (The already-published npm 0.33.1 keeps the stale labels in its bundled snapshot until the next version bump - inert, since R2 is authoritative for the bytes.)

--- a/MINIMAL_BINARIES.md
+++ b/MINIMAL_BINARIES.md
@@ -27,6 +27,14 @@ MySQL publishes a `-minimal` build only for `x86_64` Linux. Every other platform
 
 macOS is already small because Apple's MySQL builds do not bundle the test suite. **linux-arm64 is the only other big one (~1 GB)**, for the same reason linux-x64 was (test suite + debug + unstripped symbols) - but it has no vendor minimal.
 
+## Policy: vendor-minimal swaps only (no custom trimming)
+
+We adopt a smaller binary ONLY when the vendor already publishes a minimal/slim tarball (a one-line `sources.json` URL swap, as done for MySQL linux-x64). We do NOT custom-trim/strip binaries ourselves - the per-platform build + validation maintenance is not worth it outside the egregious ~1 GB MySQL case. So MySQL arm64/macOS/Windows stay full, and the custom-trim steps below are kept only as a reference in case that calculus ever changes.
+
+### Other engines checked
+
+- **MariaDB** (checked 2026-06-06): no vendor `-minimal` exists. The release directory (e.g. `archive.mariadb.org/mariadb-11.8.6/`) holds exactly one linux-x64 tarball - `bintar-linux-systemd-x86_64/mariadb-<v>-linux-systemd-x86_64.tar.gz`, the full ~360-413 MB build - and nothing matching `minimal`/`slim`/`reduced`. linux-x64 is the only large MariaDB platform (bundled test suite + unstripped; the lean arm64 build is only ~87 MB), but per the policy above we do NOT trim it. All other MariaDB platforms are already ~80-90 MB. Re-check this only if MariaDB starts publishing a slim tarball.
+
 ## Adding a vendor-minimal for a NEW x64 version
 
 If a future MySQL x64 version ships a `-minimal` tarball: point its `linux-x64` entry in `builds/mysql/sources.json` at the `-minimal` URL + sha256 (confirm the URL exists first - naming varies: `glibc2.28` for recent versions, `glibc2.17` for some). Then follow `REPLACE_BINARY_PLAYBOOK.md`. Note: 8.4.3 and the deprecated versions (8.0.40 / 9.1.0 / 9.5.0) have no vendor minimal and stay full.

--- a/REPLACE_BINARY_PLAYBOOK.md
+++ b/REPLACE_BINARY_PLAYBOOK.md
@@ -1,0 +1,60 @@
+# Replace-a-Binary Playbook
+
+How to replace an already-published binary on R2 with a different build of the same engine/version/platform (e.g. a smaller `-minimal` or custom-trimmed tarball) WITHOUT cutting a full release. See also `MINIMAL_BINARIES.md` (the MySQL minimal status) and `REMOVE_BINARY_CHEATSHEET.md` (deleting a binary entirely).
+
+## Why this works (the load-bearing facts)
+
+spindb (the primary consumer) **constructs** the download URL from a fixed template -
+`registry.layerbase.host/{engine}-{ver}/{engine}-{ver}-{platform}.tar.gz` - and **ignores** the per-asset `url` in `releases.json`. It does **not** verify `sha256` or `size`; its post-download check just runs `<server-binary> --version`. Therefore:
+
+- The replacement must live at the **canonical key** (you cannot redirect via `releases.json`).
+- Replacing the bytes there is transparent to every pinned consumer - no version bump is required for delivery.
+
+Re-verify these assumptions before relying on them (they could change in a future spindb).
+
+## Tooling
+
+- `scripts/rehost-minimal-r2.ts` - backup -> overwrite -> purge, plus `--restore`, `--dry-run`, and a `--max-size-mb` guard (default 400; refuses to overwrite with a larger file, so a stray full build cannot clobber a minimal).
+- `.github/workflows/rebuild-minimal-mysql.yml` - the same flow as a dispatchable workflow, with a `mode: rehost | restore` input. It builds + round-trip-tests before overwriting.
+
+## Procedure (local)
+
+```bash
+# 1. build the replacement artifact
+pnpm download:mysql -- --version 8.4.9 --platform linux-x64 --output ./dist
+
+# 2. validate it (do NOT skip - this is the pg_restore-loss guard)
+./builds/mysql/test-roundtrip.sh ./dist/mysql-8.4.9-linux-x64.tar.gz linux-x64
+./builds/mysql/test-spindb-e2e.sh ./dist/mysql-8.4.9-linux-x64.tar.gz 8.4.9
+
+# 3. replace on R2 (auto-creates _backup/<key> first)
+set -a; source .env; set +a
+pnpm tsx scripts/rehost-minimal-r2.ts --tag mysql-8.4.9 --file ./dist/mysql-8.4.9-linux-x64.tar.gz
+
+# 4. verify the live URL serves the new bytes
+curl -fsSL -o /tmp/x.tar.gz https://registry.layerbase.host/mysql-8.4.9/mysql-8.4.9-linux-x64.tar.gz
+shasum -a 256 /tmp/x.tar.gz   # compare to: shasum -a 256 ./dist/mysql-8.4.9-linux-x64.tar.gz
+```
+
+## Rollback (3 independent layers)
+
+1. **R2 `_backup/`** (fastest): `pnpm tsx scripts/rehost-minimal-r2.ts --tag mysql-8.4.9 --filename mysql-8.4.9-linux-x64.tar.gz --restore` (or dispatch the workflow with `mode: restore`).
+2. **Local verified original** (if the `_backup/` object is gone): keep a sha-verified copy of the pre-overwrite binary (e.g. under `~/layerbase-mysql-full-backups/`), then `--file <that-original> --no-backup --max-size-mb 2000`.
+3. **Vendor rebuild**: the original vendor URL + sha for each replaced entry is preserved in `builds/mysql/sources.json` -> `notes` (`*-full-revert` keys).
+
+## Gotchas
+
+- **CDN purge** needs `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ZONE_ID` (present in `.env` and repo secrets). Without them the script still overwrites but warns, and the old binary stays CDN-cached for up to a year (`max-age=31536000, immutable`).
+- **`_backup/` objects are orphans** by `audit:r2-orphans`' definition (not referenced by `releases.json`). Do not run `pnpm audit:r2-orphans --delete` while you rely on them for rollback.
+- This path leaves `releases.json` and the GitHub release asset **stale** (still labeled as the old binary). It is cosmetic - nothing reads size/sha for downloads - but to reconcile, run the engine release workflow (`release-<engine>.yml`); it rebuilds + updates the GitHub releases + R2 + regenerates `releases.json`.
+
+## The "proper" full path (consistent from the start)
+
+Per the publish-cascade coordination rules: edit `sources.json` + bump `package.json` -> run the release workflow (updates GitHub releases + R2 + commits a correct `releases.json`) -> merge -> `publish.yml` publishes. This avoids the stale-label residue entirely, at the cost of rebuilding all platforms. Use the direct-replace path above to ship + verify fast; use the release workflow when you want a clean, fully-labeled release.
+
+## Downstream cascade after a binary change
+
+1. **hostdb**: patch bump + CHANGELOG, merge to main -> `publish.yml` -> npm. Verify `npm view hostdb version`.
+2. **spindb**: bump the exact `hostdb` pin in `package.json`, open PR -> the CI matrix downloads the live binary and exercises it. Verify `npm view spindb version`.
+3. **layerbase-cloud**: bump `ARG SPINDB_VERSION` in `images/Dockerfile.base`, rebuild images. (Note: cloud downloads binaries at container runtime, so the binary change is already live for new containers regardless of this bump - the bump is version alignment.)
+4. **layerbase-desktop**: bump `spindb` in `package.json`; next release ships it.

--- a/databases.json
+++ b/databases.json
@@ -536,7 +536,10 @@
             ]
           }
         },
-        "8.4.3": true,
+        "8.4.3": {
+          "enabled": false,
+          "note": "Superseded by 8.4.9 (current 8.4 LTS patch, minimal build). Disabled from resolution so it is not selectable or resolvable; the existing ~953 MB R2 binary is retained (not deleted)."
+        },
         "8.0.40": {
           "deprecated": true,
           "note": "Deprecated; use 8.4.x LTS instead"

--- a/databases.yml
+++ b/databases.yml
@@ -442,7 +442,9 @@ databases:
           enhanced:
             - mycli
             - usql
-      8.4.3: true
+      8.4.3:
+        enabled: false
+        note: "Superseded by 8.4.9 (current 8.4 LTS patch, minimal build). Disabled from resolution so it is not selectable or resolvable; the existing ~953 MB R2 binary is retained (not deleted)."
       8.0.40:
         deprecated: true
         note: Deprecated; use 8.4.x LTS instead

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hostdb",
-  "version": "0.33.1",
+  "version": "0.33.2",
   "description": "Pre-built database binaries for multiple platforms, plus a typed registry library for resolving versions and download URLs offline.",
   "private": false,
   "type": "module",

--- a/tests/defaults-sync.test.ts
+++ b/tests/defaults-sync.test.ts
@@ -108,7 +108,7 @@ const SNAPSHOT: Record<string, Record<string, string>> = {
     '9.5': '9.5.0',
     '9.6': '9.6.0',
     '8.0.40': '8.0.40',
-    '8.4.3': '8.4.3',
+    // 8.4.3 disabled (enabled: false) in 0.33.2 — superseded by 8.4.9; no longer resolvable.
     '8.4.9': '8.4.9',
     '9.1.0': '9.1.0',
     '9.5.0': '9.5.0',


### PR DESCRIPTION
## What

Two related changes from the MySQL minimal effort (hostdb 0.33.1 -> **0.33.2**):

### 1. Disable MySQL 8.4.3 (`enabled: false`)

8.4.3 is superseded by **8.4.9** (the current 8.4 LTS patch, which is the minimal build). After this:

- `resolveVersion('mysql', '8.4.3')` -> **null**
- 8.4.3 is dropped from `listVersions` and from the release-workflow version dropdown
- `'8.4'` continues to resolve to **8.4.9**

The ~953 MB R2 binary is **retained, not deleted**, so any already-running container is unaffected. Nothing in the ecosystem pins `8.4.3` explicitly (layerbase uses `'8.4'`), so nothing breaks.

### 2. Docs (already on dev, carried in this PR)

`MINIMAL_BINARIES.md`, `REPLACE_BINARY_PLAYBOOK.md`, CLAUDE.md pointers, and the MariaDB / vendor-minimal-only policy note.

## Notes

- This leaves 8.4.3's released binaries flagged as orphans by `pnpm prep`'s discrepancy check - expected for a disabled-but-retained version; it would clear if the binary is later deleted via `delete:releases`. CI does not gate on this (`version-check` + `build:releases`/`test` only).
- The merge commit syncs `dev` with `main`'s healed `releases.json` (minimal labels) so this PR does not revert it.

## Why not delete the binary?

Deleting it does **not** shrink the layerbase-cloud Docker image (binaries are downloaded at container runtime, not baked in) and nothing pulls 8.4.3, so deletion would only reclaim R2 storage. `enabled: false` already achieves "not used / not selectable / not resolvable." Binary deletion can be a separate deliberate step later.
