### PR TITLE
perf(ci): harden build-releases-json (timeout + parallel fetches) (0.33.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.33.4] - 2026-06-06
+
+### Changed
+
+- **`scripts/build-releases-json.ts`: hardened the GitHub fetches.** Added a 20s per-request timeout + retry to every fetch (the releases list and each release's `checksums.txt`), and parallelized the per-release processing (bounded to 8 concurrent). Previously the fetches were sequential with no timeout, so a single stuck connection could hang the publish indefinitely, and the step slowed as the release count grew (55 releases took ~40s locally, minutes on a bad CI run). Now it's ~3s. Output is byte-identical (the manifest is deterministically re-sorted), so `releases.json` is unchanged.
+
 ## [0.33.3] - 2026-06-06
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hostdb",
-  "version": "0.33.3",
+  "version": "0.33.4",
   "description": "Pre-built database binaries for multiple platforms, plus a typed registry library for resolving versions and download URLs offline.",
   "private": false,
   "type": "module",

--- a/scripts/build-releases-json.ts
+++ b/scripts/build-releases-json.ts
@@ -173,6 +173,36 @@ function sortManifest(releases: ReleasesManifest): ReleasesManifest {
   return { ...releases, databases: sortedDatabases }
 }
 
+// Per-request timeout so a stuck connection can never hang the publish, plus a
+// couple of retries to ride out a transient timeout / network blip before
+// giving up. (Previously these fetches had no timeout and ran sequentially, so
+// one stuck checksums download could hang the whole publish indefinitely.)
+const FETCH_TIMEOUT_MS = 20_000
+const RETRY_DELAYS_MS = [0, 500, 1500]
+
+async function fetchWithRetry(
+  url: string,
+  options: RequestInit = {},
+): Promise<Response> {
+  let lastError: unknown
+  for (let attempt = 0; attempt < RETRY_DELAYS_MS.length; attempt++) {
+    if (RETRY_DELAYS_MS[attempt] > 0) {
+      await new Promise((resolve) => setTimeout(resolve, RETRY_DELAYS_MS[attempt]))
+    }
+    try {
+      return await fetch(url, {
+        ...options,
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      })
+    } catch (error) {
+      lastError = error
+    }
+  }
+  throw lastError instanceof Error
+    ? lastError
+    : new Error(`fetch failed after ${RETRY_DELAYS_MS.length} attempts: ${url}`)
+}
+
 /** Fetch all releases from GitHub API with pagination */
 async function fetchAllReleases(): Promise<Map<string, GitHubRelease>> {
   const releases = new Map<string, GitHubRelease>()
@@ -183,7 +213,7 @@ async function fetchAllReleases(): Promise<Map<string, GitHubRelease>> {
 
   while (true) {
     const url = `https://api.github.com/repos/${REPO}/releases?per_page=${perPage}&page=${page}`
-    const response = await fetch(url, { headers: githubHeaders() })
+    const response = await fetchWithRetry(url, { headers: githubHeaders() })
 
     if (!response.ok) {
       throw new Error(
@@ -230,25 +260,32 @@ function githubHeaders(
 async function downloadChecksums(
   checksumAsset: GitHubAsset,
 ): Promise<Record<string, string>> {
-  // Try browser_download_url first — goes to CDN, no API rate limit
-  const cdnResponse = await fetch(checksumAsset.browser_download_url, {
-    headers: { 'User-Agent': 'hostdb-build-releases' },
-    redirect: 'follow',
-  })
-
-  if (cdnResponse.ok) {
-    return parseChecksums(await cdnResponse.text())
+  // Try browser_download_url first - goes to CDN, no API rate limit. Wrapped so
+  // a timeout / network error falls through to the API path instead of throwing.
+  try {
+    const cdnResponse = await fetchWithRetry(checksumAsset.browser_download_url, {
+      headers: { 'User-Agent': 'hostdb-build-releases' },
+      redirect: 'follow',
+    })
+    if (cdnResponse.ok) {
+      return parseChecksums(await cdnResponse.text())
+    }
+  } catch {
+    // fall through to the API fallback
   }
 
   // Fallback: API asset download (counts against rate limit but handles private repos)
-  const apiUrl = `https://api.github.com/repos/${REPO}/releases/assets/${checksumAsset.id}`
-  const apiResponse = await fetch(apiUrl, {
-    headers: githubHeaders('application/octet-stream'),
-    redirect: 'follow',
-  })
-
-  if (apiResponse.ok) {
-    return parseChecksums(await apiResponse.text())
+  try {
+    const apiUrl = `https://api.github.com/repos/${REPO}/releases/assets/${checksumAsset.id}`
+    const apiResponse = await fetchWithRetry(apiUrl, {
+      headers: githubHeaders('application/octet-stream'),
+      redirect: 'follow',
+    })
+    if (apiResponse.ok) {
+      return parseChecksums(await apiResponse.text())
+    }
+  } catch {
+    // fall through to empty (caller treats this release as skipped)
   }
 
   return {}
@@ -323,31 +360,42 @@ async function main() {
     databases: {},
   }
 
-  // Process each release
+  // Process releases concurrently in bounded batches. Each release is
+  // independent and the manifest is deterministically re-sorted below, so
+  // batch order doesn't affect output - only speed (one slow checksums fetch
+  // no longer blocks the other 54).
   let processed = 0
   let skipped = 0
+  const CONCURRENCY = 8
 
-  for (const [tag, ghRelease] of ghReleases) {
-    const parsed = parseReleaseTag(tag)
-    if (!parsed) {
-      console.warn(`  Skipping unparseable tag: ${tag}`)
-      skipped++
-      continue
+  const tags = [...ghReleases.keys()]
+  for (let i = 0; i < tags.length; i += CONCURRENCY) {
+    const batch = tags.slice(i, i + CONCURRENCY)
+    const results = await Promise.all(
+      batch.map(async (tag) => {
+        const ghRelease = ghReleases.get(tag) as GitHubRelease
+        const parsed = parseReleaseTag(tag)
+        if (!parsed) {
+          console.warn(`  Skipping unparseable tag: ${tag}`)
+          return null
+        }
+        const entry = await buildVersionRelease(ghRelease, tag, parsed.version)
+        if (!entry) return null
+        return { database: parsed.database, version: parsed.version, entry }
+      }),
+    )
+
+    for (const result of results) {
+      if (!result) {
+        skipped++
+        continue
+      }
+      if (!manifest.databases[result.database]) {
+        manifest.databases[result.database] = {}
+      }
+      manifest.databases[result.database][result.version] = result.entry
+      processed++
     }
-
-    const { database, version } = parsed
-    const entry = await buildVersionRelease(ghRelease, tag, version)
-
-    if (!entry) {
-      skipped++
-      continue
-    }
-
-    if (!manifest.databases[database]) {
-      manifest.databases[database] = {}
-    }
-    manifest.databases[database][version] = entry
-    processed++
   }
 
   console.log(`\nProcessed ${processed} releases (${skipped} skipped)`)


### PR DESCRIPTION
## What

Hardens `scripts/build-releases-json.ts` (the step that regenerates `releases.json` during publish), addressing the slow/fragile behavior we saw on the last publish.

- **Per-request timeout + retry** on every GitHub fetch (releases list + each release's `checksums.txt`): 20s `AbortSignal.timeout`, 3 attempts. Previously these had **no timeout**, so a single stuck connection could hang the publish indefinitely.
- **Bounded parallelism** (8 concurrent) for per-release processing instead of one-at-a-time.

## Why

On the 0.33.3 publish, the "Regenerate releases.json" step sat at 3m+ (it eventually finished). Reproduced locally on Node 24: the script worked but took ~40s for 55 releases, sequentially, with no bail-out for a stuck fetch. As the release count grows this only gets worse, and a genuinely stuck connection would hang a publish.

## Validation

- `tsc --noEmit` clean.
- Ran the patched script on Node 24: **output byte-identical** (`✓ releases.json is already up to date`, 22 databases / 55 versions) - the manifest is deterministically re-sorted, so concurrency doesn't change the result and the publish drift-guard stays green.
- **~40s → ~3s** for 55 releases.

CI-only script (not shipped in the npm package); the version bump to 0.33.4 just satisfies the `version-check` gate.
