### PR TITLE
chore: Harden the release pipeline (0.38.4)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,11 @@ name: Publish to npm
 on:
   push:
     branches: [main]
+  # Manual re-fire. A push event that GitHub swallows (or a run cancelled mid
+  # flight) used to leave the only recovery as an empty commit to main. The
+  # version guard below publishes only when package.json is newer than npm, so
+  # dispatching this by hand is a no-op when there is nothing to publish.
+  workflow_dispatch:
 
 jobs:
   publish:

--- a/.github/workflows/release-clickhouse.yml
+++ b/.github/workflows/release-clickhouse.yml
@@ -270,6 +270,18 @@ jobs:
           chmod +x builds/common/validate-binaries.sh
           ./builds/common/validate-binaries.sh clickhouse ./release-assets
 
+      - name: Check GLIBC floor (Linux artifacts)
+        if: steps.prepare.outputs.has-artifacts == 'true'
+        run: |
+          chmod +x builds/common/check-glibc-floor.sh
+          ./builds/common/check-glibc-floor.sh clickhouse ./release-assets
+
+      - name: Check platform coverage
+        if: steps.prepare.outputs.has-artifacts == 'true'
+        run: |
+          chmod +x builds/common/check-platform-coverage.sh
+          ./builds/common/check-platform-coverage.sh clickhouse "${{ github.event.inputs.version }}" "${{ github.event.inputs.platforms }}" ./release-assets
+
       - name: Create Release
         if: steps.prepare.outputs.has-artifacts == 'true'
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release-cockroachdb.yml
+++ b/.github/workflows/release-cockroachdb.yml
@@ -176,6 +176,16 @@ jobs:
           chmod +x builds/common/validate-binaries.sh
           ./builds/common/validate-binaries.sh cockroachdb ./release-assets
 
+      - name: Check GLIBC floor (Linux artifacts)
+        run: |
+          chmod +x builds/common/check-glibc-floor.sh
+          ./builds/common/check-glibc-floor.sh cockroachdb ./release-assets
+
+      - name: Check platform coverage
+        run: |
+          chmod +x builds/common/check-platform-coverage.sh
+          ./builds/common/check-platform-coverage.sh cockroachdb "${{ github.event.inputs.version }}" "${{ github.event.inputs.platforms }}" ./release-assets
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release-couchdb.yml
+++ b/.github/workflows/release-couchdb.yml
@@ -501,6 +501,16 @@ jobs:
           chmod +x builds/common/validate-binaries.sh
           ./builds/common/validate-binaries.sh couchdb ./release-assets
 
+      - name: Check GLIBC floor (Linux artifacts)
+        run: |
+          chmod +x builds/common/check-glibc-floor.sh
+          ./builds/common/check-glibc-floor.sh couchdb ./release-assets
+
+      - name: Check platform coverage
+        run: |
+          chmod +x builds/common/check-platform-coverage.sh
+          ./builds/common/check-platform-coverage.sh couchdb "${{ github.event.inputs.version }}" "${{ github.event.inputs.platforms }}" ./release-assets
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release-duckdb.yml
+++ b/.github/workflows/release-duckdb.yml
@@ -186,6 +186,16 @@ jobs:
           chmod +x builds/common/validate-binaries.sh
           ./builds/common/validate-binaries.sh duckdb ./release-assets
 
+      - name: Check GLIBC floor (Linux artifacts)
+        run: |
+          chmod +x builds/common/check-glibc-floor.sh
+          ./builds/common/check-glibc-floor.sh duckdb ./release-assets
+
+      - name: Check platform coverage
+        run: |
+          chmod +x builds/common/check-platform-coverage.sh
+          ./builds/common/check-platform-coverage.sh duckdb "${{ github.event.inputs.version }}" "${{ github.event.inputs.platforms }}" ./release-assets
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release-ferretdb.yml
+++ b/.github/workflows/release-ferretdb.yml
@@ -189,6 +189,16 @@ jobs:
           chmod +x builds/common/validate-binaries.sh
           ./builds/common/validate-binaries.sh ferretdb ./release-assets
 
+      - name: Check GLIBC floor (Linux artifacts)
+        run: |
+          chmod +x builds/common/check-glibc-floor.sh
+          ./builds/common/check-glibc-floor.sh ferretdb ./release-assets
+
+      - name: Check platform coverage
+        run: |
+          chmod +x builds/common/check-platform-coverage.sh
+          ./builds/common/check-platform-coverage.sh ferretdb "${{ github.event.inputs.version }}" "${{ github.event.inputs.platforms }}" ./release-assets
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release-influxdb.yml
+++ b/.github/workflows/release-influxdb.yml
@@ -211,6 +211,16 @@ jobs:
           chmod +x builds/common/validate-binaries.sh
           ./builds/common/validate-binaries.sh influxdb ./release-assets
 
+      - name: Check GLIBC floor (Linux artifacts)
+        run: |
+          chmod +x builds/common/check-glibc-floor.sh
+          ./builds/common/check-glibc-floor.sh influxdb ./release-assets
+
+      - name: Check platform coverage
+        run: |
+          chmod +x builds/common/check-platform-coverage.sh
+          ./builds/common/check-platform-coverage.sh influxdb "${{ github.event.inputs.version }}" "${{ github.event.inputs.platforms }}" ./release-assets
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release-libsql.yml
+++ b/.github/workflows/release-libsql.yml
@@ -177,6 +177,16 @@ jobs:
           chmod +x builds/common/validate-binaries.sh
           ./builds/common/validate-binaries.sh libsql ./release-assets
 
+      - name: Check GLIBC floor (Linux artifacts)
+        run: |
+          chmod +x builds/common/check-glibc-floor.sh
+          ./builds/common/check-glibc-floor.sh libsql ./release-assets
+
+      - name: Check platform coverage
+        run: |
+          chmod +x builds/common/check-platform-coverage.sh
+          ./builds/common/check-platform-coverage.sh libsql "${{ github.event.inputs.version }}" "${{ github.event.inputs.platforms }}" ./release-assets
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release-mariadb.yml
+++ b/.github/workflows/release-mariadb.yml
@@ -427,6 +427,16 @@ jobs:
           chmod +x builds/common/validate-binaries.sh
           ./builds/common/validate-binaries.sh mariadb ./release-assets
 
+      - name: Check GLIBC floor (Linux artifacts)
+        run: |
+          chmod +x builds/common/check-glibc-floor.sh
+          ./builds/common/check-glibc-floor.sh mariadb ./release-assets
+
+      - name: Check platform coverage
+        run: |
+          chmod +x builds/common/check-platform-coverage.sh
+          ./builds/common/check-platform-coverage.sh mariadb "${{ github.event.inputs.version }}" "${{ github.event.inputs.platforms }}" ./release-assets
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release-meilisearch.yml
+++ b/.github/workflows/release-meilisearch.yml
@@ -178,6 +178,16 @@ jobs:
           chmod +x builds/common/validate-binaries.sh
           ./builds/common/validate-binaries.sh meilisearch ./release-assets
 
+      - name: Check GLIBC floor (Linux artifacts)
+        run: |
+          chmod +x builds/common/check-glibc-floor.sh
+          ./builds/common/check-glibc-floor.sh meilisearch ./release-assets
+
+      - name: Check platform coverage
+        run: |
+          chmod +x builds/common/check-platform-coverage.sh
+          ./builds/common/check-platform-coverage.sh meilisearch "${{ github.event.inputs.version }}" "${{ github.event.inputs.platforms }}" ./release-assets
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release-mongodb.yml
+++ b/.github/workflows/release-mongodb.yml
@@ -187,6 +187,16 @@ jobs:
           chmod +x builds/common/validate-binaries.sh
           ./builds/common/validate-binaries.sh mongodb ./release-assets
 
