### PR TITLE
docs: re-point ecosystem doc references to layerbase-cloud

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,8 +12,8 @@ Pre-built database binaries for all major platforms, hosted on Cloudflare R2 via
 - **layerbase-desktop** (`~/dev/layerbase-desktop`) — Electron GUI over spindb.
 - **layerbase** (`~/dev/layerbase`) — web app at layerbase.com.
 
-**Ecosystem docs:** `~/dev/layerbase-architecture/` — shared architecture, cross-project rules, infrastructure inventory.
-**Ecosystem invariants:** `~/dev/layerbase-architecture/INVARIANTS.md` — non-negotiable rules. Read before architectural changes.
+**Ecosystem docs:** `~/dev/layerbase-cloud/` — shared architecture, cross-project rules, infrastructure inventory.
+**Ecosystem invariants:** `~/dev/layerbase-cloud/INVARIANTS.md` — non-negotiable rules. Read before architectural changes.
 
 ## Read Before You Edit
 


### PR DESCRIPTION
The `layerbase-architecture` repo was deprecated (archived read-only) on 2026-07-11. Its living docs moved into `layerbase-cloud`. This re-points every reference in this repo to the new canonical paths (INVARIANTS.md, tracker.md, DIVERGENCES.md, docs/decisions/*, plans/). Docs/comments only, no runtime changes.