### PR TITLE
release: hostdb 0.38.1 - complete engine security + feature wave

### DIFF
--- a/.github/workflows/release-valkey.yml
+++ b/.github/workflows/release-valkey.yml
@@ -316,7 +316,10 @@ jobs:
 
           # Build with TLS support and Windows-compatible flags
           # -Wno-char-subscripts suppresses warnings, -O0 helps compatibility
-          make -j$(nproc) BUILD_TLS=yes CFLAGS="-Wno-char-subscripts -O0"
+          # -D_GNU_SOURCE exposes the GNU extensions Cygwin's newlib headers gate
+          # behind __GNU_VISIBLE. Valkey 9.0.5 calls asprintf() in valkey-benchmark.c,
+          # which is otherwise an implicit declaration and a hard error on Cygwin.
+          make -j$(nproc) BUILD_TLS=yes CFLAGS="-Wno-char-subscripts -O0 -D_GNU_SOURCE"
 
           # Install
           make PREFIX="$(pwd)/../install/valkey" install

--- a/.github/workflows/release-weaviate.yml
+++ b/.github/workflows/release-weaviate.yml
@@ -114,7 +114,11 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.23'
+          # Must be >= the go directive in Weaviate's go.mod (1.26 as of 1.38.8).
+          # The cross-compile step runs with GOTOOLCHAIN=local, so an older Go here
+          # does not auto-upgrade: it fails the darwin/win32 builds with
+          # "go.mod requires go >= 1.26" while the workflow still reports success.
+          go-version: '1.26'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.38.1] - 2026-08-05
+
+Metadata-only republish of the 0.38.0 engine wave. No `databases.yml` change, no resolver change, no defaults change: every version resolves exactly as it does on 0.38.0.
+
+### Fixed
+
+- **`releases.json` in the published package now lists all 21 versions from the wave.** 0.38.0 reached `main` and published to npm while four release workflows were still building, so its bundled `releases.json` snapshot was missing `valkey 9.0.5`, `redis 8.4.5`, `influxdb 3.10.5` and `mariadb 11.8.8`. `getReleaseInfo` returned null for those, `valkey 9.0.5` (the CVE-2026-56684 / CVE-2026-63639 fix) among them, even though the binaries were on R2. This republish carries the complete snapshot. Release-before-publish ordering is the standing rule; see the engine-version runbook.
+- **Valkey Windows builds define `-D_GNU_SOURCE`.** Valkey 9.0.5 calls `asprintf()` in `valkey-benchmark.c`, which Cygwin's newlib headers gate behind `__GNU_VISIBLE`. Without it the call is an implicit declaration and a hard error, and it blocked the entire 9.0.5 release even though the other four platforms built clean. 9.0.5 now ships on all five platforms.
+- **Weaviate release builds use Go 1.26.** Weaviate 1.38.8's `go.mod` requires `go >= 1.26` while the workflow pinned 1.23. Because the cross-compile runs with `GOTOOLCHAIN=local`, Go did not auto-upgrade and the darwin-x64, darwin-arm64 and win32-x64 builds failed. The build script counts a failed cross-compile as a skipped platform, so the run still reported success and 1.38.8 first shipped with only its two linux platforms. It now ships on all five.
+
+### Known issue
+
+- A requested-but-unbuilt platform does not fail a release run: the per-engine build scripts report it as "skipped" and the workflow still concludes success. That is how the Weaviate gap above stayed invisible until `releases.json` was inspected by hand. Worth making a platform that was requested and did not build a hard failure.
+
 ## [0.38.0] - 2026-08-05
 
 Engine security + feature wave. Thirteen engines gain new versions in one release; no existing version was removed, and every prior version still resolves.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hostdb",
-  "version": "0.38.0",
+  "version": "0.38.1",
   "description": "Pre-built database binaries for multiple platforms, plus a typed registry library for resolving versions and download URLs offline.",
   "private": false,
   "type": "module",


### PR DESCRIPTION
Follow-up release closing out the 0.38.0 engine wave. Carries a patch version bump plus the two build fixes that the wave uncovered.

## Why this exists

**hostdb 0.38.0 is already on npm, and its bundled `releases.json` is incomplete.** PR #208 (`dev -> main`) merged at 20:15 UTC while four of the eighteen release workflows were still building, so `publish.yml` shipped 0.38.0 with a snapshot that lacks:

- `valkey 9.0.5` (the CVE-2026-56684 / CVE-2026-63639 fix this wave exists for)
- `redis 8.4.5`
- `influxdb 3.10.5`
- `mariadb 11.8.8`

The binaries are all on R2, but `getReleaseInfo` returns null for those four on 0.38.0. **0.38.1 is a metadata-only republish carrying the complete snapshot.** No `databases.yml` change, no resolver change, no defaults change: every version resolves exactly as it does on 0.38.0.

This is the failure mode the runbook's release-before-publish rule guards against.

## Also included

Two genuine build regressions found while releasing, each fixed and verified by a successful re-dispatch:

- **`fix/valkey-cygwin-gnu-source` (#210)** - Valkey 9.0.5 calls `asprintf()` in `valkey-benchmark.c`, which Cygwin's newlib headers gate behind `__GNU_VISIBLE`. Without `-D_GNU_SOURCE` it is an implicit declaration and a hard error, and it blocked the whole 9.0.5 release (failed twice) even though the other four platforms built clean. 9.0.5 now ships on all five platforms.
- **`fix/weaviate-go-126` (#211)** - Weaviate 1.38.8's `go.mod` requires `go >= 1.26` while the workflow pinned Go 1.23. With `GOTOOLCHAIN=local` Go does not auto-upgrade, so all three cross-compiles failed. The build script counts a failed cross-compile as a *skipped* platform, so the run reported success and 1.38.8 first shipped with only its two linux platforms. It now ships on all five.

## State of the wave

All 21 versions across 13 engines are released, on R2, and in `releases.json` with full platform coverage (5 platforms each; `influxdb 3.10.5` also picked up darwin-x64 from a source build).

| Engine | Versions |
|---|---|
| Valkey | 9.0.5, 8.0.10 |
| Redis | 7.2.15, 8.4.5, 7.4.10 |
| MongoDB | 8.0.28, 8.2.12, 7.0.39 |
| MySQL | 8.4.11, 9.7.2 |
| MariaDB | 11.8.8 |
| TypeDB | 3.12.1 |
| Meilisearch | 1.52.0 |
| Qdrant | 1.18.3 |
| Weaviate | 1.38.8 |
| InfluxDB | 3.10.5 |
| SQLite | 3.53.4 |
| CouchDB | 3.5.2 |

`pnpm prep --check` is clean; the only warnings are the 2 pre-existing orphaned `win32-x64` entries that predate this work.

## Known issue worth a follow-up

A requested-but-unbuilt platform does not fail a release run: the build scripts report it as "skipped" and the workflow still concludes success. That is exactly how the Weaviate gap stayed invisible until `releases.json` was read by hand. Making a requested platform that did not build a hard failure would have caught it at the source.

## Downstream

Once this publishes, the cascade continues per the runbook: spindb exact-pins `hostdb@0.38.1` (**not** 0.38.0, whose snapshot is incomplete), then layerbase-cloud `SPINDB_VERSION`, then desktop. No cloud `engine-registry.ts` edit is needed for the patch-only lines; MySQL 9.7.2 and the other new patches resolve by prefix.