### PR TITLE
feat: Add QuestDB 9.4.3 (major-9 default)

### DIFF
--- a/.github/workflows/release-questdb.yml
+++ b/.github/workflows/release-questdb.yml
@@ -8,8 +8,9 @@ on:
         required: true
         type: choice
         options:
+          - 9.4.3
           - 9.2.3
-        default: 9.2.3
+        default: 9.4.3
       platforms:
         description: 'Platforms'
         required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.37.0] - 2026-08-05
+
+### Added
+
+- **QuestDB 9.4.3** (all 5 platforms: linux-x64, linux-arm64, darwin-x64, darwin-arm64, win32-x64). Repackaged from the official QuestDB 9.4.3 GitHub release: `-rt-` runtime bundles for linux-x64 and win32-x64, the `no-jre` package plus a bundled Adoptium Temurin JRE elsewhere, matching the 9.2.3 packaging.
+
+### Changed
+
+- **QuestDB default shifted from 9.2.3 to 9.4.3** (latest over previous stable). The `defaults` block now resolves major `9` to `9.4.3`, so a bare `questdb` request and `spindb create questdb` now provision 9.4.3. The 9.2 line stays fully supported: `9.2` still resolves to `9.2.3`, and existing containers self-pin their stored full version, so nothing on 9.2 is disturbed. Minor bump per the defaults-policy rule.
+
 ## [0.36.0] - 2026-07-24
 
 ### Added

--- a/builds/questdb/README.md
+++ b/builds/questdb/README.md
@@ -9,6 +9,7 @@ Download and repackage QuestDB binaries for distribution via GitHub Releases.
 ## Supported Versions
 
 - 9.2.3
+- 9.4.3
 
 ## Supported Platforms
 
@@ -42,7 +43,7 @@ The bundled JRE is placed in `questdb/jre/` within the archive.
 pnpm download:questdb
 
 # Download specific version
-pnpm download:questdb -- --version 9.2.3
+pnpm download:questdb -- --version 9.4.3
 
 # Download for all platforms
 pnpm download:questdb -- --all-platforms

--- a/builds/questdb/download.ts
+++ b/builds/questdb/download.ts
@@ -4,7 +4,7 @@
  *
  * Usage:
  *   pnpm download:questdb
- *   pnpm download:questdb -- --version 9.2.3
+ *   pnpm download:questdb -- --version 9.4.3
  *   pnpm download:questdb -- --all-platforms
  *
  * QuestDB distribution:
