### PR TITLE
fix(weaviate): Bump release Go toolchain to 1.26 for cross-compiles

### DIFF
--- a/.github/workflows/release-weaviate.yml
+++ b/.github/workflows/release-weaviate.yml
@@ -114,7 +114,11 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.23'
+          # Must be >= the go directive in Weaviate's go.mod (1.26 as of 1.38.8).
+          # The cross-compile step runs with GOTOOLCHAIN=local, so an older Go here
+          # does not auto-upgrade: it fails the darwin/win32 builds with
+          # "go.mod requires go >= 1.26" while the workflow still reports success.
+          go-version: '1.26'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
Weaviate 1.38.8 shipped with only `linux-x64` and `linux-arm64` instead of all five platforms.

Cause: `release-weaviate.yml` pinned `go-version: '1.23'`, but Weaviate 1.38.8's `go.mod` requires `go >= 1.26`. The cross-compile step runs with `GOTOOLCHAIN=local`, so Go does not auto-upgrade and every cross-compile failed with:

```
go: go.mod requires go >= 1.26 (running go 1.23.12; GOTOOLCHAIN=local)
```

**This failed silently.** The build script counts a failed cross-compile as a skipped platform, so the `build` job, the run, and `update-releases` all reported success while three platforms were quietly missing from `releases.json`. Worth a follow-up to make a requested-but-unbuilt platform fail the run; leaving that out of this change to keep it to the actual regression.

After this merges, re-dispatch `release-weaviate.yml` for 1.38.8 to backfill the three missing platforms.