### PR TITLE
release: hostdb 0.38.3 - qdrant glibc + couchdb linux fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.38.3] - 2026-08-06
+
+Linux packaging fixes for two engines in the 0.38.0 wave. Both were caught by spindb's full engine matrix (robertjbass/spindb#268), both are repackages of the same upstream version, and no `databases.yml` entry, default or resolver behaviour changes.
+
+### Fixed
+
+- **Qdrant 1.18.3 `linux-x64` now runs on Ubuntu 22.04.** Upstream builds `qdrant-x86_64-unknown-linux-gnu.tar.gz` for 1.18.3 against a newer glibc than 1.16.3 was: the binary imports `GLIBC_2.38`, so on Ubuntu 22.04 (glibc 2.35) it never execs, failing at spindb's post-download `qdrant --version` verification with ``version `GLIBC_2.38' not found``. Ubuntu 24.04 (glibc 2.39) was unaffected, which is why only half the matrix went red. `linux-x64` now uses upstream's `qdrant-x86_64-unknown-linux-musl.tar.gz`, the same static musl asset `linux-arm64` has always used. Verified in `ubuntu:22.04`: the musl binary is `static-pie linked`, starts, and answers `/healthz`, `/` and `/collections`. 1.16.3 keeps the gnu asset (it only needs `GLIBC_2.34`).
+- **CouchDB 3.5.2 `linux-x64` / `linux-arm64` now start on Ubuntu 22.04 and 24.04.** `builds/couchdb/Dockerfile` copied `/opt/couchdb` out of the official `couchdb:<version>` image but not the system libraries the bundled Erlang runtime links against, so the extracted tree silently inherited that image's base distro. The 3.5.2 image moved from Debian 12 (bookworm, glibc 2.36 / OpenSSL 3.0) to Debian 13 (trixie, glibc 2.41 / OpenSSL 3.5), which broke both supported baselines in different ways: on 22.04 `beam.smp` needs `GLIBC_2.38` and never execs, and on 24.04 it execs but `crypto.so` needs `OPENSSL_3.4.0`, so the crypto NIF fails to load and the node aborts with `{application_start_failure,config,{undef,{crypto,info_fips,[]}}}`. CI only saw "start timeout, then ECONNREFUSED" because `couchdb.log` was never dumped. Linux packaging now builds from the official Apache CouchDB apt repository (`couchdb=<version>~jammy`) inside `ubuntu:22.04` - our oldest supported Linux target - and unpacks the package with `dpkg-deb -x` so no maintainer script can bake a debconf admin password, node name or Erlang cookie into a redistributable tarball. Verified in `ubuntu:22.04` and `ubuntu:24.04` (x64) and `ubuntu:22.04` (arm64): CouchDB 3.5.2 starts and answers `GET /` on 5984. Rebuilding 3.5.1 through the new path was also verified and yields the same `erts-14.2.5.12` the shipping 3.5.1 tarball has.
+
+### Changed
+
+- **CouchDB Linux trees are normalized after unpacking**, so the tarball keeps the shape the working 3.5.1 artifact had. The package's FHS symlinks (`data -> /var/lib/couchdb`, `var/log -> /var/log/couchdb`) become real in-tree directories - `database_dir` defaults to `./data`, and with a dangling symlink `mem3` cannot create `_nodes` and the node dies with `{case_clause,{not_found,no_db_file}}`. The package's `10-filelog.ini` (which pins logging to `/var/log/couchdb`) is dropped, `etc/default.d/10-docker-default.ini` (`bind_address = any`) is restored, and the packaged `-name` line is stripped from `vm.args` so the node name comes from the caller. spindb generates its own `local.ini` and `vm.args`, so none of this changes how a spindb container is configured.
+
+### Note
+
+- The wave's other url-sourced `linux-x64` binaries were swept for the same glibc hazard (`objdump -T`, highest imported symbol version): influxdb 3.10.5 `2.18`, typedb 3.12.1 `2.25`, mysql 9.7.2 `2.28`, qdrant 1.16.3 `2.34`, meilisearch 1.52.0 `2.35`, mongodb 8.2.12 `2.35`, weaviate 1.38.8 none (static). All run on Ubuntu 22.04 today, and all of those engines passed spindb's 22.04 matrix. Meilisearch and MongoDB sit exactly at the 2.35 ceiling, so they are the two most likely to trip this next.
+
 ## [0.38.2] - 2026-08-06
 
 ### Fixed

