### PR TITLE
fix(valkey): Build Windows with -D_GNU_SOURCE so asprintf resolves

### DIFF
--- a/.github/workflows/release-valkey.yml
+++ b/.github/workflows/release-valkey.yml
@@ -316,7 +316,10 @@ jobs:
 
           # Build with TLS support and Windows-compatible flags
           # -Wno-char-subscripts suppresses warnings, -O0 helps compatibility
-          make -j$(nproc) BUILD_TLS=yes CFLAGS="-Wno-char-subscripts -O0"
+          # -D_GNU_SOURCE exposes the GNU extensions Cygwin's newlib headers gate
+          # behind __GNU_VISIBLE. Valkey 9.0.5 calls asprintf() in valkey-benchmark.c,
+          # which is otherwise an implicit declaration and a hard error on Cygwin.
+          make -j$(nproc) BUILD_TLS=yes CFLAGS="-Wno-char-subscripts -O0 -D_GNU_SOURCE"
 
           # Install
           make PREFIX="$(pwd)/../install/valkey" install


### PR DESCRIPTION
Valkey 9.0.5's `win32-x64` release build failed twice with:

```
valkey-benchmark.c:2444:23: error: implicit declaration of function 'asprintf'; did you mean 'asnprintf'?
make[1]: *** [Makefile:548: valkey-benchmark.o] Error 1
```

Cygwin's newlib headers gate the GNU extensions behind `__GNU_VISIBLE`, so `asprintf()` is not declared unless `_GNU_SOURCE` is defined. gcc treats the resulting implicit declaration as a hard error, so the whole 9.0.5 release was blocked even though the other four platforms built clean (and 8.0.10 was unaffected, since it does not make that call).

This adds `-D_GNU_SOURCE` to the Cygwin build's `CFLAGS`. It generalizes the workaround already in this step, which force-sets `__GNU_VISIBLE` to 1 in `dlfcn.h` for the same underlying reason.

Verified by re-dispatching `release-valkey.yml` for 9.0.5 off `dev` after this merges.