+      - name: Check GLIBC floor (Linux artifacts)
+        run: |
+          chmod +x builds/common/check-glibc-floor.sh
+          ./builds/common/check-glibc-floor.sh mongodb ./release-assets
+
+      - name: Check platform coverage
+        run: |
+          chmod +x builds/common/check-platform-coverage.sh
+          ./builds/common/check-platform-coverage.sh mongodb "${{ github.event.inputs.version }}" "${{ github.event.inputs.platforms }}" ./release-assets
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release-mysql.yml
+++ b/.github/workflows/release-mysql.yml
@@ -182,6 +182,16 @@ jobs:
           chmod +x builds/common/validate-binaries.sh
           ./builds/common/validate-binaries.sh mysql ./release-assets
 
+      - name: Check GLIBC floor (Linux artifacts)
+        run: |
+          chmod +x builds/common/check-glibc-floor.sh
+          ./builds/common/check-glibc-floor.sh mysql ./release-assets
+
+      - name: Check platform coverage
+        run: |
+          chmod +x builds/common/check-platform-coverage.sh
+          ./builds/common/check-platform-coverage.sh mysql "${{ github.event.inputs.version }}" "${{ github.event.inputs.platforms }}" ./release-assets
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release-postgresql-documentdb.yml
+++ b/.github/workflows/release-postgresql-documentdb.yml
@@ -406,6 +406,16 @@ jobs:
           chmod +x builds/common/validate-binaries.sh
           ./builds/common/validate-binaries.sh postgresql-documentdb ./release-assets
 
+      - name: Check GLIBC floor (Linux artifacts)
+        run: |
+          chmod +x builds/common/check-glibc-floor.sh
+          ./builds/common/check-glibc-floor.sh postgresql-documentdb ./release-assets
+
+      - name: Check platform coverage
+        run: |
+          chmod +x builds/common/check-platform-coverage.sh
+          ./builds/common/check-platform-coverage.sh postgresql-documentdb "${{ github.event.inputs.version }}" "${{ github.event.inputs.platforms }}" ./release-assets
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release-postgresql.yml
+++ b/.github/workflows/release-postgresql.yml
@@ -816,6 +816,16 @@ jobs:
           chmod +x builds/common/validate-binaries.sh
           ./builds/common/validate-binaries.sh postgresql ./release-assets
 
+      - name: Check GLIBC floor (Linux artifacts)
+        run: |
+          chmod +x builds/common/check-glibc-floor.sh
+          ./builds/common/check-glibc-floor.sh postgresql ./release-assets
+
+      - name: Check platform coverage
+        run: |
+          chmod +x builds/common/check-platform-coverage.sh
+          ./builds/common/check-platform-coverage.sh postgresql "${{ github.event.inputs.version }}" "${{ github.event.inputs.platforms }}" ./release-assets
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release-qdrant.yml
+++ b/.github/workflows/release-qdrant.yml
@@ -177,6 +177,16 @@ jobs:
           chmod +x builds/common/validate-binaries.sh
           ./builds/common/validate-binaries.sh qdrant ./release-assets
 
+      - name: Check GLIBC floor (Linux artifacts)
+        run: |
+          chmod +x builds/common/check-glibc-floor.sh
+          ./builds/common/check-glibc-floor.sh qdrant ./release-assets
+
+      - name: Check platform coverage
+        run: |
+          chmod +x builds/common/check-platform-coverage.sh
+          ./builds/common/check-platform-coverage.sh qdrant "${{ github.event.inputs.version }}" "${{ github.event.inputs.platforms }}" ./release-assets
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release-questdb.yml
+++ b/.github/workflows/release-questdb.yml
@@ -177,6 +177,16 @@ jobs:
           chmod +x builds/common/validate-binaries.sh
           ./builds/common/validate-binaries.sh questdb ./release-assets
 
+      - name: Check GLIBC floor (Linux artifacts)
+        run: |
+          chmod +x builds/common/check-glibc-floor.sh
+          ./builds/common/check-glibc-floor.sh questdb ./release-assets
+
+      - name: Check platform coverage
+        run: |
+          chmod +x builds/common/check-platform-coverage.sh
+          ./builds/common/check-platform-coverage.sh questdb "${{ github.event.inputs.version }}" "${{ github.event.inputs.platforms }}" ./release-assets
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release-redis.yml
+++ b/.github/workflows/release-redis.yml
@@ -10,7 +10,6 @@ on:
         options:
           - 8.4.5
           - 8.4.0
-          - 7.4.10
           - 7.2.15
           - 7.2.14
         default: 8.4.5
@@ -386,6 +385,16 @@ jobs:
         run: |
           chmod +x builds/common/validate-binaries.sh
           ./builds/common/validate-binaries.sh redis ./release-assets
+
+      - name: Check GLIBC floor (Linux artifacts)
+        run: |
+          chmod +x builds/common/check-glibc-floor.sh
+          ./builds/common/check-glibc-floor.sh redis ./release-assets
+
+      - name: Check platform coverage
+        run: |
+          chmod +x builds/common/check-platform-coverage.sh
+          ./builds/common/check-platform-coverage.sh redis "${{ github.event.inputs.version }}" "${{ github.event.inputs.platforms }}" ./release-assets
 
       - name: Create Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release-sqlite.yml
+++ b/.github/workflows/release-sqlite.yml
@@ -259,6 +259,16 @@ jobs:
           chmod +x builds/common/validate-binaries.sh
           ./builds/common/validate-binaries.sh sqlite ./release-assets
 
+      - name: Check GLIBC floor (Linux artifacts)
+        run: |
+          chmod +x builds/common/check-glibc-floor.sh
+          ./builds/common/check-glibc-floor.sh sqlite ./release-assets
+
+      - name: Check platform coverage
+        run: |
+          chmod +x builds/common/check-platform-coverage.sh
+          ./builds/common/check-platform-coverage.sh sqlite "${{ github.event.inputs.version }}" "${{ github.event.inputs.platforms }}" ./release-assets
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release-surrealdb.yml
+++ b/.github/workflows/release-surrealdb.yml
@@ -176,6 +176,16 @@ jobs:
           chmod +x builds/common/validate-binaries.sh
           ./builds/common/validate-binaries.sh surrealdb ./release-assets
 
+      - name: Check GLIBC floor (Linux artifacts)
+        run: |
+          chmod +x builds/common/check-glibc-floor.sh
+          ./builds/common/check-glibc-floor.sh surrealdb ./release-assets
+
+      - name: Check platform coverage
+        run: |
+          chmod +x builds/common/check-platform-coverage.sh
+          ./builds/common/check-platform-coverage.sh surrealdb "${{ github.event.inputs.version }}" "${{ github.event.inputs.platforms }}" ./release-assets
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release-tigerbeetle.yml
+++ b/.github/workflows/release-tigerbeetle.yml
@@ -182,6 +182,16 @@ jobs:
           chmod +x builds/common/validate-binaries.sh
           ./builds/common/validate-binaries.sh tigerbeetle ./release-assets
 
+      - name: Check GLIBC floor (Linux artifacts)
+        run: |
+          chmod +x builds/common/check-glibc-floor.sh
+          ./builds/common/check-glibc-floor.sh tigerbeetle ./release-assets
+
+      - name: Check platform coverage
+        run: |
+          chmod +x builds/common/check-platform-coverage.sh
+          ./builds/common/check-platform-coverage.sh tigerbeetle "${{ github.event.inputs.version }}" "${{ github.event.inputs.platforms }}" ./release-assets
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release-typedb.yml
+++ b/.github/workflows/release-typedb.yml
@@ -177,6 +177,16 @@ jobs:
           chmod +x builds/common/validate-binaries.sh
           ./builds/common/validate-binaries.sh typedb ./release-assets
 