--- a/builds/couchdb/Dockerfile
+++ b/builds/couchdb/Dockerfile
@@ -1,56 +1,100 @@
 # CouchDB Extraction Dockerfile
-# Extracts CouchDB from official Docker image for Linux platforms
+# Packages CouchDB for Linux from the official Apache CouchDB apt repository.
 #
-# The official CouchDB Docker image contains a complete, pre-built installation
-# with all dependencies (Erlang, ICU, OpenSSL, etc.) statically linked.
-# This Dockerfile extracts that installation for portable use.
+# WHY NOT THE OFFICIAL DOCKER IMAGE (the 3.5.2 regression):
+#   Until 3.5.1 this file copied /opt/couchdb out of `couchdb:<version>`. That
+#   image tracks Debian stable, and the 3.5.2 image moved from Debian 12
+#   (bookworm, glibc 2.36 / OpenSSL 3.0) to Debian 13 (trixie, glibc 2.41 /
+#   OpenSSL 3.5). The bundled Erlang runtime is linked against the image's
+#   system libraries, which we do NOT copy, so the extracted tree stopped
+#   running on our supported Linux baselines:
+#     - Ubuntu 22.04 (glibc 2.35): beam.smp needs GLIBC_2.38, exec fails
+#     - Ubuntu 24.04 (OpenSSL 3.0): crypto.so needs OPENSSL_3.4.0, the crypto
+#       NIF fails to load and CouchDB dies with `{undef,{crypto,info_fips,[]}}`
+#
+#   Apache publishes per-distro CouchDB packages, so we build against `jammy`
+#   (Ubuntu 22.04) - exactly our oldest supported target - which yields a tree
+#   that runs on 22.04 and every newer glibc/OpenSSL 3.0 distro.
+#
+# The .deb is unpacked with `dpkg-deb -x` (no postinst): the maintainer scripts
+# inject a debconf admin password, a node name and an Erlang cookie into the
+# config, which must never ship inside a redistributable tarball.
 #
 # Usage:
 #   docker buildx build --platform linux/amd64 \
-#     --build-arg VERSION=3.5.1 \
+#     --build-arg VERSION=3.5.2 \
 #     --output type=local,dest=./downloads \
 #     -f builds/couchdb/Dockerfile .
 #
-# Extraction time: ~1-2 minutes (pulling image + copying files)
+# Extraction time: ~2-3 minutes (package download + unpack)
 
-ARG VERSION=3.5.1
-
-# =============================================================================
-# Stage 1: Extract from official image
-# =============================================================================
-FROM couchdb:${VERSION} AS source
-
-# Nothing to do here - we just need the base image
+ARG VERSION=3.5.2
 
 # =============================================================================
-# Stage 2: Package
+# Stage 1: Fetch + unpack the Apache CouchDB package
 # =============================================================================
 FROM ubuntu:22.04 AS packager
 
 ARG VERSION
 ARG TARGETARCH
 
