### PR TITLE
Release 0.35.1: Layerbase sponsor banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.35.1] - 2026-07-13
+
+### Documentation
+
+- Add a "Sponsored by Layerbase" banner to the README, with the Layerbase icon vendored to `assets/layerbase-icon.svg` and a link to [layerbase.com](https://layerbase.com).
+
 ## [0.35.0] - 2026-07-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # hostdb
 
+<p align="center">
+  <a href="https://layerbase.com">
+    <img src="assets/layerbase-icon.svg" alt="Layerbase" width="20" height="20" align="top" />
+    Sponsored by <strong>Layerbase</strong>
+  </a>
+</p>
+
 Pre-built database binaries for all major platforms, distributed via Cloudflare R2 (mirrored from GitHub Releases). Also a **typed npm package** (`hostdb`) that bundles the registry offline so consumers can resolve versions and download URLs without a network round-trip to `registry.layerbase.host`.
 
 **Primary consumer:** [SpinDB](https://github.com/robertjbass/spindb) — a CLI tool for spinning up local database instances. SpinDB depends on `hostdb` as a pinned npm dependency; bumping `hostdb` is how SpinDB picks up new database versions.

--- a/assets/layerbase-icon.svg
+++ b/assets/layerbase-icon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <path d="M14,40 C14,22 24,14 38,14 C48,14 56,18 58,26 C60,32 58,38 52,40" fill="none" stroke="#3FBFB0" stroke-width="3.5" stroke-linecap="round"/>
+  <circle cx="48" cy="22" r="3.5" fill="none" stroke="#3FBFB0" stroke-width="3.5"/>
+  <path d="M14,40 C8,40 4,44 6,48 C8,52 14,52 14,48 C14,46 12,44 10,46" fill="none" stroke="#3FBFB0" stroke-width="3.5" stroke-linecap="round"/>
+  <path d="M22,48 C22,42 24,40 26,42 C28,44 28,48 28,48" fill="none" stroke="#3FBFB0" stroke-width="3.5" stroke-linecap="round"/>
+  <path d="M40,46 C40,40 42,38 44,40 C46,42 46,46 46,46" fill="none" stroke="#3FBFB0" stroke-width="3.5" stroke-linecap="round"/>
+</svg>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hostdb",
-  "version": "0.35.0",
+  "version": "0.35.1",
   "description": "Pre-built database binaries for multiple platforms, plus a typed registry library for resolving versions and download URLs offline.",
   "private": false,
   "type": "module",


### PR DESCRIPTION
Release PR for 0.35.1.

- docs: add 'Sponsored by Layerbase' banner to the README (icon vendored to `assets/layerbase-icon.svg`, links to https://layerbase.com)
- chore(release): bump version to 0.35.1 + changelog

Merging to main triggers the OIDC publish of 0.35.1 to npm.

Note: GitHub sanitizes README links to `rel="nofollow"`, so the banner is visibility/click-through only — no SEO backlink value.