### PR TITLE
release: hostdb 0.38.2 - QuestDB 9.4.3 JRE 25 fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.38.2] - 2026-08-06
+
+### Fixed
+
+- **QuestDB 9.4.3 now starts on `darwin-arm64`, `darwin-x64` and `linux-arm64`.** Those three platforms have no official QuestDB `-rt-` package, so hostdb repackages the `no-jre` tarball with an Adoptium Temurin JRE it bundles itself, and that JRE was pinned to the 21 line. QuestDB 9.4.x's `questdb.sh` passes `--sun-misc-unsafe-memory-access=allow`, a flag that only exists from JDK 24 on, so the JVM exited with `Unrecognized option` / `Could not create the Java Virtual Machine` before QuestDB ever started. The bundled JRE moves to the Temurin 25 LTS line (`api.adoptium.net/v3/binary/latest/25/ga/...`). `linux-x64` and `win32-x64` use QuestDB's own runtime bundles and were never affected.
+
 ## [0.38.1] - 2026-08-05
 
 Metadata-only republish of the 0.38.0 engine wave. No `databases.yml` change, no resolver change, no defaults change: every version resolves exactly as it does on 0.38.0.

--- a/builds/questdb/README.md
+++ b/builds/questdb/README.md
@@ -24,17 +24,19 @@ Download and repackage QuestDB binaries for distribution via GitHub Releases.
 | Source | Platforms | Format | Notes |
 |--------|-----------|--------|-------|
 | Official `-rt-` package | linux-x64, win32-x64 | tar.gz | JRE included by QuestDB |
-| Official no-JRE + Adoptium JRE 21 | linux-arm64, darwin-x64, darwin-arm64 | tar.gz | Bundled by hostdb |
+| Official no-JRE + Adoptium JRE 25 | linux-arm64, darwin-x64, darwin-arm64 | tar.gz | Bundled by hostdb |
 
 ### JRE Bundling
 
 QuestDB only provides runtime packages (`-rt-`) for Linux x64 and Windows x64. For other platforms, we:
 
 1. Download the official `no-jre` package from QuestDB GitHub releases
-2. Download Adoptium Temurin JRE 21 LTS for the target platform
+2. Download Adoptium Temurin JRE 25 LTS for the target platform
 3. Bundle them together into a single archive
 
 The bundled JRE is placed in `questdb/jre/` within the archive.
+
+The JRE line must be 24 or newer: QuestDB 9.4.x's `questdb.sh` passes `--sun-misc-unsafe-memory-access=allow`, a flag that only exists from JDK 24 on. A JRE 21 bundle makes the JVM exit with `Unrecognized option` before QuestDB starts.
 
 ## Usage
 

--- a/builds/questdb/download.ts
+++ b/builds/questdb/download.ts
@@ -9,7 +9,7 @@
  *
  * QuestDB distribution:
  * - Linux x64, Windows x64: Official -rt- packages with bundled JRE