-# Install minimal tools for packaging
+ENV DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
+    curl \
+    gnupg \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy CouchDB installation from official image
-# CouchDB is installed at /opt/couchdb in the official image
-COPY --from=source /opt/couchdb /opt/couchdb
+# Official Apache CouchDB apt repository (jammy = Ubuntu 22.04 baseline)
+RUN curl -fsSL https://couchdb.apache.org/repo/keys.asc \
+      | gpg --dearmor -o /usr/share/keyrings/couchdb-archive-keyring.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/couchdb-archive-keyring.gpg] https://apache.jfrog.io/artifactory/couchdb-deb jammy main" \
+      > /etc/apt/sources.list.d/couchdb.list
+
+# Download and unpack WITHOUT running maintainer scripts
+RUN apt-get update \
+    && mkdir -p /tmp/deb /tmp/unpacked \
+    && cd /tmp/deb \
+    && apt-get download "couchdb=${VERSION}~jammy" \
+    && dpkg-deb -x /tmp/deb/couchdb_*.deb /tmp/unpacked \
+    && rm -rf /tmp/deb /var/lib/apt/lists/* \
+    && mv /tmp/unpacked/opt/couchdb /opt/couchdb
 
 WORKDIR /opt/couchdb
+
+# Normalize the tree to the portable layout hostdb has always shipped:
+#  - replace the FHS symlinks (data -> /var/lib/couchdb, var/log ->
+#    /var/log/couchdb) with real in-tree directories. `database_dir` defaults to
+#    ./data, so a dangling symlink makes mem3 fail to create `_nodes` and the
+#    node dies with `{case_clause,{not_found,no_db_file}}`
+#  - drop the package default that pins logging to /var/log/couchdb (absent in a
+#    relocatable install); spindb supplies its own [log] settings
+#  - restore the permissive default bind address the previous tarballs carried
+#  - drop the packaged `-name` so the node name comes from the caller's vm.args
+RUN rm -f /opt/couchdb/data /opt/couchdb/var/log \
+    && mkdir -p /opt/couchdb/data /opt/couchdb/var/log \
+    && rm -f /opt/couchdb/etc/default.d/10-filelog.ini \
+    && printf '; CouchDB Configuration Settings\n\n; Custom settings should be made in this file. They will override settings\n; in default.ini, but unlike changes made to default.ini, this file won'"'"'t be\n; overwritten on server upgrade.\n\n[chttpd]\nbind_address = any\n' \
+      > /opt/couchdb/etc/default.d/10-docker-default.ini \
+    && sed -i '/^-name /d' /opt/couchdb/etc/vm.args \
+    && chmod 644 /opt/couchdb/etc/vm.args \
+    && chown -R root:root /opt/couchdb
 
 # Map Docker TARGETARCH to hostdb platform naming
 RUN PLATFORM="linux-x64"; \
     if [ "$TARGETARCH" = "arm64" ]; then PLATFORM="linux-arm64"; fi; \
-    printf '{\n  "name": "couchdb",\n  "version": "%s",\n  "platform": "%s",\n  "source": "docker-extract",\n  "sourceUrl": "https://hub.docker.com/_/couchdb",\n  "dockerImage": "couchdb:%s",\n  "rehosted_by": "hostdb",\n  "rehosted_at": "%s"\n}\n' \
+    printf '{\n  "name": "couchdb",\n  "version": "%s",\n  "platform": "%s",\n  "source": "docker-extract",\n  "sourceUrl": "https://couchdb.apache.org/repo",\n  "debPackage": "couchdb=%s~jammy",\n  "rehosted_by": "hostdb",\n  "rehosted_at": "%s"\n}\n' \
         "${VERSION}" "${PLATFORM}" "${VERSION}" "$(date -Iseconds)" \
         > /opt/couchdb/.hostdb-metadata.json
 
 # Verify key files exist
 RUN test -f /opt/couchdb/bin/couchdb \
     && test -d /opt/couchdb/etc \
+    && test -f /opt/couchdb/etc/vm.args \
+    && test -d /opt/couchdb/data && test ! -L /opt/couchdb/data \
+    && test -d /opt/couchdb/var/log && test ! -L /opt/couchdb/var/log \
+    && ls -d /opt/couchdb/erts-* > /dev/null \
     && echo "Extraction verification passed"
 
 # List contents for debugging
@@ -58,7 +102,7 @@ RUN echo "=== CouchDB bin directory ===" && ls -la /opt/couchdb/bin/ | head -20
 RUN echo "=== CouchDB structure ===" && find /opt/couchdb -maxdepth 2 -type d
 
 # =============================================================================
-# Stage 3: Export (scratch image for minimal output)
+# Stage 2: Export (scratch image for minimal output)
 # =============================================================================
 FROM scratch AS export
 

--- a/builds/couchdb/README.md
+++ b/builds/couchdb/README.md
@@ -6,21 +6,25 @@ Apache CouchDB binaries for all 5 platforms.
 
 | Platform | Source | Notes |
 |----------|--------|-------|
-| `linux-x64` | Docker extraction | Extracted from official `couchdb` Docker image |
-| `linux-arm64` | Docker extraction | Extracted from official `couchdb` Docker image (QEMU) |
+| `linux-x64` | Docker build | Apache apt package `couchdb=<version>~jammy`, unpacked on `ubuntu:22.04` |
+| `linux-arm64` | Docker build | Apache apt package `couchdb=<version>~jammy`, unpacked on `ubuntu:22.04` (QEMU) |
 | `darwin-x64` | Neighbourhoodie | Official macOS x86_64 binary |
 | `darwin-arm64` | Neighbourhoodie | Official macOS Apple Silicon binary |
 | `win32-x64` | Neighbourhoodie | MSI installer, extracted for portable use |
 
 ## Binary Sources
 
-### Linux (Docker Extraction)
+### Linux (Docker build from the Apache apt repository)
 
-CouchDB does not provide standalone Linux binaries - only .deb/.rpm packages that require system installation. Instead, we extract the complete CouchDB installation from the official Docker image, which includes all dependencies (Erlang, ICU, OpenSSL, etc.) pre-configured.
+CouchDB does not provide standalone Linux binaries - only .deb/.rpm packages that require system installation. `builds/couchdb/Dockerfile` downloads the official Apache package (`couchdb=<version>~jammy`) inside an `ubuntu:22.04` container and unpacks it with `dpkg-deb -x` (no maintainer scripts), then normalizes the tree for relocatable use.
 
-**Docker Image:** [`couchdb`](https://hub.docker.com/_/couchdb) (official)
+**Repository:** `https://apache.jfrog.io/artifactory/couchdb-deb` (`jammy` suite, key from `https://couchdb.apache.org/repo/keys.asc`)
 
-**Extraction Path:** `/opt/couchdb` in the Docker image
+**Extraction Path:** `/opt/couchdb` inside the unpacked package
+
+**Why not the official `couchdb` Docker image?** It tracks Debian stable and moved from bookworm to trixie at 3.5.2. Only `/opt/couchdb` was ever copied out, so the bundled Erlang runtime kept its link to the image's system libraries: the 3.5.2 extract needed `GLIBC_2.38` (dead on Ubuntu 22.04, glibc 2.35) and `OPENSSL_3.4.0` in `crypto.so` (dead on Ubuntu 24.04, OpenSSL 3.0, where CouchDB aborted with `{undef,{crypto,info_fips,[]}}`). Building against the `jammy` package pins the toolchain to our oldest supported Linux baseline.
+
+**Normalization applied after unpacking:** the FHS symlinks `data -> /var/lib/couchdb` and `var/log -> /var/log/couchdb` become real in-tree directories (`database_dir` defaults to `./data`; a dangling symlink makes `mem3` fail to create `_nodes` and the node dies with `{case_clause,{not_found,no_db_file}}`), the package's `10-filelog.ini` default is dropped, `10-docker-default.ini` (`bind_address = any`) is restored for parity with earlier tarballs, and the packaged `-name` is stripped from `vm.args`.
 
 ### macOS & Windows (Neighbourhoodie)
 
@@ -69,8 +73,8 @@ pnpm download:couchdb -- --all-platforms --build-fallback
 | `darwin-x64` | Download + repackage | 1-2 minutes |
 | `darwin-arm64` | Download + repackage | 1-2 minutes |
 | `win32-x64` | MSI extract | 2-3 minutes |
-| `linux-x64` | Docker pull + extract | 2-3 minutes |
-| `linux-arm64` | Docker pull + extract (QEMU) | 5-10 minutes |
+| `linux-x64` | Package download + unpack | 2-3 minutes |
+| `linux-arm64` | Package download + unpack (QEMU) | 5-10 minutes |
 
 ## Archive Structure
 

--- a/builds/couchdb/sources.json
+++ b/builds/couchdb/sources.json
@@ -57,9 +57,9 @@
   },
   "notes": {
     "neighbourhoodie": "Official binaries hosted by Neighbourhoodie (https://neighbourhood.ie/couchdb-support/download-binaries)",
-    "docker-extract": "Extracted from official Apache CouchDB Docker image (couchdb:VERSION)",
-    "linux-x64": "Extracted from official Docker image couchdb:VERSION on linux/amd64",
-    "linux-arm64": "Extracted from official Docker image couchdb:VERSION on linux/arm64",
+    "docker-extract": "Packaged inside a Docker build from the official Apache CouchDB apt repository (couchdb=VERSION~jammy). The couchdb:VERSION Docker image is NOT used: it tracks Debian stable and moved to trixie at 3.5.2, whose glibc/OpenSSL the extracted tree then requires.",
+    "linux-x64": "builds/couchdb/Dockerfile, ubuntu:22.04 (jammy) base on linux/amd64",
+    "linux-arm64": "builds/couchdb/Dockerfile, ubuntu:22.04 (jammy) base on linux/arm64",
     "darwin-x64": "Downloaded from Neighbourhoodie (macOS x86_64)",
     "darwin-arm64": "Downloaded from Neighbourhoodie (macOS Apple Silicon)",
     "win32-x64": "MSI installer downloaded from Neighbourhoodie, extracted for portable use"

--- a/builds/qdrant/README.md
+++ b/builds/qdrant/README.md
@@ -8,11 +8,12 @@ Download and repackage Qdrant binaries for distribution via GitHub Releases.
 
 ## Supported Versions
 
+- 1.18.3
 - 1.16.3
 
 ## Supported Platforms
 
-- `linux-x64` - Linux x86_64 (glibc)
+- `linux-x64` - Linux x86_64 (musl, static; 1.16.3 uses glibc)
 - `linux-arm64` - Linux ARM64 (musl)
 - `darwin-x64` - macOS Intel
 - `darwin-arm64` - macOS Apple Silicon
@@ -22,13 +23,18 @@ Download and repackage Qdrant binaries for distribution via GitHub Releases.
 
 | Platform | Source | Format | Notes |
 |----------|--------|--------|-------|
-| linux-x64 | Official | tar.gz | glibc build |
+| linux-x64 | Official | tar.gz | musl (static) build from 1.18.3 on; 1.16.3 uses the glibc build |
 | linux-arm64 | Official | tar.gz | musl build |
 | darwin-x64 | Official | tar.gz | |
 | darwin-arm64 | Official | tar.gz | |
 | win32-x64 | Official | zip | MSVC build |
 
 All binaries are downloaded from official Qdrant GitHub releases.
+
+**linux-x64 uses the musl (static) asset from 1.18.3 on.** Upstream builds the
+`x86_64-unknown-linux-gnu` asset for 1.18.3 against glibc 2.38, so it fails to
+exec on Ubuntu 22.04 (glibc 2.35), which hostdb supports. The musl asset is
+statically linked and runs on every supported Linux baseline.
 
 ## Usage
 

--- a/builds/qdrant/sources.json
+++ b/builds/qdrant/sources.json
@@ -4,9 +4,9 @@
   "versions": {
     "1.18.3": {
       "linux-x64": {
-        "url": "https://github.com/qdrant/qdrant/releases/download/v1.18.3/qdrant-x86_64-unknown-linux-gnu.tar.gz",
+        "url": "https://github.com/qdrant/qdrant/releases/download/v1.18.3/qdrant-x86_64-unknown-linux-musl.tar.gz",
         "format": "tar.gz",
-        "sha256": "60663a254cf421dba4db45710872895cd3a714fe1e6978f7927923b5cfae4718",
+        "sha256": "b4faedcdf8c9577bf1c8f2ab9b454636b87e056c116c99d49bd4f9fb2e634285",
         "sourceType": "official"
       },
       "linux-arm64": {
@@ -69,7 +69,7 @@
   },
   "notes": {
     "source": "Official Qdrant GitHub releases: https://github.com/qdrant/qdrant/releases",
-    "linux-x64": "Using glibc build (linux-gnu) for broader compatibility",
+    "linux-x64": "1.18.3+ uses the static musl build. Upstream's linux-gnu asset for 1.18.3 is linked against GLIBC_2.38, so it cannot run on Ubuntu 22.04 (glibc 2.35), which is a supported target. 1.16.3 predates that and stays on linux-gnu.",
     "linux-arm64": "Only musl build available for ARM64",
     "naming": "Qdrant uses Rust target triple naming: {arch}-{vendor}-{os}[-{env}]"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hostdb",
-  "version": "0.38.2",
+  "version": "0.38.3",
   "description": "Pre-built database binaries for multiple platforms, plus a typed registry library for resolving versions and download URLs offline.",
   "private": false,
   "type": "module",


### PR DESCRIPTION
Publishes **hostdb 0.38.3**. Two Linux packaging regressions from the 0.38.0 engine wave, both caught by spindb's full engine matrix on robertjbass/spindb#268. Both are repackages of the same upstream version: no `databases.yml` entry, no default, no resolver change, and `pnpm prep` produced no file changes.

## Qdrant 1.18.3 linux-x64: GLIBC_2.38

Upstream builds `qdrant-x86_64-unknown-linux-gnu.tar.gz` for 1.18.3 against a newer glibc than 1.16.3 was. The binary imports `GLIBC_2.38`, so on Ubuntu 22.04 (glibc 2.35) it never execs and spindb's post-download `qdrant --version` verification fails with ``version `GLIBC_2.38' not found``. Ubuntu 24.04 (glibc 2.39) was unaffected, which is why only half the matrix went red.

`linux-x64` now uses upstream's `qdrant-x86_64-unknown-linux-musl.tar.gz`, the same static asset `linux-arm64` has always used. 1.16.3 keeps the gnu asset (it only needs `GLIBC_2.34`).

## CouchDB 3.5.2 linux: base-image drift

`builds/couchdb/Dockerfile` copied `/opt/couchdb` out of `couchdb:<version>` but not the system libraries the bundled Erlang runtime links against, so the extracted tree silently inherited that image's base distro. The 3.5.2 image moved from Debian 12 (bookworm, glibc 2.36 / OpenSSL 3.0) to Debian 13 (trixie, glibc 2.41 / OpenSSL 3.5), breaking both baselines differently:

- Ubuntu 22.04: `beam.smp` needs `GLIBC_2.38`, never execs
- Ubuntu 24.04: execs, but `crypto.so` needs `OPENSSL_3.4.0`, so the crypto NIF fails to load and the node aborts with `{application_start_failure,config,{undef,{crypto,info_fips,[]}}}`

CI only reported "start timeout, then ECONNREFUSED" because `couchdb.log` was never dumped.

Linux packaging now builds from the official Apache CouchDB apt repository (`couchdb=<version>~jammy`) inside `ubuntu:22.04`, our oldest supported Linux target, and unpacks the package with `dpkg-deb -x` so no maintainer script can bake a debconf admin password, node name or Erlang cookie into a redistributable tarball. The tree is normalized back to the shape the working 3.5.1 artifact had: the FHS symlinks (`data -> /var/lib/couchdb`, `var/log -> /var/log/couchdb`) become real in-tree directories, the package's `10-filelog.ini` is dropped, `10-docker-default.ini` (`bind_address = any`) is restored, and the packaged `-name` is stripped from `vm.args`.

## Releases dispatched and verified

| Run | Result |
| --- | --- |
| [Release Qdrant 1.18.3, all platforms](https://github.com/robertjbass/hostdb/actions/runs/31140410266) | success |
| [Release CouchDB 3.5.2, all platforms](https://github.com/robertjbass/hostdb/actions/runs/31140411558) | success |

Both bot `releases.json` commits are merged back into `dev` (`f393edc`), so the drift gate is clean and `pnpm prep --check` passes.

**Artifacts downloaded from `registry.layerbase.host` and booted in Docker, not just ticked green:**

| Artifact | sha256 | Result |
| --- | --- | --- |
| `qdrant-1.18.3-linux-x64.tar.gz` on `ubuntu:22.04` | `904740fe...` | `static-pie linked`, starts, `/healthz` + `/` OK |
| `couchdb-3.5.2-linux-x64.tar.gz` on `ubuntu:22.04` | `1ce8be6a...` | starts, `GET /` returns the 3.5.2 welcome |
| `couchdb-3.5.2-linux-x64.tar.gz` on `ubuntu:24.04` | `1ce8be6a...` | starts, `GET /` returns the 3.5.2 welcome |

Both sha256 values match what `releases.json` now records. Pre-release local verification also covered CouchDB 3.5.2 arm64 on `ubuntu:22.04` and a 3.5.1 rebuild through the new path (same `erts-14.2.5.12` as the shipping 3.5.1 tarball).

## Related sweep

The wave's other url-sourced `linux-x64` binaries were checked for the same hazard (`objdump -T`, highest imported glibc symbol): influxdb 3.10.5 `2.18`, typedb 3.12.1 `2.25`, mysql 9.7.2 `2.28`, qdrant 1.16.3 `2.34`, meilisearch 1.52.0 `2.35`, mongodb 8.2.12 `2.35`, weaviate 1.38.8 none (static). All clear on Ubuntu 22.04, and all of those engines passed spindb's 22.04 matrix. Meilisearch and MongoDB sit exactly at the 2.35 ceiling and are the likeliest to trip this next.

Merging publishes 0.38.3 to npm, which unblocks spindb#268 (re-pin `hostdb` to 0.38.3).