### PR TITLE
release: hostdb 0.34.1 (docs: TypeDB 3.12 archive structure)

### DIFF
--- a/BINARIES.md
+++ b/BINARIES.md
@@ -20,7 +20,9 @@ Archive structure for each database distributed by hostdb.
 | Meilisearch | `meilisearch/` | `meilisearch` `.hostdb-metadata.json` | `meilisearch` | — (HTTP) |
 | InfluxDB | `influxdb/` | `influxdb3` `python/` `LICENSE-APACHE` `LICENSE-MIT` `.hostdb-metadata.json` | `influxdb3` | — (HTTP/SQL) |
 | TigerBeetle | `tigerbeetle/` | `tigerbeetle` `.hostdb-metadata.json` | `tigerbeetle` | `tigerbeetle` (REPL) |
-| TypeDB | `typedb/` | `server/` `console/` `typedb` `LICENSE` `.hostdb-metadata.json` | `server/typedb_server_bin` | `console/typedb_console_bin` |
+| TypeDB | `typedb/` | `server/` `console/` `admin/`\* `loader/`\* `typedb` `LICENSE` `.hostdb-metadata.json` | `server/typedb_server_bin` | `console/typedb_console_bin` |
+
+\* `admin/` (OS-socket admin CLI) and `loader/` (bulk-import tool) exist in TypeDB 3.12+ only.
 
 ## Detailed Structure
 
@@ -123,12 +125,21 @@ typedb/
 ├── typedb                   # launcher script (typedb.bat on Windows)
 ├── server/
 │   ├── typedb_server_bin    # or .exe on Windows
-│   ├── config.yml
-│   └── data/
+│   └── config.yml
 ├── console/
 │   └── typedb_console_bin   # or .exe on Windows
+├── admin/
+│   └── typedb_admin_bin     # 3.12+: OS-socket admin CLI
+├── loader/
+│   └── typedb_loader_bin    # 3.12+: bulk-import tool
 ├── LICENSE
 └── .hostdb-metadata.json
+```
+
+Version differences: 3.11.x and earlier have no `admin/` or `loader/` dirs and ship a
+pre-created `server/data/`; 3.12+ adds both dirs and creates `data/` on first boot.
+
+```
 ```
 
 ### Single binary (no bin/ subdirectory)
@@ -200,4 +211,4 @@ Every archive includes `.hostdb-metadata.json`:
 | Meilisearch | No | 1 | HTTP API only |
 | TigerBeetle | No | 1 | Built-in REPL |
 | InfluxDB | Custom (`python/`) | 1 + runtime | HTTP API / SQL |
-| TypeDB | Custom (`server/`, `console/`) | 2 + launcher | CLI (`typedb_console_bin`) |
+| TypeDB | Custom (`server/`, `console/`; 3.12+ adds `admin/`, `loader/`) | 2 + launcher (3.12+: 4 + launcher) | CLI (`typedb_console_bin`) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.34.1] - 2026-07-10
+
+### Documentation
+
+- `BINARIES.md` now documents the two new top-level directories in TypeDB 3.12+ archives: `admin/typedb_admin_bin` (OS-socket admin CLI) and `loader/typedb_loader_bin` (bulk import). Pre-3.12 archives lack both and shipped a pre-created `server/data/` directory that 3.12 creates on first boot instead. No code or registry changes.
+
 ## [0.34.0] - 2026-07-10
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hostdb",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "description": "Pre-built database binaries for multiple platforms, plus a typed registry library for resolving versions and download URLs offline.",
   "private": false,
   "type": "module",


### PR DESCRIPTION
Docs-only release. BINARIES.md now documents the admin/ and loader/ dirs in TypeDB 3.12+ archives (verified against the live R2 tarballs). Patch bump so the publish version-guard passes; no code, registry, or binary changes. Tests green locally.