+      - name: Check GLIBC floor (Linux artifacts)
+        run: |
+          chmod +x builds/common/check-glibc-floor.sh
+          ./builds/common/check-glibc-floor.sh typedb ./release-assets
+
+      - name: Check platform coverage
+        run: |
+          chmod +x builds/common/check-platform-coverage.sh
+          ./builds/common/check-platform-coverage.sh typedb "${{ github.event.inputs.version }}" "${{ github.event.inputs.platforms }}" ./release-assets
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release-valkey.yml
+++ b/.github/workflows/release-valkey.yml
@@ -446,6 +446,16 @@ jobs:
           chmod +x builds/common/validate-binaries.sh
           ./builds/common/validate-binaries.sh valkey ./release-assets
 
+      - name: Check GLIBC floor (Linux artifacts)
+        run: |
+          chmod +x builds/common/check-glibc-floor.sh
+          ./builds/common/check-glibc-floor.sh valkey ./release-assets
+
+      - name: Check platform coverage
+        run: |
+          chmod +x builds/common/check-platform-coverage.sh
+          ./builds/common/check-platform-coverage.sh valkey "${{ github.event.inputs.version }}" "${{ github.event.inputs.platforms }}" ./release-assets
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release-weaviate.yml
+++ b/.github/workflows/release-weaviate.yml
@@ -186,6 +186,16 @@ jobs:
           chmod +x builds/common/validate-binaries.sh
           ./builds/common/validate-binaries.sh weaviate ./release-assets
 
+      - name: Check GLIBC floor (Linux artifacts)
+        run: |
+          chmod +x builds/common/check-glibc-floor.sh
+          ./builds/common/check-glibc-floor.sh weaviate ./release-assets
+
+      - name: Check platform coverage
+        run: |
+          chmod +x builds/common/check-platform-coverage.sh
+          ./builds/common/check-platform-coverage.sh weaviate "${{ github.event.inputs.version }}" "${{ github.event.inputs.platforms }}" ./release-assets
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.38.4] - 2026-08-07
+
+Release-pipeline hardening from the 0.38.x engine wave. Every problem the wave hit (qdrant's glibc, couchdb's drifting base image, weaviate shipping 2 of 5 platforms, a swallowed publish push) got through because nothing in the pipeline was looking for it. No engine version, default, or resolver behaviour changes, and no artifact was rebuilt.
+
+### Added
+
+- **GLIBC floor check on every release.** `builds/common/check-glibc-floor.sh` extracts each `linux-x64` / `linux-arm64` artifact, finds every ELF file by magic bytes, reads the highest `GLIBC_x.y.z` symbol version it references (`readelf -V`, falling back to `objdump -T`), and fails the release if anything exceeds the floor. The floor is one constant at the top of the script, `GLIBC_FLOOR="2.35"`, matching Ubuntu 22.04 (jammy), the oldest supported Linux target and the base image every `builds/*/Dockerfile` uses. This is what qdrant 1.18.3 (`GLIBC_2.38`, from the upstream gnu build) and couchdb 3.5.2 (glibc 2.41, inherited by a docker-extract that followed the upstream image to trixie) both needed: they shipped green in 0.38.0 and only failed two repos downstream, in spindb's Ubuntu 22.04 CI. Static binaries (musl, Go, Zig) reference no GLIBC versions and pass trivially; non-ELF payloads such as the QuestDB and TypeDB jars are skipped. Wired into all 22 release workflows next to the existing binary validation. Validated against real artifacts: upstream `qdrant-x86_64-unknown-linux-gnu.tar.gz` for 1.18.3 fails at `GLIBC_2.38`, the musl tarball we actually ship passes with no GLIBC references, and couchdb 3.5.2 passes at exactly `2.35`.
+- **Platform coverage check on every release.** `builds/common/check-platform-coverage.sh` compares the platforms a run requested against the artifacts it produced, and fails when one is missing. Closes the known issue filed in 0.38.1. Covered by `tests/platform-coverage.test.ts`.
+
+### Changed
+
+- **A requested platform that does not build now fails the release.** Every engine's `download.ts` counts a failed download, a missing cross-compiler, or a build error as a "skipped" platform and still exits 0, so a run stayed green as long as one platform produced a tarball. Weaviate 1.38.8 shipped 2 of 5 platforms that way and nothing in the run said so. A platform is expected only when the engine declares it for that version in both `databases.json` and `builds/<db>/sources.json`, so engines with no win32 build by design (libsql, postgresql) still pass; the skip is driven by the declared platform list, never by the build outcome.
+- **`postgresql-documentdb` Linux builds moved from `debian:bookworm` to `ubuntu:22.04`.** Same base-image-drift class that broke couchdb: a tag that tracks "stable" is a moving target, and bookworm's glibc 2.36 is already above the floor. The dependency bundler copies host libraries into the package, and the published 17-0.107.0 `linux-x64` tarball carries a `lib/libexpat.so.1` requiring `GLIBC_2.36`, so it cannot load on Ubuntu 22.04. Every apt dependency resolves on jammy (verified on both `linux/amd64` and `linux/arm64`: GEOS 3.10.2, PROJ 8.2.1, cmake 3.22, gcc 11), libbson and the Intel decimal math library were already built from source, and the latter already tracks the `ubuntu/jammy` branch. `DEBIAN_FRONTEND=noninteractive` was added so tzdata cannot stall the build. **No documentdb artifact was rebuilt here**; the next documentdb release is the first jammy build.
+- **`publish.yml` accepts `workflow_dispatch`.** A push event that GitHub swallows used to leave an empty commit to `main` as the only way to re-fire the publish. The job's existing version guard publishes only when `package.json` is newer than npm, so a manual dispatch is a no-op when there is nothing to publish.
+
+### Deprecated
+
+- **Redis 7.4.10.** Now carries `deprecated: true`, the follow-up its 0.38.0 note promised once the binaries were on R2, exactly as 7.4.9 was handled in 0.32.0. The whole 7.4+ line is RSALv2/SSPLv1, which forbids offering Redis as a competing managed service, so it is desktop/local use only. Deprecation does not remove anything: 7.4.10 still resolves and its binaries stay on R2. `sync:versions` drops deprecated versions from the release-workflow dropdown, so 7.4.10 leaves the `release-redis` picker. Use 7.2.15 (BSD-3-Clause, and it carries the same CVE-2026-66373 fix) for managed-service use cases.
+
 ## [0.38.3] - 2026-08-06
 
 Linux packaging fixes for two engines in the 0.38.0 wave. Both were caught by spindb's full engine matrix (robertjbass/spindb#268), both are repackages of the same upstream version, and no `databases.yml` entry, default or resolver behaviour changes.