- * - Linux ARM64, macOS: No-JRE package + bundled Adoptium Temurin JRE 21
+ * - Linux ARM64, macOS: No-JRE package + bundled Adoptium Temurin JRE 25
  */
 
 import {
@@ -54,14 +54,16 @@ const PLATFORMS_NEEDING_JRE: Platform[] = [
   'darwin-arm64',
 ]
 
-// Adoptium JRE download URLs (using latest JRE 21 LTS)
+// Adoptium JRE download URLs (using latest JRE 25 LTS)
+// QuestDB 9.4.x passes --sun-misc-unsafe-memory-access=allow, a JDK 24+ flag,
+// so a JRE 21 bundle fails to start with "Unrecognized option".
 const JRE_URLS: Record<string, string> = {
   'linux-arm64':
-    'https://api.adoptium.net/v3/binary/latest/21/ga/linux/aarch64/jre/hotspot/normal/eclipse',
+    'https://api.adoptium.net/v3/binary/latest/25/ga/linux/aarch64/jre/hotspot/normal/eclipse',
   'darwin-x64':
-    'https://api.adoptium.net/v3/binary/latest/21/ga/mac/x64/jre/hotspot/normal/eclipse',
+    'https://api.adoptium.net/v3/binary/latest/25/ga/mac/x64/jre/hotspot/normal/eclipse',
   'darwin-arm64':
-    'https://api.adoptium.net/v3/binary/latest/21/ga/mac/aarch64/jre/hotspot/normal/eclipse',
+    'https://api.adoptium.net/v3/binary/latest/25/ga/mac/aarch64/jre/hotspot/normal/eclipse',
 }
 
 function isValidPlatform(value: string): value is Platform {
@@ -265,12 +267,12 @@ async function downloadAndExtractJre(
     throw new Error(`No JRE URL for platform: ${platform}`)
   }
 
-  const jreDownloadPath = join(downloadDir, `jre-21-${platform}.tar.gz`)
+  const jreDownloadPath = join(downloadDir, `jre-25-${platform}.tar.gz`)
 
   if (existsSync(jreDownloadPath)) {
     logInfo(`Using cached JRE download: ${basename(jreDownloadPath)}`)
   } else {
-    logInfo('=== Downloading Adoptium JRE 21 ===')
+    logInfo('=== Downloading Adoptium JRE 25 ===')
     await downloadFile(jreUrl, jreDownloadPath)
   }
 
@@ -280,7 +282,7 @@ async function downloadAndExtractJre(
   mkdirSync(jreExtractDir, { recursive: true })
   extractTarGz(jreDownloadPath, jreExtractDir)
 
-  // Find the JRE directory (format: jdk-21.x.x+y-jre on Linux, or jdk-21.x.x+y-jre/Contents/Home on macOS)
+  // Find the JRE directory (format: jdk-25.x.x+y-jre on Linux, or jdk-25.x.x+y-jre/Contents/Home on macOS)
   const jreDir = findDirectory(jreExtractDir, 'jdk-')
   if (!jreDir) {
     throw new Error('Could not find extracted JRE directory')
@@ -354,7 +356,7 @@ async function repackage(
     version,
     platform,
     source: 'official',
-    jre_bundled: jreDir ? 'adoptium-21' : 'included',
+    jre_bundled: jreDir ? 'adoptium-25' : 'included',
     rehosted_by: 'hostdb',
     rehosted_at: new Date().toISOString(),
   }
@@ -463,7 +465,7 @@ Platforms: linux-x64, linux-arm64, darwin-x64, darwin-arm64, win32-x64
 
 Notes:
   - Linux x64 and Windows x64 use official -rt- packages (JRE included)
-  - Linux ARM64 and macOS use no-JRE package + bundled Adoptium JRE 21
+  - Linux ARM64 and macOS use no-JRE package + bundled Adoptium JRE 25
 
 Examples:
   pnpm download:questdb

--- a/builds/questdb/sources.json
+++ b/builds/questdb/sources.json
@@ -69,7 +69,7 @@
   },
   "notes": {
     "source": "Official QuestDB releases from GitHub",
-    "jre-bundling": "QuestDB only provides runtime packages (-rt-) for Linux x64 and Windows x64. Other platforms use the no-JRE package bundled with Adoptium Temurin JRE 21 LTS.",
+    "jre-bundling": "QuestDB only provides runtime packages (-rt-) for Linux x64 and Windows x64. Other platforms use the no-JRE package bundled with Adoptium Temurin JRE 25 LTS. QuestDB 9.4.x passes --sun-misc-unsafe-memory-access=allow, which requires JDK 24 or newer.",
     "linux-arm64": "Uses no-jre package + bundled Adoptium JRE",
     "darwin-x64": "Uses no-jre package + bundled Adoptium JRE",
     "darwin-arm64": "Uses no-jre package + bundled Adoptium JRE"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hostdb",
-  "version": "0.38.1",
+  "version": "0.38.2",
   "description": "Pre-built database binaries for multiple platforms, plus a typed registry library for resolving versions and download URLs offline.",
   "private": false,
   "type": "module",


### PR DESCRIPTION
Release PR for hostdb 0.38.2.

## What is in it

**QuestDB 9.4.3 would not start on `darwin-arm64`, `darwin-x64` or `linux-arm64`.** Those three platforms have no official QuestDB `-rt-` package, so `builds/questdb/download.ts` repackages the upstream `no-jre` tarball with an Adoptium Temurin JRE that hostdb bundles itself. That JRE was pinned to the 21 line, while QuestDB 9.4.x's `questdb.sh` passes `--sun-misc-unsafe-memory-access=allow`, a flag that only exists from JDK 24 on. The JVM exited with `Unrecognized option` / `Could not create the Java Virtual Machine` before QuestDB started. `linux-x64` and `win32-x64` use QuestDB's own runtime bundles and were never affected.

`JRE_URLS` now points at the Adoptium `/25/` endpoints (Temurin 25 LTS, currently `jdk-25.0.4+7`). No other engine bundles a JRE.

## Release-first ordering is satisfied

The JRE is baked into the artifact at release time, so the fix required rebuilding the 9.4.3 binaries, not just shipping code. That already happened before this PR:

- Re-release run: https://github.com/robertjbass/hostdb/actions/runs/31127131187 (success, all five platforms)
- `releases.json` bot commit `a6f8d6e` is on `main` and merged back into `dev` as `7970151`, so the `publish.yml` drift gate is clean (`git diff origin/main origin/dev -- releases.json` is empty).

## Artifact verification (not just a green tick)

Downloaded the new `darwin-arm64` tarball from R2 (`registry.layerbase.host`):

- size `89,153,331` bytes, up from `80,988,883`
- sha256 `f3b2d595fefcb2f536fc0ce213004b387bf792b58f2959b85a493ac427307f18`, matching `releases.json`
- `.hostdb-metadata.json` -> `"jre_bundled": "adoptium-25"`
- `jre/bin/java -version` -> `OpenJDK Runtime Environment Temurin-25.0.4+7 (build 25.0.4+7-LTS)`
- started it and ran a query: `select 1 as ok` -> `{"dataset":[[1]],"count":1}`

`darwin-x64` and `linux-arm64` both report `"jre_bundled": "adoptium-25"` and `JAVA_VERSION="25.0.4"` in `jre/release`.

## Note on the previous publish

`publish.yml` for 0.38.1 (commit `dcc084b`) failed during the GitHub Actions outage at `Set up job` with `Failed to resolve action download info. Error: Service Unavailable`, so npm `latest` is still `0.38.0`. That run was deliberately left alone; merging this PR publishes 0.38.2, which supersedes it.