### PR TITLE
ci: bump pnpm/action-setup + docker actions off Node 20 (0.33.5)

### DIFF
--- a/.github/workflows/build-missing-releases.yml
+++ b/.github/workflows/build-missing-releases.yml
@@ -270,7 +270,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Setup pnpm
         if: steps.check.outputs.publish == 'true'
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         if: steps.check.outputs.publish == 'true'

--- a/.github/workflows/rebuild-minimal-mysql.yml
+++ b/.github/workflows/rebuild-minimal-mysql.yml
@@ -57,7 +57,7 @@ jobs:
           ref: main
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/rebuild-releases.yml
+++ b/.github/workflows/rebuild-releases.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'

--- a/.github/workflows/release-clickhouse.yml
+++ b/.github/workflows/release-clickhouse.yml
@@ -147,7 +147,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -321,7 +321,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -347,7 +347,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'

--- a/.github/workflows/release-cockroachdb.yml
+++ b/.github/workflows/release-cockroachdb.yml
@@ -102,7 +102,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -214,7 +214,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -240,7 +240,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'

--- a/.github/workflows/release-couchdb.yml
+++ b/.github/workflows/release-couchdb.yml
@@ -148,7 +148,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -162,11 +162,11 @@ jobs:
       # Set up QEMU for cross-platform Docker builds (required for linux-arm64 on x64 runners)
       - name: Set up QEMU
         if: matrix.build_type == 'docker'
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         if: matrix.build_type == 'docker'
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       # For Linux: extract from official Docker image
       - name: Build for Linux (Docker extraction)
@@ -549,7 +549,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -575,7 +575,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'

--- a/.github/workflows/release-duckdb.yml
+++ b/.github/workflows/release-duckdb.yml
@@ -103,7 +103,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -223,7 +223,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -249,7 +249,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'

--- a/.github/workflows/release-ferretdb.yml
+++ b/.github/workflows/release-ferretdb.yml
@@ -103,7 +103,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -242,7 +242,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -268,7 +268,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'

--- a/.github/workflows/release-influxdb.yml
+++ b/.github/workflows/release-influxdb.yml
@@ -102,7 +102,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -268,7 +268,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -294,7 +294,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'

--- a/.github/workflows/release-libsql.yml
+++ b/.github/workflows/release-libsql.yml
@@ -101,7 +101,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -214,7 +214,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -240,7 +240,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'

--- a/.github/workflows/release-mariadb.yml
+++ b/.github/workflows/release-mariadb.yml
@@ -150,7 +150,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -164,11 +164,11 @@ jobs:
       # Set up QEMU for cross-platform Docker builds (required for linux-arm64 on x64 runners)
       - name: Set up QEMU
         if: matrix.build_type == 'docker'
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         if: matrix.build_type == 'docker'
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       # For Linux: use Docker-based builds (download or source build)
       - name: Build for Linux/Windows (download or Docker)
@@ -471,7 +471,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -497,7 +497,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'

--- a/.github/workflows/release-meilisearch.yml
+++ b/.github/workflows/release-meilisearch.yml
@@ -103,7 +103,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -215,7 +215,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -241,7 +241,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'

--- a/.github/workflows/release-mongodb.yml
+++ b/.github/workflows/release-mongodb.yml
@@ -107,7 +107,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -230,7 +230,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -256,7 +256,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'

--- a/.github/workflows/release-mysql.yml
+++ b/.github/workflows/release-mysql.yml
@@ -103,7 +103,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -221,7 +221,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -247,7 +247,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'

--- a/.github/workflows/release-postgresql-documentdb.yml
+++ b/.github/workflows/release-postgresql-documentdb.yml
@@ -147,7 +147,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -161,11 +161,11 @@ jobs:
       # Set up QEMU for cross-platform Docker builds (required for linux-arm64 on x64 runners)
       - name: Set up QEMU
         if: matrix.build_type == 'docker'
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         if: matrix.build_type == 'docker'
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       # For Linux: Docker extraction
       # ARM64 builds use QEMU emulation which is 5-10x slower than native
@@ -471,7 +471,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -497,7 +497,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'

--- a/.github/workflows/release-postgresql.yml
+++ b/.github/workflows/release-postgresql.yml
@@ -168,7 +168,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -182,11 +182,11 @@ jobs:
       # Set up QEMU for cross-platform Docker builds (required for linux-arm64 on x64 runners)
       - name: Set up QEMU
         if: matrix.build_type == 'docker'
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         if: matrix.build_type == 'docker'
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       # Check if there's a download URL available in sources.json
       - name: Check for download URL
@@ -848,7 +848,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -874,7 +874,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'