--- a/builds/common/README.md
+++ b/builds/common/README.md
@@ -32,6 +32,48 @@ The script:
     ./builds/common/validate-binaries.sh <database-id> ./release-assets
 ```
 
+### `check-glibc-floor.sh <database> <release-assets-dir>`
+
+Fails a release whose Linux artifacts need a newer glibc than hostdb's oldest supported target.
+
+Two 2026-08 releases shipped green and only failed two repos downstream, in spindb's Ubuntu 22.04 CI: qdrant 1.18.3 (upstream gnu build referenced `GLIBC_2.38`) and couchdb 3.5.2 (docker-extract followed the upstream image from bookworm to trixie and inherited glibc 2.41). Nothing in the pipeline looked at what the binaries actually require.
+
+For every `linux-x64` / `linux-arm64` archive the script extracts the tree, finds every ELF file by magic bytes, reads the highest `GLIBC_x.y.z` symbol version each one references (`readelf -V`, falling back to `objdump -T`), and fails if anything exceeds the floor.
+
+**The floor is a single constant, `GLIBC_FLOOR`, at the top of the script.** It is `2.35`: Ubuntu 22.04 (jammy), the base image every `builds/*/Dockerfile` uses. Change it there and nowhere else. When the check fires, fix the build - use a musl/static upstream asset, or pin the docker base to `ubuntu:22.04` - rather than raising the floor.
+
+Static binaries (musl, Go, Zig) reference no GLIBC versions and pass trivially. Non-ELF payloads (jars, scripts, `.a` archives, data files) are skipped, so JVM engines like QuestDB and TypeDB pass with nothing to inspect. darwin and win32 archives are not examined.
+
+**Used by:** all 22 release workflows, in the `release` job right after "Validate required binaries":
+
+```yaml
+- name: Check GLIBC floor (Linux artifacts)
+  run: |
+    chmod +x builds/common/check-glibc-floor.sh
+    ./builds/common/check-glibc-floor.sh <database-id> ./release-assets
+```
+
+### `check-platform-coverage.sh <database> <version> <requested-platforms> <release-assets-dir>`
+
+Fails a release that silently shipped fewer platforms than were asked for.
+
+Every engine's `download.ts` loops over platforms and counts a failed download, a missing cross-compiler, or a build error as a "skip", then exits 0. As long as one platform produced a tarball the release completed green: weaviate 1.38.8 shipped 2 of 5 platforms that way and the release run said nothing.
+
+A platform is EXPECTED only when the engine declares it for that version in **both** `databases.json` (the registry platform list, resolved the same way `getVersionPlatforms()` does) and `builds/<db>/sources.json` (the build recipe). Engines with no win32 build by design, such as libsql and postgresql, simply do not declare it, so `all` never expects one. Anything expected that produced no artifact is a hard failure. The skip is driven by the declared platform list, never by the build outcome.
+
+`<requested-platforms>` is the workflow's `platforms` input verbatim: the literal `all`, or a comma/space separated list. Built platforms are read from artifact filenames, so compound versions like `postgresql-documentdb 17-0.107.0` work.
+
+Covered by `tests/platform-coverage.test.ts`. `HOSTDB_ROOT` overrides the repo root the script reads its JSON from.
+
+**Used by:** all 22 release workflows, immediately after the GLIBC floor check:
+
+```yaml
+- name: Check platform coverage
+  run: |
+    chmod +x builds/common/check-platform-coverage.sh
+    ./builds/common/check-platform-coverage.sh <database-id> "${{ github.event.inputs.version }}" "${{ github.event.inputs.platforms }}" ./release-assets
+```
+
 ### `fix-macos-dylibs.sh <package-root>`
 
 macOS source builds that link against Homebrew (OpenSSL, pcre2, etc.) produce binaries with absolute paths like `/opt/homebrew/opt/openssl@3/lib/libssl.3.dylib`. These break on any Mac without those exact Homebrew packages installed.

--- a/builds/common/check-glibc-floor.sh
+++ b/builds/common/check-glibc-floor.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# check-glibc-floor.sh - Fail a release whose Linux artifacts need a newer glibc
+#                        than our oldest supported Linux target.
+#
+# Usage: check-glibc-floor.sh <database> <release-assets-dir>
+#
+# Why this exists:
+#   Two 2026-08 releases shipped green and only broke two repos downstream, in
+#   spindb's Ubuntu 22.04 CI:
+#     - qdrant 1.18.3: the upstream gnu build referenced GLIBC_2.38.
+#     - couchdb 3.5.2: the docker-extract followed the upstream image from
+#       bookworm to trixie and inherited glibc 2.41.
+#   Nothing in the release pipeline looked at what the binaries actually
+#   require, so a binary that cannot start on our oldest supported distro
+#   passed every gate.
+#
+# What it does:
+#   For every linux-x64 / linux-arm64 archive in the release-assets directory,
+#   extracts it, finds every ELF file, and reads the highest GLIBC_x.y.z symbol
+#   version the file references. If any file needs more than GLIBC_FLOOR, the
+#   release fails loudly and names the offending files.
+#
+#   Static binaries (musl, Go, Zig) reference no GLIBC versions at all and pass
+#   trivially. Non-ELF payloads (jars, scripts, .a archives, data files) are
+#   skipped gracefully - engines like QuestDB and TypeDB ship JVM artifacts with
+#   nothing to inspect.
+#
+#   darwin-* and win32-* archives are not examined: there is no glibc there.
+
+set -euo pipefail
+
+# =============================================================================
+# THE FLOOR - the single value to change if the oldest supported Linux target
+# moves. 2.35 is Ubuntu 22.04 LTS (jammy): the oldest distro hostdb binaries
+# must run on, the base image used by builds/*/Dockerfile, and the runner
+# spindb's CI matrix pins.
+# =============================================================================
+GLIBC_FLOOR="2.35"
+
+DB="${1:?Usage: check-glibc-floor.sh <database> <release-assets-dir>}"
+ASSETS_DIR="${2:?Usage: check-glibc-floor.sh <database> <release-assets-dir>}"
+
+if [ ! -d "$ASSETS_DIR" ]; then
+  echo "::error::Release assets directory not found: $ASSETS_DIR"
+  exit 1
+fi
+
+echo "=== GLIBC Floor Check for $DB ==="
+echo "Floor: GLIBC_$GLIBC_FLOOR (Ubuntu 22.04 / jammy)"
+
+# Pick an ELF reader. Both ship in binutils on the GitHub runners; readelf is
+# preferred because its version-needs output is stable across architectures.
+ELF_READER=""
+if command -v readelf > /dev/null 2>&1; then
+  ELF_READER="readelf"
+elif command -v objdump > /dev/null 2>&1; then
+  ELF_READER="objdump"
+else
+  echo "::error::Neither readelf nor objdump is available - cannot verify the GLIBC floor"
+  echo "Install binutils on the runner, or the check cannot be trusted."
+  exit 1
+fi
+echo "ELF reader: $ELF_READER"
+
+# Compare two dotted versions numerically. Returns 0 when $1 > $2.
+version_gt() {
+  local a="$1" b="$2"
+  local IFS=.
+  # shellcheck disable=SC2206
+  local av=($a) bv=($b)
+  local i
+  for i in 0 1 2; do
+    local an="${av[i]:-0}" bn="${bv[i]:-0}"
+    if [ "$an" -gt "$bn" ]; then return 0; fi
+    if [ "$an" -lt "$bn" ]; then return 1; fi
+  done
+  return 1
+}
+
+# An ELF file starts with the 4-byte magic 0x7f 'E' 'L' 'F'.
+is_elf() {
+  [ -f "$1" ] || return 1
+  [ "$(head -c 4 "$1" 2> /dev/null | od -An -tx1 | tr -d ' \n')" = "7f454c46" ]
+}
+
+# Highest GLIBC_x.y.z referenced by an ELF file, or empty when it references
+# none (static binaries, musl builds). GLIBC_PRIVATE carries no version number
+# and never matches the pattern.
+max_glibc_for_file() {
+  local file="$1" refs=""
+
+  if [ "$ELF_READER" = "readelf" ]; then
+    refs=$(readelf -V "$file" 2> /dev/null | grep -oE 'GLIBC_[0-9]+\.[0-9]+(\.[0-9]+)?' || true)
+  else
+    refs=$(objdump -T "$file" 2> /dev/null | grep -oE 'GLIBC_[0-9]+\.[0-9]+(\.[0-9]+)?' || true)
+  fi
+
+  [ -z "$refs" ] && return 0
+
+  echo "$refs" \
+    | sed 's/^GLIBC_//' \
+    | sort -t. -k1,1n -k2,2n -k3,3n \
+    | tail -1
+}
+
+shopt -s nullglob
+ARCHIVES=("$ASSETS_DIR"/*.tar.gz "$ASSETS_DIR"/*.zip)
+
+if [ ${#ARCHIVES[@]} -eq 0 ]; then
+  echo "::warning::No archives found in $ASSETS_DIR - skipping GLIBC floor check"
+  exit 0
+fi
+
+OVERALL_FAILED=0
+LINUX_ARCHIVES=0
+
+for archive in "${ARCHIVES[@]}"; do
+  FILENAME=$(basename "$archive")
+
+  case "$FILENAME" in
+    *-linux-x64.* | *-linux-arm64.*) ;;
+    *)
+      echo "Skip: $FILENAME (not a Linux artifact)"
+      continue
+      ;;
+  esac
+
+  LINUX_ARCHIVES=$((LINUX_ARCHIVES + 1))
+  echo ""
+  echo "--- Checking: $FILENAME ---"
+
+  TEMP_DIR=$(mktemp -d)
+
+  if [[ "$archive" == *.tar.gz ]]; then
+    tar -xzf "$archive" -C "$TEMP_DIR"
+  else
+    unzip -q "$archive" -d "$TEMP_DIR"
+  fi
+
+  ARCHIVE_MAX=""
+  ARCHIVE_MAX_FILE=""
+  ELF_COUNT=0
+  SKIPPED_COUNT=0
+  OFFENDERS=""
+
+  while IFS= read -r -d '' file; do
+    if ! is_elf "$file"; then
+      SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
+      continue
+    fi
+
+    ELF_COUNT=$((ELF_COUNT + 1))
+    FILE_MAX=$(max_glibc_for_file "$file")
+    [ -z "$FILE_MAX" ] && continue
+
+    REL="${file#"$TEMP_DIR"/}"
+
+    if [ -z "$ARCHIVE_MAX" ] || version_gt "$FILE_MAX" "$ARCHIVE_MAX"; then
+      ARCHIVE_MAX="$FILE_MAX"
+      ARCHIVE_MAX_FILE="$REL"
+    fi
+
+    if version_gt "$FILE_MAX" "$GLIBC_FLOOR"; then
+      OFFENDERS="${OFFENDERS}    $REL needs GLIBC_$FILE_MAX"$'\n'
+    fi
+  done < <(find "$TEMP_DIR" -type f -print0)
+
+  echo "  ELF files inspected: $ELF_COUNT (skipped $SKIPPED_COUNT non-ELF)"
+
+  if [ "$ELF_COUNT" -eq 0 ]; then
+    echo "  No ELF files in this archive - nothing to check"
+  elif [ -z "$ARCHIVE_MAX" ]; then
+    echo "  No GLIBC symbol versions referenced (static or musl build) - OK"
+  else
+    echo "  Highest requirement: GLIBC_$ARCHIVE_MAX ($ARCHIVE_MAX_FILE)"
+  fi
+
+  if [ -n "$OFFENDERS" ]; then
+    echo "  ABOVE FLOOR - these files need more than GLIBC_$GLIBC_FLOOR:"
+    printf '%s' "$OFFENDERS"
+    OVERALL_FAILED=1
+  fi
+
+  rm -rf "$TEMP_DIR"
+done
+
+echo ""
+
+if [ "$LINUX_ARCHIVES" -eq 0 ]; then
+  echo "No Linux artifacts in this release - GLIBC floor check not applicable"
+  exit 0
+fi
+
+if [ $OVERALL_FAILED -eq 1 ]; then
+  echo "::error::GLIBC floor check failed for $DB - one or more Linux artifacts require a newer glibc than $GLIBC_FLOOR (Ubuntu 22.04) and will not start there."
+  echo ""
+  echo "Fix the BUILD, not this floor. The usual causes:"
+  echo "  - An upstream gnu tarball built on a newer distro (use the musl or"
+  echo "    static variant, or build it ourselves)."
+  echo "  - A docker-extract whose base image drifted to a newer release"
+  echo "    (pin the base to ubuntu:22.04, as builds/couchdb/Dockerfile does)."
+  exit 1
+fi
+
+echo "All Linux artifacts satisfy the GLIBC_$GLIBC_FLOOR floor for $DB"

--- a/builds/common/check-platform-coverage.sh
+++ b/builds/common/check-platform-coverage.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# check-platform-coverage.sh - Fail a release that silently shipped fewer
+#                              platforms than were asked for.
+#
+# Usage: check-platform-coverage.sh <database> <version> <requested-platforms> <release-assets-dir>
+#
+#   <requested-platforms> is the workflow's `platforms` input verbatim:
+#   either the literal string "all" or a comma/space separated list.
+#
+# Why this exists:
+#   Every engine's download.ts loops over platforms and counts a failed
+#   download, a missing cross-compiler, or a build error as a "skip". The loop
+#   then exits 0, so as long as ONE platform produced a tarball the release
+#   completed green. weaviate 1.38.8 shipped 2 of 5 platforms that way and
+#   nobody found out from the release run.
+#
+# Supported vs failed:
+#   A platform is EXPECTED only when the engine declares it for this version,
+#   in BOTH databases.json (the registry's platform list) and the engine's
+#   builds/<db>/sources.json (the build recipe). Engines that legitimately have
+#   no win32 build - libsql, postgresql - simply do not declare it, so it is
+#   never expected and never fails. The skip is driven by the declared platform
+#   list, never by the build outcome.
+#
+#   Anything expected that produced no artifact is a hard failure.
+
+set -euo pipefail
+
+DB="${1:?Usage: check-platform-coverage.sh <database> <version> <requested-platforms> <release-assets-dir>}"
+VERSION="${2:?Usage: check-platform-coverage.sh <database> <version> <requested-platforms> <release-assets-dir>}"
+REQUESTED_RAW="${3:?Usage: check-platform-coverage.sh <database> <version> <requested-platforms> <release-assets-dir>}"
+ASSETS_DIR="${4:?Usage: check-platform-coverage.sh <database> <version> <requested-platforms> <release-assets-dir>}"
+
+# Find the repo root relative to this script. HOSTDB_ROOT overrides it so the
+# unit tests can point the script at a fixture tree.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${HOSTDB_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+DATABASES_JSON="$REPO_ROOT/databases.json"
+SOURCES_JSON="$REPO_ROOT/builds/$DB/sources.json"
+
+if [ ! -f "$DATABASES_JSON" ]; then
+  echo "::error::databases.json not found at $DATABASES_JSON"
+  exit 1
+fi
+
+if [ ! -d "$ASSETS_DIR" ]; then
+  echo "::error::Release assets directory not found: $ASSETS_DIR"
+  exit 1
+fi
+
+echo "=== Platform Coverage Check for $DB $VERSION ==="
+
+# --- Declared platforms, per databases.json -----------------------------------
+# Mirrors getVersionPlatforms() in lib/databases.ts: a version-level `platforms`
+# (array or object) fully replaces the engine-level list; otherwise the
+# engine-level list applies.
+DECLARED_REGISTRY=$(jq -r "
+  .databases[\"$DB\"] as \$engine |
+  (\$engine.versions[\"$VERSION\"] // null) as \$v |
+  (
+    if (\$v | type) == \"object\" and (\$v.platforms != null) then
+      (if (\$v.platforms | type) == \"array\" then \$v.platforms else (\$v.platforms | keys) end)
+    else
+      (\$engine.platforms // [])
+    end
+  ) |
+  if length == 0 then (\$engine.platforms // []) else . end |
+  .[]
+" "$DATABASES_JSON" | sort -u)
+
+if [ -z "$DECLARED_REGISTRY" ]; then
+  echo "::error::No platforms declared for $DB in databases.json - cannot verify coverage"
+  exit 1
+fi
+
+# --- Declared platforms, per the engine's sources.json ------------------------
+DECLARED_SOURCES=""
+if [ -f "$SOURCES_JSON" ]; then
+  DECLARED_SOURCES=$(jq -r "
+    .versions[\"$VERSION\"] // {} | keys | .[]
+  " "$SOURCES_JSON" 2> /dev/null | sort -u || true)
+fi
+
+if [ -n "$DECLARED_SOURCES" ]; then
+  DECLARED=$(comm -12 <(echo "$DECLARED_REGISTRY") <(echo "$DECLARED_SOURCES"))
+else
+  # Engines without a sources.json entry for this version (or without the file
+  # at all) fall back to the registry list.
+  DECLARED="$DECLARED_REGISTRY"
+fi
+
+echo "Declared platforms: $(echo "$DECLARED" | tr '\n' ' ')"
+
+# --- Requested platforms ------------------------------------------------------
+REQUESTED_NORM=$(echo "$REQUESTED_RAW" | tr ',' '\n' | tr ' ' '\n' | sed '/^$/d' | sort -u)
+
+if [ "$REQUESTED_RAW" = "all" ] || echo "$REQUESTED_NORM" | grep -qx "all"; then
+  REQUESTED="$DECLARED"
+  echo "Requested platforms: all -> $(echo "$REQUESTED" | tr '\n' ' ')"
+else
+  REQUESTED="$REQUESTED_NORM"
+  echo "Requested platforms: $(echo "$REQUESTED" | tr '\n' ' ')"
+fi
+
+# Requested but not declared: a legitimate, declared-driven skip. Loud enough to
+# notice in the log, but never a failure - this is how "no win32 by design"
+# stays green.
+NOT_DECLARED=$(comm -23 <(echo "$REQUESTED") <(echo "$DECLARED"))
+if [ -n "$NOT_DECLARED" ]; then
+  for platform in $NOT_DECLARED; do
+    echo "::warning::$platform was requested but $DB $VERSION does not declare it - skipping (not a build failure)"
+  done
+fi
+
+EXPECTED=$(comm -12 <(echo "$REQUESTED") <(echo "$DECLARED"))
+
+if [ -z "$EXPECTED" ]; then
+  echo "::error::No requested platform is declared for $DB $VERSION - nothing could have been built"
+  exit 1
+fi
+
+# --- Built platforms, from the artifact filenames -----------------------------
+# Artifacts are named <db>-<version>-<platform>.<ext>; matching on the platform
+# suffix keeps compound versions like postgresql-documentdb 17-0.107.0 working.
+shopt -s nullglob
+ARCHIVES=("$ASSETS_DIR"/*.tar.gz "$ASSETS_DIR"/*.zip)
+
+BUILT=""
+for archive in "${ARCHIVES[@]}"; do
+  FILENAME=$(basename "$archive")
+  PLATFORM=$(echo "$FILENAME" | sed -nE 's/.*-((linux|darwin|win32)-(x64|arm64))\.(tar\.gz|zip)$/\1/p')
+  [ -n "$PLATFORM" ] && BUILT="${BUILT}${PLATFORM}"$'\n'
+done
+BUILT=$(echo "$BUILT" | sed '/^$/d' | sort -u)
+
+echo "Built platforms: $(echo "$BUILT" | tr '\n' ' ')"
+echo ""
+
+MISSING=$(comm -23 <(echo "$EXPECTED") <(echo "$BUILT" | sed '/^$/d'))
+
+if [ -n "$MISSING" ]; then
+  echo "::error::Platform coverage check failed for $DB $VERSION - these platforms were requested and declared but produced no artifact: $(echo "$MISSING" | tr '\n' ' ')"
+  echo ""
+  echo "A platform that fails to download, cross-compile, or build is NOT a skip."
+  echo "Read the build job log for the platform above: the engine's download.ts"
+  echo "logs the real error and then continues, which is why the run got this far."
+  echo ""
+  echo "If the platform genuinely is not buildable for this version, remove it"
+  echo "from builds/$DB/sources.json and databases.yml so it stops being expected."
+  exit 1
+fi
+
+echo "All expected platforms produced an artifact for $DB $VERSION"

--- a/builds/postgresql-documentdb/README.md
+++ b/builds/postgresql-documentdb/README.md
@@ -10,8 +10,8 @@ This package bundles PostgreSQL 17 with the DocumentDB extension and several sup
 
 | Platform | Source | Notes |
 |----------|--------|-------|
-| linux-x64 | Docker | Extract from ghcr.io/ferretdb/postgres-documentdb |
-| linux-arm64 | Docker | Extract from ghcr.io/ferretdb/postgres-documentdb |
+| linux-x64 | Build | Source build inside an `ubuntu:22.04` container |
+| linux-arm64 | Build | Source build inside an `ubuntu:22.04` container (QEMU) |
 | darwin-x64 | Build | Native build on macOS Intel |
 | darwin-arm64 | Build | Native build on macOS Apple Silicon |
 | win32-x64 | Build | Stretch goal - hybrid download + source build |
@@ -113,19 +113,32 @@ macOS binaries must be fully relocatable — no hardcoded Homebrew paths. The bu
 
 **Important**: The bundling step must scan both `lib/*.dylib` and `lib/postgresql/*.dylib`. Extension dylibs in `lib/postgresql/` (like `pg_documentdb_core.dylib`) may reference Homebrew libraries (e.g. `libbson2.2.dylib` from `mongo-c-driver`, `libpcre2-8.0.dylib` from `pcre2`) that are not dependencies of any `bin/` binary. If the `lib/postgresql/` subdirectory is not included in the scan, these transitive dependencies will be missing from the bundle, causing `dlopen` failures at runtime.
 
-## Docker Extraction (Linux)
+## Linux builds (Docker)
 
-For Linux, binaries are extracted from the official FerretDB Docker image:
+Linux binaries are **built from source** inside a container by `build-linux.sh`,
+not extracted from `ghcr.io/ferretdb/postgres-documentdb`. Extracting that image
+would give a tree wired to the image's own PostgreSQL layout and system
+libraries; building from source is what makes the package relocatable.
 
 ```bash
-# Pull the image
-docker pull --platform linux/amd64 ghcr.io/ferretdb/postgres-documentdb:17-0.107.0
-
-# Extract (handled by download.ts)
-docker create --name temp-pg ghcr.io/ferretdb/postgres-documentdb:17-0.107.0
-docker cp temp-pg:/usr/lib/postgresql/17 ./postgresql-documentdb
-docker rm temp-pg
+# Handled by download.ts -> build-linux.sh
+./build-linux.sh 17-0.107.0 linux-x64 ./dist
 ```
+
+**Base image: `ubuntu:22.04` (jammy, glibc 2.35).** It was `debian:bookworm`
+until 2026-08-07. Two reasons for the move:
+
+- A "stable" distro tag is a moving target. CouchDB 3.5.2 shipped broken when
+  its base followed the upstream image from bookworm to trixie and inherited
+  glibc 2.41. `ubuntu:22.04` names one release and stays on it.
+- bookworm's glibc is 2.36, already above hostdb's 2.35 floor. The dependency
+  bundler copies host libraries into the package, and the published 17-0.107.0
+  linux-x64 tarball carries a `lib/libexpat.so.1` that needs `GLIBC_2.36`, so it
+  cannot load on Ubuntu 22.04. `builds/common/check-glibc-floor.sh` now fails a
+  release for that.
+
+The published 17-0.107.0 artifacts were not rebuilt when the base changed; the
+next release is the first jammy build.
 
 ## Usage with FerretDB
 

--- a/builds/postgresql-documentdb/build-linux.sh
+++ b/builds/postgresql-documentdb/build-linux.sh
@@ -122,6 +122,9 @@ POSTGIS_VERSION="$8"
 echo "[INFO] Building PostgreSQL ${PG_SOURCE_VERSION} from source..."
 
 # Install build dependencies
+# noninteractive keeps tzdata (pulled in transitively by libgdal-dev) from
+# stopping the build on its geographic-area prompt.
+export DEBIAN_FRONTEND=noninteractive
 apt-get update -qq
 apt-get install -y -qq \
     build-essential \
@@ -558,13 +561,35 @@ chmod +x "${TEMP_DIR}/build-inside-docker.sh"
 # Run the build inside Docker
 log_info "Starting Docker build for ${PLATFORM}..."
 
+# Base image: ubuntu:22.04 (jammy, glibc 2.35), hostdb's oldest supported Linux
+# target and the same base builds/couchdb, builds/postgresql and builds/mariadb
+# build on.
+#
+# Changed from debian:bookworm 2026-08-07. Two reasons:
+#
+#  1. Base-image drift. CouchDB 3.5.2 shipped broken because its extract
+#     followed the upstream image from bookworm to trixie and inherited
+#     glibc 2.41. A distro tag that tracks "stable" is a moving target;
+#     ubuntu:22.04 names one release and stays on it.
+#  2. bookworm is already above the floor. Its glibc is 2.36, and the
+#     dependency bundler copies host libraries into the package: the shipped
+#     17-0.107.0 linux-x64 tarball carries a lib/libexpat.so.1 that requires
+#     GLIBC_2.36, so it cannot load on Ubuntu 22.04. builds/common/check-glibc-floor.sh
+#     now fails a release for exactly that.
+#
+# Every apt dependency below exists in jammy, libbson and the Intel decimal
+# math library are already built from source (the latter from the ubuntu/jammy
+# branch), so nothing here depended on bookworm.
+#
+# NOTE: the currently published 17-0.107.0 artifacts were NOT rebuilt when this
+# changed. The next documentdb release is the first build on jammy.
 CONTAINER_NAME="hostdb-pg-build-$$"
 docker run --rm \
     --name "${CONTAINER_NAME}" \
     --platform "${DOCKER_PLATFORM}" \
     -v "${TEMP_DIR}:/input:ro" \
     -v "${OUTPUT_DIR}:/host-output" \
-    debian:bookworm \
+    ubuntu:22.04 \
     /bin/bash -c "
         set -e  # Exit on error in inline script too
         mkdir -p /build /output

--- a/databases.json
+++ b/databases.json
@@ -836,7 +836,8 @@
         "8.4.5": true,
         "8.4.0": true,
         "7.4.10": {
-          "note": "Security patch for the 7.4 line (CVE-2026-66373). NOT deprecated only so the release workflow dropdown can build it; sync:versions skips deprecated versions. RSALv2/SSPLv1 still forbids offering Redis as a competing managed service, so use 7.2.15 (BSD) for managed-service use cases and 7.4.10 only for self-contained app use. Deprecate it in a follow-up policy commit once the binaries are on R2, exactly as 7.4.9 was handled in 0.32.0."
+          "deprecated": true,
+          "note": "Deprecated; RSALv2/SSPLv1 license forbids offering Redis as a competing managed service. Carries the CVE-2026-66373 fix for the 7.4 line, so use 7.2.15 (BSD) for managed-service use cases, or stay on 7.4.10 only for self-contained app use."
         },
         "7.4.9": {
           "deprecated": true,

--- a/databases.yml
+++ b/databases.yml
@@ -697,7 +697,8 @@ databases:
       8.4.5: true
       8.4.0: true
       7.4.10:
-        note: Security patch for the 7.4 line (CVE-2026-66373). NOT deprecated only so the release workflow dropdown can build it; sync:versions skips deprecated versions. RSALv2/SSPLv1 still forbids offering Redis as a competing managed service, so use 7.2.15 (BSD) for managed-service use cases and 7.4.10 only for self-contained app use. Deprecate it in a follow-up policy commit once the binaries are on R2, exactly as 7.4.9 was handled in 0.32.0.
+        deprecated: true
+        note: Deprecated; RSALv2/SSPLv1 license forbids offering Redis as a competing managed service. Carries the CVE-2026-66373 fix for the 7.4 line, so use 7.2.15 (BSD) for managed-service use cases, or stay on 7.4.10 only for self-contained app use.
       7.4.9:
         deprecated: true
         note: Deprecated; RSALv2/SSPLv1 license forbids offering Redis as a competing managed service. Use 7.2.14 (BSD) for managed-service use cases, or stay on 7.4.9 only for self-contained app use.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hostdb",
-  "version": "0.38.3",
+  "version": "0.38.4",
   "description": "Pre-built database binaries for multiple platforms, plus a typed registry library for resolving versions and download URLs offline.",
   "private": false,
   "type": "module",

--- a/releases.json
+++ b/releases.json
@@ -1812,7 +1812,8 @@
             "sha256": "7a950a52102fc3770907a931c464b5a43b762bfdf869f96c3cf7908db6107a4b",
             "size": 11491889
           }
-        }
+        },
+        "deprecated": true
       },
       "7.4.9": {
         "version": "7.4.9",

--- a/tests/platform-coverage.test.ts
+++ b/tests/platform-coverage.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Platform-coverage test.
+ *
+ * `builds/common/check-platform-coverage.sh` is the release-time gate that
+ * turns "a requested platform produced no artifact" from a silent skip into a
+ * hard failure. weaviate 1.38.8 shipped 2 of 5 platforms green because every
+ * engine's download.ts counts a failed build as a skip and still exits 0.
+ *
+ * The distinction the gate has to keep straight, and what these tests pin:
+ *   - a platform the engine DECLARES (databases.json + builds/<db>/sources.json)
+ *     that produced nothing is a failure, and
+ *   - a platform the engine does not declare is a legitimate skip, even when
+ *     the workflow asked for "all".
+ *
+ * The tests run against real registry data rather than fixtures so the two
+ * declaration sources stay wired up: weaviate declares all five platforms,
+ * libsql declares four (no win32 build by design). Only the artifact directory
+ * is synthetic - the script reads filenames, never archive contents.
+ */
+
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+const SCRIPT = join(ROOT, 'builds', 'common', 'check-platform-coverage.sh')
+
+type Platform =
+  | 'linux-x64'
+  | 'linux-arm64'
+  | 'darwin-x64'
+  | 'darwin-arm64'
+  | 'win32-x64'
+
+const ALL: Platform[] = [
+  'linux-x64',
+  'linux-arm64',
+  'darwin-x64',
+  'darwin-arm64',
+  'win32-x64',
+]
+
+function withAssets(
+  database: string,
+  version: string,
+  platforms: Platform[],
+  run: (assetsDir: string) => void,
+) {
+  const dir = mkdtempSync(join(tmpdir(), 'hostdb-coverage-'))
+  try {
+    for (const platform of platforms) {
+      const ext = platform.startsWith('win32') ? 'zip' : 'tar.gz'
+      writeFileSync(join(dir, `${database}-${version}-${platform}.${ext}`), '')
+    }
+    run(dir)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+function checkCoverage(options: {
+  database: string
+  version: string
+  requested: string
+  built: Platform[]
+}): { status: number; output: string } {
+  let result = { status: -1, output: '' }
+
+  withAssets(options.database, options.version, options.built, (assetsDir) => {
+    const proc = spawnSync(
+      'bash',
+      [SCRIPT, options.database, options.version, options.requested, assetsDir],
+      { encoding: 'utf-8' },
+    )
+    result = {
+      status: proc.status ?? -1,
+      output: `${proc.stdout ?? ''}${proc.stderr ?? ''}`,
+    }
+  })
+
+  return result
+}
+
+describe('check-platform-coverage.sh', () => {
+  test('passes when every requested platform produced an artifact', () => {
+    const { status } = checkCoverage({
+      database: 'weaviate',
+      version: '1.38.8',
+      requested: 'all',
+      built: ALL,
+    })
+
+    assert.equal(status, 0)
+  })
+
+  test('fails when a requested, declared platform produced no artifact', () => {
+    // The weaviate 1.38.8 incident: 2 of 5 platforms, release still green.
+    const { status, output } = checkCoverage({
+      database: 'weaviate',
+      version: '1.38.8',
+      requested: 'all',
+      built: ['linux-x64', 'darwin-arm64'],
+    })
+
+    assert.equal(status, 1)
+    assert.match(output, /Platform coverage check failed/)
+    for (const missing of ['linux-arm64', 'darwin-x64', 'win32-x64']) {
+      assert.match(output, new RegExp(missing))
+    }
+  })
+
+  test('passes when an undeclared platform is missing (no win32 by design)', () => {
+    // libsql declares four platforms; "all" must not expect a win32 build.
+    const { status } = checkCoverage({
+      database: 'libsql',
+      version: '0.24.32',
+      requested: 'all',
+      built: ['linux-x64', 'linux-arm64', 'darwin-x64', 'darwin-arm64'],
+    })
+
+    assert.equal(status, 0)
+  })
+
+  test('fails on a missing platform from an explicit request list', () => {
+    const { status, output } = checkCoverage({
+      database: 'weaviate',
+      version: '1.38.8',
+      requested: 'linux-x64,linux-arm64',
+      built: ['linux-x64'],
+    })
+
+    assert.equal(status, 1)
+    assert.match(output, /linux-arm64/)
+  })
+
+  test('handles compound versions like postgresql-documentdb 17-0.107.0', () => {
+    const { status } = checkCoverage({
+      database: 'postgresql-documentdb',
+      version: '17-0.107.0',
+      requested: 'all',
+      built: ALL,
+    })
+
+    assert.equal(status, 0)
+  })
+})


### PR DESCRIPTION
Five follow-ups from the 0.38.x engine wave, shipped as 0.38.4 (patch: no engine version, default, or resolver behaviour changes, and no artifact was rebuilt).

## 1. GLIBC floor check

`builds/common/check-glibc-floor.sh`, wired into all 22 release workflows next to the existing "Validate required binaries" step. For every `linux-x64` / `linux-arm64` artifact it extracts the tree, finds every ELF file by magic bytes, reads the highest `GLIBC_x.y.z` symbol version each references (`readelf -V`, falling back to `objdump -T`), and fails the release when anything exceeds the floor.

**The floor is one constant at the top of the script:** `GLIBC_FLOOR="2.35"` (Ubuntu 22.04 / jammy, the base image every `builds/*/Dockerfile` uses). Static binaries (musl, Go, Zig) reference no GLIBC versions and pass trivially; non-ELF payloads such as the QuestDB and TypeDB jars are skipped gracefully.

Validated against real artifacts inside `ubuntu:22.04`:

| Artifact | Highest requirement | Result |
|---|---|---|
| upstream `qdrant-x86_64-unknown-linux-gnu.tar.gz` 1.18.3 (negative control) | `GLIBC_2.38` | FAIL, exit 1 |
| shipped qdrant 1.18.3 linux-x64 + linux-arm64 (musl) | none | PASS |
| shipped couchdb 3.5.2 linux-x64 (post jammy fix) | `GLIBC_2.35` | PASS, exactly at the floor |
| shipped postgresql-documentdb 17-0.107.0 linux-x64 | `GLIBC_2.36` (`lib/libexpat.so.1`) | FAIL, see item 5 |

## 2. A requested platform that does not build fails the release

`builds/common/check-platform-coverage.sh`, also in all 22 release workflows. Every engine's `download.ts` counts a failed download, a missing cross-compiler, or a build error as a "skipped" platform and still exits 0, so a run stayed green as long as one platform produced a tarball. That is how weaviate 1.38.8 shipped 2 of 5 platforms. Closes the known issue filed in 0.38.1.

A platform is EXPECTED only when the engine declares it for that version in **both** `databases.json` (resolved the way `getVersionPlatforms()` does) and `builds/<db>/sources.json`. Engines with no win32 build by design, libsql and postgresql, simply do not declare it, so `all` never expects one. The skip is driven by the declared platform list, never by the build outcome.

Covered by `tests/platform-coverage.test.ts` (5 cases, including the weaviate 2-of-5 incident and the libsql no-win32 skip). Also smoke-run against all 22 engines' newest versions: none false-fails, and no engine has an empty declared-platform intersection.

## 3. `workflow_dispatch` on `publish.yml`

A swallowed push event no longer needs an empty commit to `main`. The job's existing version guard publishes only when `package.json` is newer than npm, so a manual dispatch is a no-op when there is nothing to publish.

## 4. Redis 7.4.10 deprecated

`deprecated: true` plus a note mirroring the 7.4.9 entry, which is the follow-up 7.4.10's own note promised once the binaries were on R2. The 7.4+ line is RSALv2/SSPLv1, desktop and local use only. Nothing is removed: 7.4.10 still resolves and its binaries stay on R2. `sync:versions` drops deprecated versions from the release dropdown, so it leaves the `release-redis` picker, exactly as 7.4.9 did in 0.32.0.

## 5. postgresql-documentdb Linux base pinned to `ubuntu:22.04`

Moved off `debian:bookworm`. This started as a judgment call between a jammy switch and a bookworm digest pin, and the measurement above settled it: bookworm's glibc is 2.36, already above the floor, and the dependency bundler copies host libraries into the package, so the **currently published** 17-0.107.0 linux-x64 tarball ships a `lib/libexpat.so.1` that requires `GLIBC_2.36` and cannot load on Ubuntu 22.04. A digest pin would have frozen that.

Jammy is not a stretch for this build: every apt dependency resolves on `linux/amd64` and `linux/arm64` (GEOS 3.10.2 for PostGIS 3.5.1, PROJ 8.2.1, cmake 3.22 for mongo-c-driver 1.29, gcc 11, OpenSSL 3.0), libbson and the Intel decimal math library were already built from source, and the latter already tracks the `ubuntu/jammy` branch. `DEBIAN_FRONTEND=noninteractive` was added so tzdata cannot stall the build.

**No documentdb artifact was rebuilt or re-released here.** The next documentdb release is the first jammy build.

## Checks

- `pnpm prep` and `pnpm prep --check`: clean apart from the two known pre-existing "orphaned win32-x64" warnings.
- `pnpm test`: 214/214.
- All 30 workflow YAML files parse.