@@ -392,7 +392,7 @@ function parseArgs(): {
   outputDir: string
 } {
   const args = process.argv.slice(2)
-  let version = '9.2.3'
+  let version = '9.4.3'
   let platforms: Platform[] = []
   let outputDir = './dist'
   let allPlatforms = false
@@ -453,7 +453,7 @@ Usage: pnpm download:questdb [options]
 Downloads and bundles QuestDB with JRE for all platforms.
 
 Options:
-  --version VERSION    QuestDB version (default: 9.2.3)
+  --version VERSION    QuestDB version (default: 9.4.3)
   --platform PLATFORM  Target platform (default: current)
   --output DIR         Output directory (default: ./dist)
   --all-platforms      Download for all platforms
@@ -467,7 +467,7 @@ Notes:
 
 Examples:
   pnpm download:questdb
-  pnpm download:questdb -- --version 9.2.3 --platform linux-x64
+  pnpm download:questdb -- --version 9.4.3 --platform linux-x64
   pnpm download:questdb -- --all-platforms
 `)
         process.exit(0)

--- a/builds/questdb/sources.json
+++ b/builds/questdb/sources.json
@@ -33,6 +33,38 @@
         "sourceType": "official",
         "sha256": "93164bfbe3a710c5f64dbc58bd7454c9b0c58fb144a0e2a0bdcaae7198feb279"
       }
+    },
+    "9.4.3": {
+      "linux-x64": {
+        "url": "https://github.com/questdb/questdb/releases/download/9.4.3/questdb-9.4.3-rt-linux-x86-64.tar.gz",
+        "format": "tar.gz",
+        "sourceType": "official",
+        "sha256": "2324f5920d6476843df6c35ad975bed18bba10f3459f67fd243f48f15e438cd5"
+      },
+      "linux-arm64": {
+        "url": "https://github.com/questdb/questdb/releases/download/9.4.3/questdb-9.4.3-no-jre-bin.tar.gz",
+        "format": "tar.gz",
+        "sourceType": "official",
+        "sha256": "7fc11a03b8e2ab85314226b7b10bed54dfefe1d87c7ec836e85c8ad6175e7d5c"
+      },
+      "darwin-x64": {
+        "url": "https://github.com/questdb/questdb/releases/download/9.4.3/questdb-9.4.3-no-jre-bin.tar.gz",
+        "format": "tar.gz",
+        "sourceType": "official",
+        "sha256": "7fc11a03b8e2ab85314226b7b10bed54dfefe1d87c7ec836e85c8ad6175e7d5c"
+      },
+      "darwin-arm64": {
+        "url": "https://github.com/questdb/questdb/releases/download/9.4.3/questdb-9.4.3-no-jre-bin.tar.gz",
+        "format": "tar.gz",
+        "sourceType": "official",
+        "sha256": "7fc11a03b8e2ab85314226b7b10bed54dfefe1d87c7ec836e85c8ad6175e7d5c"
+      },
+      "win32-x64": {
+        "url": "https://github.com/questdb/questdb/releases/download/9.4.3/questdb-9.4.3-rt-windows-x86-64.tar.gz",
+        "format": "tar.gz",
+        "sourceType": "official",
+        "sha256": "ff8e0cade90559720c78660e1391b9dc95ec0d365dac496c00212ff3095d40f5"
+      }
     }
   },
   "notes": {

--- a/databases.json
+++ b/databases.json
@@ -747,10 +747,11 @@
         }
       ],
       "defaults": {
-        "9": "9.2.3"
+        "9": "9.4.3"
       },
       "versions": {
-        "9.2.3": true
+        "9.2.3": true,
+        "9.4.3": true
       },
       "platforms": [
         "linux-x64",

--- a/databases.yml
+++ b/databases.yml
@@ -617,9 +617,10 @@ databases:
         cascade_delete: false
         note: QuestDB uses PostgreSQL client tools (psql, pgcli) for its wire protocol; PostgreSQL remains installed as a standalone database when QuestDB is removed
     defaults:
-      '9': '9.2.3'
+      '9': '9.4.3'
     versions:
       9.2.3: true
+      9.4.3: true
     platforms:
       - linux-x64
       - linux-arm64

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hostdb",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "description": "Pre-built database binaries for multiple platforms, plus a typed registry library for resolving versions and download URLs offline.",
   "private": false,
   "type": "module",

--- a/tests/defaults-sync.test.ts
+++ b/tests/defaults-sync.test.ts
@@ -151,9 +151,11 @@ const SNAPSHOT: Record<string, Record<string, string>> = {
     '1.16.3': '1.16.3',
   },
   questdb: {
-    '9': '9.2.3',
+    '9': '9.4.3',
     '9.2': '9.2.3',
+    '9.4': '9.4.3',
     '9.2.3': '9.2.3',
+    '9.4.3': '9.4.3',
   },
   redis: {
     // 0.32.0 policy change: '7' now resolves to 7.2.14 (BSD-3-Clause) instead of


### PR DESCRIPTION
Adds QuestDB 9.4.3 across all 5 platforms and makes it the default patch for major 9.

## Changes

- `databases.yml`: `9.4.3: true` added, `defaults.'9'` shifted from 9.2.3 to 9.4.3. 9.2.3 kept for backward compatibility.
- `builds/questdb/sources.json`: 9.4.3 URLs + sha256 for linux-x64, linux-arm64, darwin-x64, darwin-arm64, win32-x64. Same packaging pattern as 9.2.3 (`-rt-` bundles for linux-x64 / win32-x64, `no-jre` + bundled Adoptium Temurin JRE elsewhere).
- `tests/defaults-sync.test.ts`: questdb block updated for the new default.
- `package.json` 0.36.0 -> 0.37.0 (minor: defaults-policy change) + CHANGELOG entry.
- `databases.json` and the `release-questdb.yml` dropdown regenerated by `pnpm prep`.
- `builds/questdb/README.md` + `download.ts` default version refreshed to 9.4.3.

## Verification

- Upstream release: https://github.com/questdb/questdb/releases/tag/9.4.3 (published 2026-06-15).
- QuestDB publishes no checksum file, so each asset was downloaded and its sha256 computed locally.
- `pnpm prep` and `pnpm prep --check` clean; `pnpm test` 186/186 green.
- The only prep discrepancy is the expected "9.4.3 is enabled but not released" notice; the release workflow is dispatched after this merges to dev.