### PR TITLE
chore(release): 0.33.6 - standardize commercial licensing language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.33.6] - 2026-07-04
+
+### Changed
+
+- **Licensing: standardized the commercial-licensing language in `LICENSE` (matches spindb).** Added a commercial-use notice above the PolyForm Noncommercial 1.0.0 body (the grant itself is unchanged) that enumerates commercial use - commercial products/services/SaaS, internal for-profit operations, and using the software, its source, or its output to train, fine-tune, evaluate, or retrieval-augment AI/ML models, systems, or agents for any for-profit purpose - states that a one-time commercial license fee applies, and lists the licensing contact as bob@layerbase.com.
+
 ## [0.33.5] - 2026-06-06
 
 ### Changed

--- a/LICENSE
+++ b/LICENSE
@@ -2,6 +2,30 @@
 
 <https://polyformproject.org/licenses/noncommercial/1.0.0>
 
+## Commercial Licensing
+
+This software is free for noncommercial use under the terms below.
+**Any commercial use requires a separate, paid commercial license.**
+
+Commercial use includes, without limitation:
+
+- use in or for any commercial product, service, or SaaS offering;
+- use in the internal business operations of any for-profit entity;
+- using the software, its source code, or its output to train,
+  fine-tune, evaluate, retrieval-augment, or otherwise develop any
+  AI or machine-learning model, system, or agent in connection with a
+  commercial, for-profit, or revenue-generating purpose; and
+- any other for-profit endeavor.
+
+A one-time commercial license fee applies. To obtain a commercial
+license, or to confirm whether your use requires one, contact the
+licensor at **bob@layerbase.com**.
+
+This section does not grant any rights beyond the PolyForm
+Noncommercial License 1.0.0 set out below. It describes the separate
+commercial license the licensor offers for uses that the license
+below does not permit.
+
 ## Acceptance
 
 In order to get any license under these terms, you must agree

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hostdb",
-  "version": "0.33.5",
+  "version": "0.33.6",
   "description": "Pre-built database binaries for multiple platforms, plus a typed registry library for resolving versions and download URLs offline.",
   "private": false,
   "type": "module",


### PR DESCRIPTION
## Summary

Standardizes the commercial-licensing language in `LICENSE` (to match spindb) and bumps the release to `0.33.6`.

## Changes

- **LICENSE:** Added a commercial-use notice above the PolyForm Noncommercial 1.0.0 body (the grant itself is unchanged). Enumerates commercial use - commercial products/services/SaaS, internal for-profit operations, and using the software/its source/its output to train, fine-tune, evaluate, or retrieval-augment AI/ML models, systems, or agents for any for-profit purpose. States that a one-time commercial license fee applies. Licensing contact is `bob@layerbase.com`.
- **Version:** `0.33.5 -> 0.33.6` (patch; docs/license change, no API change).
- **CHANGELOG:** `[0.33.6] - 2026-07-04` under Changed.

Merging to `main` triggers the OIDC publish job.