--- a/.github/workflows/release-qdrant.yml
+++ b/.github/workflows/release-qdrant.yml
@@ -102,7 +102,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -214,7 +214,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -240,7 +240,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'

--- a/.github/workflows/release-questdb.yml
+++ b/.github/workflows/release-questdb.yml
@@ -102,7 +102,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -214,7 +214,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -240,7 +240,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'

--- a/.github/workflows/release-redis.yml
+++ b/.github/workflows/release-redis.yml
@@ -146,7 +146,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -160,11 +160,11 @@ jobs:
       # Set up QEMU for cross-platform Docker builds (required for linux-arm64 on x64 runners)
       - name: Set up QEMU
         if: matrix.build_type == 'docker'
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         if: matrix.build_type == 'docker'
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       # For Linux: use Docker-based builds
       - name: Build for Linux (Docker)
@@ -434,7 +434,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -460,7 +460,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'

--- a/.github/workflows/release-sqlite.yml
+++ b/.github/workflows/release-sqlite.yml
@@ -124,11 +124,11 @@ jobs:
 
       - name: Set up QEMU
         if: steps.check.outputs.should_build == 'true'
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         if: steps.check.outputs.should_build == 'true'
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build SQLite for ${{ matrix.platform }}
         if: steps.check.outputs.should_build == 'true'
@@ -173,7 +173,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -313,7 +313,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -339,7 +339,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'

--- a/.github/workflows/release-surrealdb.yml
+++ b/.github/workflows/release-surrealdb.yml
@@ -102,7 +102,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -214,7 +214,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -240,7 +240,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'

--- a/.github/workflows/release-tigerbeetle.yml
+++ b/.github/workflows/release-tigerbeetle.yml
@@ -102,7 +102,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -220,7 +220,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -246,7 +246,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'

--- a/.github/workflows/release-typedb.yml
+++ b/.github/workflows/release-typedb.yml
@@ -102,7 +102,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -227,7 +227,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -253,7 +253,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'

--- a/.github/workflows/release-valkey.yml
+++ b/.github/workflows/release-valkey.yml
@@ -149,7 +149,7 @@ jobs:
 
       - name: Setup pnpm
         if: matrix.build_type != 'native-windows'
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         if: matrix.build_type != 'native-windows'
@@ -165,11 +165,11 @@ jobs:
       # Set up QEMU for cross-platform Docker builds (required for linux-arm64 on x64 runners)
       - name: Set up QEMU
         if: matrix.build_type == 'docker'
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         if: matrix.build_type == 'docker'
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       # For Linux: use Docker-based builds
       - name: Build for Linux (Docker)
@@ -490,7 +490,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -516,7 +516,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'

--- a/.github/workflows/release-weaviate.yml
+++ b/.github/workflows/release-weaviate.yml
@@ -102,7 +102,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -219,7 +219,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -245,7 +245,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'

--- a/.github/workflows/reupload-r2.yml
+++ b/.github/workflows/reupload-r2.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.33.5] - 2026-06-06
+
+### Changed
+
+- **CI: bump the remaining safe actions off Node 20.** `pnpm/action-setup@v4 -> v6` (73x) and `docker/setup-buildx-action`/`docker/setup-qemu-action@v3 -> v4`. This clears the Node-20 deprecation on the everyday workflows (publish, ci, version-check). Known residual on the **dispatch-only `release-*.yml`** workflows: `upload-artifact@v4`/`download-artifact@v4` (latest v7/v8 are breaking-prone and PR CI can't validate them), `softprops/action-gh-release@v2` (latest v3), and `ilammy/msvc-dev-cmd@v1` (already the latest major) - those need a separate, manually-tested release-workflow pass.
+
 ## [0.33.4] - 2026-06-06
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hostdb",
-  "version": "0.33.4",
+  "version": "0.33.5",
   "description": "Pre-built database binaries for multiple platforms, plus a typed registry library for resolving versions and download URLs offline.",
   "private": false,
   "type": "module",


### PR DESCRIPTION
Bumps the **safe** remaining Node-20 actions: `pnpm/action-setup@v4 -> v6` (73x) and `docker/setup-buildx-action`/`setup-qemu-action@v3 -> v4`. Clears the Node-20 deprecation on the everyday workflows (publish, ci, version-check) - my earlier #196 only covered the `actions/*` ones and missed these.

**Residual (intentional, dispatch-only release workflows):** `upload-artifact@v4`/`download-artifact@v4` (latest v7/v8 are multi-major breaking-prone, and PR CI can't exercise them), `softprops/action-gh-release@v2` (latest v3), and `ilammy/msvc-dev-cmd@v1` (already the latest major). Those need a separate, manually-tested release-workflow pass.